### PR TITLE
fix: turn off `@typescript-eslint/no-unnecessary-condition`

### DIFF
--- a/.changeset/red-pandas-cover.md
+++ b/.changeset/red-pandas-cover.md
@@ -1,0 +1,5 @@
+---
+"@qlik/eslint-config": patch
+---
+
+fix: turn off `@typescript-eslint/no-unnecessary-condition`

--- a/packages/eslint-config/src/configs/rules/typescript.js
+++ b/packages/eslint-config/src/configs/rules/typescript.js
@@ -151,7 +151,7 @@ const rules = {
   // Lots of false/iffy positives
   // watch out for always truthy conditions
   // https://typescript-eslint.io/rules/no-unnecessary-condition
-  "@typescript-eslint/no-unnecessary-condition": "error",
+  "@typescript-eslint/no-unnecessary-condition": "off",
 
   // no unnecessary namespace qualifiers.
   // https://typescript-eslint.io/rules/no-unnecessary-qualifier

--- a/test/test-base/src/typescript/rules/no-non-null-asserted-nullish-coalescing.ts
+++ b/test/test-base/src/typescript/rules/no-non-null-asserted-nullish-coalescing.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-lone-blocks */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /* eslint-disable prefer-const */
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 


### PR DESCRIPTION
not much value from this one and makes the code less symmetric