### PR TITLE
fix: add airbnb/hooks

### DIFF
--- a/.changeset/sharp-moose-double.md
+++ b/.changeset/sharp-moose-double.md
@@ -1,0 +1,5 @@
+---
+"@qlik/eslint-config": patch
+---
+
+Adding react/hooks to config

--- a/packages/eslint-config/overrides/react.js
+++ b/packages/eslint-config/overrides/react.js
@@ -2,7 +2,7 @@ module.exports = {
   overrides: [
     {
       files: ["*.js", "*.jsx"],
-      extends: ["airbnb", "../configs/airbnb-mod", "prettier", "../configs/env"],
+      extends: ["airbnb", "airbnb/hooks", "../configs/airbnb-mod", "prettier", "../configs/env"],
     },
     {
       files: ["*.ts", "*.tsx"],
@@ -10,6 +10,7 @@ module.exports = {
         "plugin:@typescript-eslint/recommended",
         "plugin:@typescript-eslint/recommended-requiring-type-checking",
         "airbnb",
+        "airbnb/hooks",
         "airbnb-typescript",
         "../configs/airbnb-ts-mod",
         "prettier",


### PR DESCRIPTION
airbnb/hooks used to be present in react setup:

https://github.com/qlik-oss/dev-tools-js/blob/%40qlik/eslint-config-react%400.0.15/packages/eslint-config-react/index.js#L5

https://github.com/qlik-oss/dev-tools-js/blob/%40qlik/eslint-config-react%400.0.15/packages/eslint-config-react/typescript.js#L6