### PR TITLE
fix: make `extend` property useful

### DIFF
--- a/.changeset/mean-dancers-eat.md
+++ b/.changeset/mean-dancers-eat.md
@@ -1,0 +1,5 @@
+---
+"@qlik/eslint-config": patch
+---
+
+fix: make `extend` property useful

--- a/packages/eslint-config/src/__tests__/qlik-eslint.test.ts
+++ b/packages/eslint-config/src/__tests__/qlik-eslint.test.ts
@@ -6,4 +6,28 @@ describe("qlik-eslint", () => {
     const base = qlikEslint.configs.recommended;
     expect(base[0]).toHaveProperty("rules");
   });
+
+  it("should support extend property", () => {
+    const config = qlikEslint.compose(
+      // adds the base config for both JS and TS
+      {
+        extend: [...qlikEslint.configs.vitest],
+        rules: {
+          "vitest/expect-expect": "warn", // TODO should be ERROR
+          "testing-library/render-result-naming-convention": "warn", // TODO should be ERROR
+        },
+      },
+      {
+        rules: {
+          "no-undef": "off",
+          "no-console": "off",
+          "no-magic-numbers": "off",
+          "@typescript-eslint/no-magic-numbers": "off",
+        },
+      },
+    );
+    expect(config.length).toBe(2);
+    expect(config[0]).toHaveProperty("rules");
+    expect(config[0].rules?.["testing-library/render-result-naming-convention"]).toBe("warn");
+  });
 });

--- a/packages/eslint-config/src/utils/__tests__/compose.test.ts
+++ b/packages/eslint-config/src/utils/__tests__/compose.test.ts
@@ -23,7 +23,7 @@ describe("compose function", () => {
       files: ["*.js"],
     });
 
-    expect(result).toEqual([{ files: ["*.js"], rules: { "no-console": "error" } }]);
+    expect(result).toEqual([{ files: ["*.js"], rules: { "no-console": "error", "no-debugger": "warn" } }]);
   });
 
   it("should merge configs and overwrite files correctly", () => {
@@ -59,7 +59,7 @@ describe("compose function", () => {
       extend: [baseConfig1, baseConfig2],
     });
 
-    expect(result).toEqual([{ rules: { "no-console": "error" } }, { rules: { "no-debugger": "warn" } }, {}]);
+    expect(result).toEqual([{ rules: { "no-console": "error" } }, { rules: { "no-debugger": "warn" } }]);
   });
 
   it("should throw an error if extend property is not an array", () => {
@@ -91,9 +91,7 @@ describe("compose function", () => {
 
     expect(result).toEqual([
       { rules: { "no-console": "error" }, files: ["*.js"] },
-      { files: ["*.js"] },
       { rules: { "no-debugger": "warn" }, files: ["*.ts"] },
-      { files: ["*.ts"] },
     ]);
   });
 
@@ -113,14 +111,8 @@ describe("compose function", () => {
     );
 
     expect(result).toEqual([
-      { name: "base-config-1", rules: { "no-console": "error" }, files: ["*.js"] },
-      {
-        files: ["*.js"],
-      },
-      { name: "base-config-2", rules: { "no-debugger": "warn" }, files: ["*.ts"] },
-      {
-        files: ["*.ts"],
-      },
+      { name: "@qlik/eslint-config/base-config-1", rules: { "no-console": "error" }, files: ["*.js"] },
+      { name: "@qlik/eslint-config/base-config-2", rules: { "no-debugger": "warn" }, files: ["*.ts"] },
     ]);
   });
 
@@ -136,7 +128,6 @@ describe("compose function", () => {
     expect(result).toEqual([
       { rules: { "no-console": "error" }, files: ["*.js"] },
       { rules: { "no-debugger": "warn" }, files: ["*.js"] },
-      { files: ["*.js"] },
     ]);
   });
 
@@ -154,7 +145,6 @@ describe("compose function", () => {
     expect(result).toEqual([
       { rules: { "no-console": "error" }, files: ["*.tsx"] },
       { rules: { "no-debugger": "warn" }, files: ["*.tsx"] },
-      { files: ["*.tsx"] },
     ]);
   });
 
@@ -187,28 +177,16 @@ describe("compose function", () => {
             parse: parseFn,
           },
         },
+        rules: { "no-debugger": "off" },
       },
       {
         files: ["*.jsx"],
-        rules: {
-          "no-console": "error",
-        },
-      },
-      {
-        files: ["*.jsx"],
-        rules: {
-          "no-debugger": "off",
-        },
+        rules: { "no-console": "error", "no-debugger": "off" },
       },
       {
         files: ["*.tsx"],
         rules: {
           "no-debugger": "warn",
-        },
-      },
-      {
-        files: ["*.tsx"],
-        rules: {
           "no-undef": "error",
         },
       },
