### PR TITLE
fix(eslint-config): config rules and combination update

### DIFF
--- a/.changeset/dull-ladybugs-beam.md
+++ b/.changeset/dull-ladybugs-beam.md
@@ -1,0 +1,5 @@
+---
+"@qlik/eslint-config": patch
+---
+
+fix(eslint-config): config rules and combination update

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -25,7 +25,7 @@
     "@eslint-react/eslint-plugin": "1.17.1",
     "@eslint/js": "^9.15.0",
     "@typescript-eslint/utils": "^8.16.0",
-    "@vitest/eslint-plugin": "^1.1.10",
+    "@vitest/eslint-plugin": "^1.1.11",
     "confusing-browser-globals": "^1.0.11",
     "eslint-import-resolver-typescript": "^3.6.3",
     "eslint-plugin-import-x": "^4.4.3",

--- a/packages/eslint-config/src/configs/cjs.js
+++ b/packages/eslint-config/src/configs/cjs.js
@@ -2,12 +2,13 @@
 import globals from "globals";
 import { mergeConfigs } from "../utils/config.js";
 import { recommendedJS, recommendedTS } from "./recommended.js";
+import rules from "./rules/index.js";
 
 /**
  * @satisfies {import("../types/index.js").ESLintFlatConfig['rules']}
  */
 const cjsRules = {
-  // modify rules for node here
+  // modify rules for node commonjs here
 };
 
 /**
@@ -21,6 +22,7 @@ const cjsJS = mergeConfigs(recommendedJS, {
     sourceType: "commonjs",
   },
   rules: {
+    ...rules.nodeRules,
     ...cjsRules,
   },
 });
@@ -36,6 +38,7 @@ const cjsTS = mergeConfigs(recommendedTS, {
     sourceType: "commonjs",
   },
   rules: {
+    ...rules.nodeRules,
     ...cjsRules,
     // modify ts specific rules for node here
   },

--- a/packages/eslint-config/src/configs/esm.js
+++ b/packages/eslint-config/src/configs/esm.js
@@ -1,6 +1,7 @@
 // @ts-check
+import globals from "globals";
 import { mergeConfigs } from "../utils/config.js";
-import { cjsJS, cjsTS } from "./cjs.js";
+import { recommendedJS, recommendedTS } from "./recommended.js";
 
 /**
  * @satisfies {import("../types/index.js").ESLintFlatConfig["rules"]}
@@ -13,10 +14,11 @@ const nodeEsmRules = {
 /**
  * @type {import("../types/index.js").ESLintFlatConfig}
  */
