### PR TITLE
fix: add svelte as peer dependency

### DIFF
--- a/.changeset/seven-dots-unite.md
+++ b/.changeset/seven-dots-unite.md
@@ -1,0 +1,5 @@
+---
+"@qlik/eslint-config": patch
+---
+
+Add svelte as peer dependency since `eslint-plugin-svelte` needs it.

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -54,7 +54,8 @@
     "vitest": "^2.1.6"
   },
   "peerDependencies": {
-    "eslint": ">=9.0.0"
+    "eslint": ">=9.0.0",
+    "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       globals:
         specifier: ^15.12.0
         version: 15.12.0
+      svelte:
+        specifier: ^3.37.0 || ^4.0.0 || ^5.0.0
+        version: 5.2.9
       svelte-eslint-parser:
         specifier: 0.43.0
         version: 0.43.0(svelte@5.2.9)


### PR DESCRIPTION
`eslint-plugin-svelte` needs it