@@ -235,17 +213,7 @@ describe("compose function", () => {
         files: ["*.ts"],
         rules: {
           "no-console": "error",
-        },
-      },
-      {
-        files: ["*.ts"],
-        rules: {
           "no-debugger": "warn",
-        },
-      },
-      {
-        files: ["*.ts"],
-        rules: {
           "no-typescript": "error",
         },
       },

--- a/packages/eslint-config/src/utils/__tests__/compose.test.ts
+++ b/packages/eslint-config/src/utils/__tests__/compose.test.ts
@@ -23,10 +23,7 @@ describe("compose function", () => {
       files: ["*.js"],
     });
 
-    expect(result).toEqual([
-      { files: ["*.js"], rules: { "no-console": "error" } },
-      { files: ["*.js"], rules: { "no-debugger": "warn" } },
-    ]);
+    expect(result).toEqual([{ files: ["*.js"], rules: { "no-console": "error" } }]);
   });
 
   it("should merge configs and overwrite files correctly", () => {
@@ -42,15 +39,15 @@ describe("compose function", () => {
     });
 
     expect(result).toEqual([
-      { files: ["*.js"], rules: { "no-console": "error" } },
+      { files: ["*.js"], rules: { "no-console": "error", "no-debugger": "warn" } },
       {
         files: ["*.js"],
         rules: {
+          "no-debugger": "warn",
           "no-undef": "error",
           "no-var": "error",
         },
       },
-      { files: ["*.js"], rules: { "no-debugger": "warn" } },
     ]);
   });
 

--- a/packages/eslint-config/src/utils/__tests__/merge.test.ts
+++ b/packages/eslint-config/src/utils/__tests__/merge.test.ts
@@ -69,9 +69,15 @@ describe("merge function", () => {
   });
 
   it("should handle merging with keys that should be overridden", () => {
-    const obj1 = { a: 1, b: 2, files: ["*.js"], globals: ["BrowserGlobal1"] };
-    const obj2 = { a: 3, c: 4, files: ["*.ts"], globals: ["NodeGlobal1"] };
+    const obj1 = {
+      a: 1,
+      b: 2,
+      files: ["*.js"],
+      ignores: ["should not be present after merge"],
+      globals: ["BrowserGlobal1"],
+    };
+    const obj2 = { a: 3, c: 4, files: ["*.ts"], ignores: ["only this"], globals: ["NodeGlobal1"] };
     const result = merge(obj1, obj2);
-    expect(result).toEqual({ a: 3, b: 2, c: 4, files: ["*.ts"], globals: ["NodeGlobal1"] });
+    expect(result).toEqual({ a: 3, b: 2, c: 4, files: ["*.ts"], ignores: ["only this"], globals: ["NodeGlobal1"] });
   });
 });

--- a/packages/eslint-config/src/utils/compose.js
+++ b/packages/eslint-config/src/utils/compose.js
@@ -56,7 +56,7 @@ export default function compose(...configs) {
     return [
       ...extendArr.map((extension) => {
         const name = [config.name, extension.name].filter(Boolean).join("__");
-        return mergeConfigs(extension, config, { name });
+        return mergeConfigs(extension, config, name ? { name } : {});
       }),
     ];
   });

--- a/packages/eslint-config/src/utils/compose.js
+++ b/packages/eslint-config/src/utils/compose.js
@@ -1,4 +1,7 @@
 // @ts-check
+
+import { mergeConfigs } from "./config.js";
+
 /**
  * Utility function to make it easy to strictly type your "Flat" config file
  *
@@ -33,6 +36,7 @@ export default function compose(...configs) {
     if (extendArr == null || extendArr.length === 0) {
       return config;
     }
+
     const undefinedExtensions = extendArr.reduce((acc, extension, extensionIndex) => {
       const maybeExtension = extension;
       if (maybeExtension == null) {
@@ -52,14 +56,8 @@ export default function compose(...configs) {
     return [
       ...extendArr.map((extension) => {
         const name = [config.name, extension.name].filter(Boolean).join("__");
-        return {
-          ...extension,
-          ...(config.files && { files: config.files }),
-          ...(config.ignores && { ignores: config.ignores }),
-          ...(name && { name }),
-        };
+        return mergeConfigs(extension, config, { name });
       }),
-      config,
     ];
   });
 }

--- a/packages/eslint-config/src/utils/merge.js
+++ b/packages/eslint-config/src/utils/merge.js
@@ -1,6 +1,6 @@
 // these ones will only do shallow merge, but the merge function will do deep merge
 const noNeedToDeepMerge = ["plugins", "rules", "parser"];
-const overWrite = ["files", "globals"];
+const overWrite = ["files", "globals", "ignores"];
 
 /**
  *


### PR DESCRIPTION
The `extend` property was not working as expected. This fix makes it more useful. 

The changes are described in the diff for the README.md.
