### PR TITLE
fix: remove publish config override

### DIFF
--- a/.changeset/lovely-lemons-return.md
+++ b/.changeset/lovely-lemons-return.md
@@ -1,0 +1,5 @@
+---
+"@qlik/eslint-config": patch
+---
+
+fix: remove publish config override

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -58,9 +58,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "exports": {
-      ".": "./lib/index.js"
-    },
     "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
When publishing this config was overriding the root one, so you get an error saying this file in lib does not exist. Removing this should keep the exports section defined on the root of package.json