### PR TITLE
fix: dont override import-x rules in typescript ruleset

### DIFF
--- a/.changeset/honest-pans-play.md
+++ b/.changeset/honest-pans-play.md
@@ -1,0 +1,5 @@
+---
+"@qlik/eslint-config": patch
+---
+
+fix: dont override import-x rules in typescript ruleset

--- a/packages/eslint-config/src/configs/recommended.js
+++ b/packages/eslint-config/src/configs/recommended.js
@@ -56,7 +56,6 @@ const recommendedTS = mergeConfigs(
     },
   },
   ...tsconfig.configs.recommended,
-  eslintPluginImportX.flatConfigs.recommended,
   eslintPluginImportX.flatConfigs.typescript,
   {
     name: "recommended-ts",


### PR DESCRIPTION
Before:
<img width="440" alt="Screenshot 2024-11-27 at 14 11 57" src="https://github.com/user-attachments/assets/da6d0c63-92b9-4f48-b289-05fe52f0c433">

After:
![image](https://github.com/user-attachments/assets/675032ee-b2e1-4463-acf3-7aeb8f2a614d)