-const esmJS = mergeConfigs(cjsJS, {
+const esmJS = mergeConfigs(recommendedJS, {
   name: "node-esm-js",
   files: ["**/*.{js,mjs}"],
   languageOptions: {
+    globals: globals.node,
     sourceType: "module",
   },
   rules: {
@@ -27,10 +29,11 @@ const esmJS = mergeConfigs(cjsJS, {
 /**
  * @type {import("../types/index.js").ESLintFlatConfig}
  */
-const esmTS = mergeConfigs(cjsTS, {
+const esmTS = mergeConfigs(recommendedTS, {
   name: "node-esm-ts",
   files: ["**/*.{ts,mts}"],
   languageOptions: {
+    globals: globals.node,
     sourceType: "module",
   },
   rules: {

--- a/packages/eslint-config/src/configs/react.js
+++ b/packages/eslint-config/src/configs/react.js
@@ -14,7 +14,7 @@ const reactPlugin = eslintPluginReact;
 /**
  * @type {import("../types/index.js").ESLintFlatConfig}
  */
-const reactConfig = mergeConfigs({
+const reactConfig = {
   languageOptions: {
     parserOptions: {
       ecmaFeatures: {
@@ -45,12 +45,12 @@ const reactConfig = mergeConfigs({
     ...reactHooks.configs.recommended.rules,
     ...rules.reactHooksRules,
   },
-});
+};
 
 /**
  * @type {import("../types/index.js").ESLintFlatConfig}
  */
-const reactJS = mergeConfigs(reactConfig, recommendedJS, {
+const reactJS = mergeConfigs(reactConfig, {
   name: "react-js",
   files: ["**/*.jsx"],
   rules: {
@@ -62,7 +62,7 @@ const reactJS = mergeConfigs(reactConfig, recommendedJS, {
 /**
  * @type {import("../types/index.js").ESLintFlatConfig}
  */
-const reactTS = mergeConfigs(reactConfig, recommendedTS, {
+const reactTS = mergeConfigs(reactConfig, {
   name: "react-ts",
   files: ["**/*.tsx"],
   rules: {

--- a/packages/eslint-config/src/configs/recommended.js
+++ b/packages/eslint-config/src/configs/recommended.js
@@ -7,27 +7,20 @@ import tsconfig from "typescript-eslint";
 import { mergeConfigs } from "../utils/config.js";
 import rules from "./rules/index.js";
 
-/**
- * @type {import("../types/index.js").ESLintFlatConfig}
- */
-const recommendedJS = mergeConfigs(
+const baseConfig = mergeConfigs(
   {
-    files: ["**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs"],
     languageOptions: {
       globals: globals.browser,
       parserOptions: {
         warnOnUnsupportedTypeScriptVersion: false,
       },
-      ecmaVersion: 2021,
+      ecmaVersion: "latest",
       sourceType: "module",
     },
   },
-  // tsconfig.configs.base sets eslint parser to use the typescript parser to parse .js files - handles all modern syntax
-  tsconfig.configs.base,
   js.configs.recommended,
   eslintPluginImportX.flatConfigs.recommended,
   {
-    name: "recommended-js",
     rules: {
       ...rules.importXRules,
       ...rules.eslintCoreRules,
@@ -38,16 +31,27 @@ const recommendedJS = mergeConfigs(
 /**
  * @type {import("../types/index.js").ESLintFlatConfig}
  */
+const recommendedJS = mergeConfigs(
+  baseConfig,
+  // tsconfig.configs.base sets eslint parser to use the typescript parser to parse .js files - handles all modern syntax
+  tsconfig.configs.base,
+  {
+    name: "recommended-js",
+    files: ["**/*.js", "**/*.mjs", "**/*.cjs"],
+  },
+);
+
+/**
+ * @type {import("../types/index.js").ESLintFlatConfig}
+ */
 const recommendedTS = mergeConfigs(
-  recommendedJS,
+  baseConfig,
   {
     files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts", "**/*.d.ts"],
     languageOptions: {
       parserOptions: {
         parser: tsParser,
         projectService: true,
-        ecmaVersion: "latest",
-        sourceType: "module",
       },
     },
   },

--- a/packages/eslint-config/src/configs/rules/eslint-core.js
+++ b/packages/eslint-config/src/configs/rules/eslint-core.js
@@ -208,6 +208,8 @@ const rules = {
         "response", // for Express responses
         "$scope", // for Angular 1 scopes
         "staticContext", // for ReactRouter context
+        "sharedState", // for shared state in reducers
+        "state", // for shared state in reducers
       ],
     },
   ],
@@ -706,15 +708,15 @@ const rules = {
     "error",
     {
       name: "isFinite",
-      message: "Use Number.isFinite instead https://github.com/airbnb/javascript#standard-library--isfinite",
+      message: "Use Number.isFinite instead",
     },
     {
       name: "isNaN",
-      message: "Use Number.isNaN instead https://github.com/airbnb/javascript#standard-library--isnan",
+      message: "Use Number.isNaN instead",
     },
     ...confusingBrowserGlobals.map((g) => ({
       name: g,
-      message: `Use window.${g} instead. https://github.com/facebook/create-react-app/blob/HEAD/packages/confusing-browser-globals/README.md`,
+      message: `Use window.${g} instead`,
     })),
   ],
 
@@ -866,15 +868,7 @@ const rules = {
 
   // disallow dangling underscores in identifiers
   // https://eslint.org/docs/rules/no-underscore-dangle
-  "no-underscore-dangle": [
-    "error",
-    {
-      allow: [],
-      allowAfterThis: false,
-      allowAfterSuper: false,
-      enforceInMethodNames: true,
-    },
-  ],
+  "no-underscore-dangle": "off",
 
   // disallow the use of Boolean literals in conditional expressions
   // also, prefer `a || b` over `a ? a : b`

--- a/packages/eslint-config/src/configs/rules/index.js
+++ b/packages/eslint-config/src/configs/rules/index.js
@@ -1,5 +1,6 @@
 import eslintCoreRules from "./eslint-core.js";
 import importXRules from "./import-x.js";
+import nodeRules from "./node.js";
 import reactA11yRules from "./react-a11y.js";
 import reactHooksRules from "./react-hooks.js";
 import reactRules from "./react.js";
@@ -7,11 +8,12 @@ import testingLibraryRules from "./testing-library.js";
 import typescriptRules from "./typescript.js";
 
 export default {
-  importXRules,
   eslintCoreRules,
-  typescriptRules,
+  importXRules,
+  nodeRules,
   reactRules,
   reactA11yRules,
   reactHooksRules,
   testingLibraryRules,
+  typescriptRules,
 };

--- a/packages/eslint-config/src/configs/rules/node.js
+++ b/packages/eslint-config/src/configs/rules/node.js
@@ -5,6 +5,7 @@
  */
 const rules = {
   // TODO use eslint-plugin-n https://github.com/eslint-community/eslint-plugin-n
+  "no-console": "off",
 };
 
 export default rules;

--- a/packages/eslint-config/src/configs/rules/react.js
+++ b/packages/eslint-config/src/configs/rules/react.js
@@ -387,13 +387,11 @@ const rules = {
 
   // Enforce state initialization style
   // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/state-in-constructor.md
-  // TODO: set to "never" once babel-preset-airbnb supports public class fields
-  "react/state-in-constructor": ["error", "always"],
+  "react/state-in-constructor": ["error", "never"],
 
   // Enforces where React component static properties should be positioned
   // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/static-property-placement.md
-  // TODO: set to "static public field" once babel-preset-airbnb supports public class fields
-  "react/static-property-placement": ["error", "property assignment"],
+  "react/static-property-placement": "error",
 
   // This has valid cases but best practice to be explicit about the props
   // Disallow JSX props spreading

--- a/packages/eslint-config/src/configs/rules/typescript.js
+++ b/packages/eslint-config/src/configs/rules/typescript.js
@@ -151,7 +151,7 @@ const rules = {
   // Lots of false/iffy positives
   // watch out for always truthy conditions
   // https://typescript-eslint.io/rules/no-unnecessary-condition
-  "@typescript-eslint/no-unnecessary-condition": "off",
+  "@typescript-eslint/no-unnecessary-condition": "error",
 
   // no unnecessary namespace qualifiers.
   // https://typescript-eslint.io/rules/no-unnecessary-qualifier
@@ -201,7 +201,7 @@ const rules = {
   // https://typescript-eslint.io/rules/use-unknown-in-catch-callback-variable
   "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
 
-  // Replace Airbnb 'camelcase' rule with '@typescript-eslint/naming-convention'
+  // Replace camelcase' rule with '@typescript-eslint/naming-convention'
   // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md
   camelcase: "off",
   // The `@typescript-eslint/naming-convention` rule allows `leadingUnderscore` and `trailingUnderscore` settings. However, the existing `no-underscore-dangle` rule already takes care of this.
@@ -217,7 +217,7 @@ const rules = {
       selector: "function",
       format: ["camelCase", "PascalCase"],
     },
-    // Airbnb recommends PascalCase for classes (23.3), and although Airbnb does not make TypeScript recommendations, we are assuming this rule would similarly apply to anything "type like", including interfaces, type aliases, and enums
+    // Qlik recommends PascalCase for classes (23.3),
     {
       selector: "typeLike",
       format: ["PascalCase"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^8.16.0
         version: 8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
       '@vitest/eslint-plugin':
-        specifier: ^1.1.10
-        version: 1.1.10(@typescript-eslint/utils@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)(vitest@2.1.6(@types/node@22.10.0)(jiti@2.4.0))
+        specifier: ^1.1.11
+        version: 1.1.11(@typescript-eslint/utils@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)(vitest@2.1.6(@types/node@22.10.0)(jiti@2.4.0))
       confusing-browser-globals:
         specifier: ^1.0.11
         version: 1.0.11
@@ -63,7 +63,7 @@ importers:
         version: 5.0.0(eslint@9.15.0(jiti@2.4.0))
       eslint-plugin-svelte:
         specifier: 2.46.0
-        version: 2.46.0(eslint@9.15.0(jiti@2.4.0))(svelte@5.2.8)
+        version: 2.46.0(eslint@9.15.0(jiti@2.4.0))(svelte@5.2.9)
       eslint-plugin-testing-library:
         specifier: ^7.0.0
         version: 7.0.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
@@ -72,7 +72,7 @@ importers:
         version: 15.12.0
       svelte-eslint-parser:
         specifier: 0.43.0
-        version: 0.43.0(svelte@5.2.8)
+        version: 0.43.0(svelte@5.2.9)
       typescript-eslint:
         specifier: ^8.16.0
         version: 8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
@@ -118,7 +118,7 @@ importers:
         version: 0.14.0(prettier@3.4.1)
       prettier-plugin-svelte:
         specifier: ^3.3.2
-        version: 3.3.2(prettier@3.4.1)(svelte@5.2.8)
+        version: 3.3.2(prettier@3.4.1)(svelte@5.2.9)
 
   packages/tsconfig:
     devDependencies:
@@ -178,8 +178,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
       svelte:
-        specifier: ^5.2.8
-        version: 5.2.8
+        specifier: ^5.2.9
+        version: 5.2.9
     devDependencies:
       '@qlik/eslint-config':
         specifier: workspace:*
@@ -723,8 +723,8 @@ packages:
     resolution: {integrity: sha512-pq19gbaMOmFE3CbL0ZB8J8BFCo2ckfHBfaIsaOZgBIF4EoISJIdLX5xRhd0FGB0LlHReNRuzoJoMGpTjq8F2CQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitest/eslint-plugin@1.1.10':
-    resolution: {integrity: sha512-uScH5Kz5v32vvtQYB2iodpoPg2mGASK+VKpjlc2IUgE0+16uZKqVKi2vQxjxJ6sMCQLBs4xhBFZlmZBszsmfKQ==}
+  '@vitest/eslint-plugin@1.1.11':
+    resolution: {integrity: sha512-f24vqvW1GE94Qs1qIelMdhTaYoVS6TbNz7V/1xc1A7gggoz21Lon3bDh8SRoesRpXSJ+23fXUc9cOUAKoGgZ8g==}
     peerDependencies:
       '@typescript-eslint/utils': '>= 8.0'
       eslint: '>= 8.57.0'
@@ -1054,8 +1054,8 @@ packages:
   es-shim-unscopables@1.0.2:
     resolution: {integrity: sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==}
 
-  es-to-primitive@1.2.1:
-    resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
+  es-to-primitive@1.3.0:
+    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.24.0:
@@ -1506,8 +1506,8 @@ packages:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
     engines: {node: '>= 0.4'}
 
-  is-bun-module@1.2.1:
-    resolution: {integrity: sha512-AmidtEM6D6NmUiLOvvU7+IePxjEjOzra2h0pSrsfSAcXwl/83zLLXDByafUJy9k/rKK0pvXMLdwKwGHlX2Ke6Q==}
+  is-bun-module@1.3.0:
+    resolution: {integrity: sha512-DgXeu5UWI0IsMQundYb5UAOzm6G2eVnarJ0byP6Tm55iZNKceD59LNPA2L4VvsScTtHcw0yEkVwSf7PC+QoLSA==}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -2153,8 +2153,8 @@ packages:
       svelte:
         optional: true
 
-  svelte@5.2.8:
-    resolution: {integrity: sha512-VU7a01XwnFi6wXVkH5QY3FYXRZWrhsWZhaE8AYU6UeYZdslE3TFgQq6+HLrbMjOLkVhdKt74NGHYbhFeErQQ6g==}
+  svelte@5.2.9:
+    resolution: {integrity: sha512-LjO7R6K8FI8dA3l+4CcsbJ3djIe2TtokHGzfpDTro5g8nworMbTz9alCR95EQXGsqlzIAvqJtZ7Yy0o33lL09Q==}
     engines: {node: '>=18'}
 
   synckit@0.9.2:
@@ -3032,7 +3032,7 @@ snapshots:
       '@typescript-eslint/types': 8.16.0
       eslint-visitor-keys: 4.2.0
 
-  '@vitest/eslint-plugin@1.1.10(@typescript-eslint/utils@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)(vitest@2.1.6(@types/node@22.10.0)(jiti@2.4.0))':
+  '@vitest/eslint-plugin@1.1.11(@typescript-eslint/utils@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)(vitest@2.1.6(@types/node@22.10.0)(jiti@2.4.0))':
     dependencies:
       '@typescript-eslint/utils': 8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
       eslint: 9.15.0(jiti@2.4.0)
@@ -3356,7 +3356,7 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.0.0
       es-set-tostringtag: 2.0.3
-      es-to-primitive: 1.2.1
+      es-to-primitive: 1.3.0
       function.prototype.name: 1.1.6
       get-intrinsic: 1.2.4
       get-symbol-description: 1.0.2
@@ -3432,7 +3432,7 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
-  es-to-primitive@1.2.1:
+  es-to-primitive@1.3.0:
     dependencies:
       is-callable: 1.2.7
       is-date-object: 1.0.5
@@ -3486,10 +3486,10 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.15.0(jiti@2.4.0)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-plugin-import-x@4.4.3(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
-      is-bun-module: 1.2.1
+      is-bun-module: 1.3.0
       is-glob: 4.0.3
     optionalDependencies:
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0))
@@ -3500,7 +3500,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-plugin-import-x@4.4.3(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -3539,7 +3539,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.15.0(jiti@2.4.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-plugin-import-x@4.4.3(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -3740,7 +3740,7 @@ snapshots:
       string.prototype.matchall: 4.0.11
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-svelte@2.46.0(eslint@9.15.0(jiti@2.4.0))(svelte@5.2.8):
+  eslint-plugin-svelte@2.46.0(eslint@9.15.0(jiti@2.4.0))(svelte@5.2.9):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.15.0(jiti@2.4.0))
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -3753,9 +3753,9 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       semver: 7.6.3
-      svelte-eslint-parser: 0.43.0(svelte@5.2.8)
+      svelte-eslint-parser: 0.43.0(svelte@5.2.9)
     optionalDependencies:
-      svelte: 5.2.8
+      svelte: 5.2.9
     transitivePeerDependencies:
       - ts-node
 
@@ -4066,7 +4066,7 @@ snapshots:
       call-bind: 1.0.7
       has-tostringtag: 1.0.2
 
-  is-bun-module@1.2.1:
+  is-bun-module@1.3.0:
     dependencies:
       semver: 7.6.3
 
@@ -4455,10 +4455,10 @@ snapshots:
       prettier: 3.4.1
       sh-syntax: 0.4.2
 
-  prettier-plugin-svelte@3.3.2(prettier@3.4.1)(svelte@5.2.8):
+  prettier-plugin-svelte@3.3.2(prettier@3.4.1)(svelte@5.2.9):
     dependencies:
       prettier: 3.4.1
-      svelte: 5.2.8
+      svelte: 5.2.9
 
   prettier@2.8.8: {}
 
@@ -4703,7 +4703,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-eslint-parser@0.43.0(svelte@5.2.8):
+  svelte-eslint-parser@0.43.0(svelte@5.2.9):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -4711,9 +4711,9 @@ snapshots:
       postcss: 8.4.49
       postcss-scss: 4.0.9(postcss@8.4.49)
     optionalDependencies:
-      svelte: 5.2.8
+      svelte: 5.2.9
 
-  svelte@5.2.8:
+  svelte@5.2.9:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0

--- a/test/test-base/package.json
+++ b/test/test-base/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "description": "Test project for react linting",
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "lint": "eslint ."
+  },
   "prettier": "@qlik/prettier-config",
   "devDependencies": {
     "@qlik/eslint-config": "workspace:*",

--- a/test/test-base/src/javascript/rules/no-unreachable-loop.js
+++ b/test/test-base/src/javascript/rules/no-unreachable-loop.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax */
 /* eslint-disable no-continue */
 /* eslint-disable no-unmodified-loop-condition */
 /* eslint-disable no-else-return */

--- a/test/test-base/src/typescript/rules/prefer-for-of.ts
+++ b/test/test-base/src/typescript/rules/prefer-for-of.ts
@@ -5,7 +5,6 @@ for (let i = 0; i < array.length; i++) {
   console.log(array[i]);
 }
 
-// eslint-disable-next-line no-restricted-syntax
 for (const i in array) {
   console.log(i);
 }

--- a/test/test-react-svelte/eslint.config.js
+++ b/test/test-react-svelte/eslint.config.js
@@ -2,14 +2,12 @@ import qlikEslint from "@qlik/eslint-config";
 
 const config = qlikEslint.compose(
   // adds the base config for both JS and TS
-  ...qlikEslint.configs.recommended,
+  ...qlikEslint.configs.react,
+  ...qlikEslint.configs.svelte,
   ...qlikEslint.configs.vitest,
   {
     rules: {
-      "no-undef": "off",
-      "no-console": "off",
-      "no-magic-numbers": "off",
-      "@typescript-eslint/no-magic-numbers": "off",
+      // Add any additional rules here
     },
   },
 );

--- a/test/test-react-svelte/package.json
+++ b/test/test-react-svelte/package.json
@@ -1,13 +1,15 @@
 {
   "name": "test-react-svelte",
   "private": true,
-  "type": "module",
   "description": "Test project for react-svelte linting",
-  "scripts": {},
+  "type": "module",
+  "scripts": {
+    "lint": "eslint ."
+  },
   "prettier": "@qlik/prettier-config",
   "dependencies": {
     "react": "^18.3.1",
-    "svelte": "^5.2.8"
+    "svelte": "^5.2.9"
   },
   "devDependencies": {
     "@qlik/eslint-config": "workspace:*",

--- a/test/test-react/package.json
+++ b/test/test-react/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "description": "Test project for react linting",
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "lint": "eslint ."
+  },
   "prettier": "@qlik/prettier-config",
   "dependencies": {
     "react": "^18.3.1"

--- a/test/test-react/src/ReactComponent.tsx
+++ b/test/test-react/src/ReactComponent.tsx
@@ -13,6 +13,5 @@ const ReactComponent2 = ({ name }: ReactComponentProps): React.ReactNode => {
 function reactComponent({ name }: ReactComponentProps): React.ReactNode {
   return <section>Props: {`{ this name: "${name}" }`}</section>;
 }
-var shouldUseFlatConfig = "hej";
 
 export { ReactComponent, ReactComponent2, reactComponent };

--- a/test/test-react/src/file.ts
+++ b/test/test-react/src/file.ts
@@ -1,7 +1,9 @@
-shouldUseFlatConfig;
+/* eslint-disable prefer-const */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-expressions */
 
-async (params: type) => {
-  asf;
+async (params: string[]) => {
+  params.length;
 };
 
 let nisse = 3;


### PR DESCRIPTION
Bulk update for a few issues I ran into when using the new config

- rules for `.js` files was not working properly because typescript-eslint was applied to `.js` files as well. Simple things like `no-undef` didn't work.
- Separated esm and cjs config so that esm config is not applied on .cjs files.
- Turned `"@typescript-eslint/no-unnecessary-condition` back on
- Turned off `no-underscore-dangle` (it was off in previous config)
- Removed all references to airbnb
- Turned linting back on for the test projects (should be used to discover changes in the config)