### PR TITLE
fix: enable react rules for ts/js files

### DIFF
--- a/packages/eslint-config/src/configs/react.js
+++ b/packages/eslint-config/src/configs/react.js
@@ -52,7 +52,7 @@ const reactConfig = {
  */
 const reactJS = mergeConfigs(reactConfig, {
   name: "react-js",
-  files: ["**/*.jsx"],
+  files: ["**/*.js", "**/*.jsx"],
   rules: {
     // turn on/off or modify js rules necessary for react
     "react/jsx-filename-extension": [2, { extensions: [".js", ".jsx"] }],
@@ -64,7 +64,7 @@ const reactJS = mergeConfigs(reactConfig, {
  */
 const reactTS = mergeConfigs(reactConfig, {
   name: "react-ts",
-  files: ["**/*.tsx"],
+  files: ["**/*.ts", "**/*.tsx"],
   rules: {
     // turn on/off or modify js/ts rules necessary for react
     "react/jsx-filename-extension": [2, { extensions: [".js", ".jsx", ".ts", ".tsx"] }],


### PR DESCRIPTION
Hooks are generally in non tsx/jsx files, so these rules need to apply for everything when you pull in those rules.
