### PR TITLE
feat(eslint-config): improve no-param-reassign

### DIFF
--- a/.changeset/dull-bulldogs-care.md
+++ b/.changeset/dull-bulldogs-care.md
@@ -1,0 +1,5 @@
+---
+"@qlik/eslint-config": minor
+---
+
+Improve no-param-reassign to not complain on "prev" property which is a normal use case in reducers

--- a/packages/eslint-config/configs/airbnb-base-mod.js
+++ b/packages/eslint-config/configs/airbnb-base-mod.js
@@ -7,6 +7,14 @@ module.exports = {
     "no-plusplus": "off",
     "prefer-destructuring": ["error", { object: true, array: false }],
     "guard-for-in": "off",
+    // allow prev to be re-assigned in reducers
+    "no-param-reassign": [
+      "error",
+      {
+        props: true,
+        ignorePropertyModificationsFor: ["prev"],
+      },
+    ],
 
     // eslint import/order and prettier-plugin-organize-imports are currently incompatible
     "import/order": "off",

--- a/test/test-react/src/test-lint.js
+++ b/test/test-react/src/test-lint.js
@@ -1,0 +1,9 @@
+const parsed = { HEY: "HO" };
+const envKeys = parsed
+  ? Object.keys(parsed).reduce((prev, next) => {
+      prev[`process.env.${next}`] = JSON.stringify(parsed[next]);
+      return prev;
+    }, {})
+  : {};
+
+console.log(envKeys); // eslint-disable-line no-console


### PR DESCRIPTION
will not give no-param-reassign errors on a "prev" property which is a normal use case in reducers.