### PR TITLE
fix(eslint*): disable poorly working @typescript-eslint/no-unsafe-*

### DIFF
--- a/.changeset/angry-bears-matter.md
+++ b/.changeset/angry-bears-matter.md
@@ -1,0 +1,8 @@
+---
+"@qlik/eslint-config-svelte": patch
+"@qlik/eslint-config-react": patch
+"@qlik/eslint-config-base": patch
+"@qlik/eslint-config": patch
+---
+
+Disable poorly working @typescript-eslint/no-unsafe-\* rules

--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -27,9 +27,6 @@ module.exports = {
     // https://typescript-eslint.io/rules/lines-between-class-members
     "lines-between-class-members": "off",
 
-    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/prefer-default-export.md
-    "import/prefer-default-export": "off",
-
     // https://typescript-eslint.io/rules/dot-notation/
     "dot-notation": "off",
 

--- a/packages/eslint-config-base/typescript.js
+++ b/packages/eslint-config-base/typescript.js
@@ -30,5 +30,17 @@ module.exports = {
         checksConditionals: false,
       },
     ],
+
+    // no-unsafe-* does not work correctly
+    // https://typescript-eslint.io/rules/no-unsafe-call/
+    // https://typescript-eslint.io/rules/no-unsafe-member-access/
+    // https://typescript-eslint.io/rules/no-unsafe-return/
+    // https://typescript-eslint.io/rules/no-unsafe-argument/
+    // https://typescript-eslint.io/rules/no-unsafe-assignment/
+    "@typescript-eslint/no-unsafe-call": "off",
+    "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-unsafe-return": "off",
+    "@typescript-eslint/no-unsafe-argument": "off",
+    "@typescript-eslint/no-unsafe-assignment": "off",
   },
 };

--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -4,19 +4,17 @@ module.exports = {
       files: ["**/*.js", "**/*.jsx"],
       extends: ["airbnb", "airbnb/hooks", "@qlik/eslint-config-base", "prettier"],
       rules: {
+        // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md
+        "import/no-extraneous-dependencies": [
+          "off",
+          {
+            devDependencies: ["**/jest-setup.js", "**/webpack.config.js", "**/svelte.config.js"],
+          },
+        ],
         "react/jsx-props-no-spreading": "off",
         "react/jsx-uses-react": "off",
         "react/react-in-jsx-scope": "off",
         "react/forbid-prop-types": "off",
-        "import/no-extraneous-dependencies": [
-          "off",
-          {
-            devDependencies: [
-              "**/jest-setup.js", // jest setup
-              "**/webpack.config.js", // webpack config
-            ],
-          },
-        ],
         "react/function-component-definition": [
           2,
           {

--- a/packages/eslint-config-svelte/index.js
+++ b/packages/eslint-config-svelte/index.js
@@ -12,11 +12,5 @@ module.exports = {
         "no-restricted-syntax": ["error", "ForInStatement", "ForOfStatement", "WithStatement"], // remove LabeledStatement from the list
       },
     },
-    {
-      files: ["svelte.config.js"],
-      rules: {
-        "import/no-extraneous-dependencies": "off",
-      },
-    },
   ],
 };

--- a/packages/eslint-config-svelte/typescript.js
+++ b/packages/eslint-config-svelte/typescript.js
@@ -20,11 +20,5 @@ module.exports = {
         "no-restricted-syntax": ["error", "ForInStatement", "ForOfStatement", "WithStatement"], // remove LabeledStatement from the list
       },
     },
-    {
-      files: ["svelte.config.js"],
-      rules: {
-        "import/no-extraneous-dependencies": "off",
-      },
-    },
   ],
 };

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,3 +1,14 @@
 module.exports = {
   extends: ["airbnb-base", "@qlik/eslint-config-base", "prettier"],
+  rules: {
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/prefer-default-export.md
+    "import/prefer-default-export": "off",
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md
+    "import/no-extraneous-dependencies": [
+      "off",
+      {
+        devDependencies: ["**/jest-setup.js", "**/webpack.config.js", "**/svelte.config.js"],
+      },
+    ],
+  },
 };

--- a/packages/eslint-config/typescript.js
+++ b/packages/eslint-config/typescript.js
@@ -4,6 +4,17 @@ module.exports = {
     {
       files: ["**/*.ts", "**/*.tsx"],
       extends: ["airbnb-base", "airbnb-typescript/base", "@qlik/eslint-config-base/typescript", "prettier"],
+      rules: {
+        // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/prefer-default-export.md
+        "import/prefer-default-export": "off",
+        // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md
+        "import/no-extraneous-dependencies": [
+          "off",
+          {
+            devDependencies: ["**/jest-setup.js", "**/webpack.config.js", "**/svelte.config.js"],
+          },
+        ],
+      },
     },
   ],
 };


### PR DESCRIPTION
@typescript-eslint/no-unsafe-* are not working well.

They often do not understand inferred types and instead see them as any.