### PR TITLE
fix(eslint-config): better file ending enforcing of .js/.ts-files for esm config

### DIFF
--- a/.changeset/three-suits-notice.md
+++ b/.changeset/three-suits-notice.md
@@ -1,0 +1,5 @@
+---
+"@qlik/eslint-config": patch
+---
+
+Only enforce file endings in esm-config by default for js-files.

--- a/packages/eslint-config/src/configs/esm.js
+++ b/packages/eslint-config/src/configs/esm.js
@@ -10,8 +10,19 @@ import nodeRules from "./rules/node.js";
  */
 const nodeEsmRules = {
   ...nodeRules,
-  "import-x/extensions": ["error", "ignorePackages"],
   // modify rules for node esm here
+
+  // Ensure consistent use of file extension within the import path
+  // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/extensions.md
+  "import-x/extensions": [
+    "error",
+    "ignorePackages",
+    {
+      ts: "never",
+      mts: "never",
+      tsx: "never",
+    },
+  ],
 };
 
 /**

--- a/packages/eslint-config/src/configs/rules/import-x.js
+++ b/packages/eslint-config/src/configs/rules/import-x.js
@@ -98,9 +98,11 @@ const rules = {
     "ignorePackages",
     {
       js: "never",
+      cjs: "never",
       mjs: "never",
       jsx: "never",
       ts: "never",
+      cts: "never",
       mts: "never",
       tsx: "never",
     },

--- a/packages/eslint-config/test/generated/cjs-final-config.js
+++ b/packages/eslint-config/test/generated/cjs-final-config.js
@@ -202,6 +202,8 @@ export default [
         "error",
         "ignorePackages",
         {
+          "cjs": "never",
+          "cts": "never",
           "js": "never",
           "jsx": "never",
           "mjs": "never",
@@ -1321,6 +1323,8 @@ export default [
         "error",
         "ignorePackages",
         {
+          "cjs": "never",
+          "cts": "never",
           "js": "never",
           "jsx": "never",
           "mjs": "never",

--- a/packages/eslint-config/test/generated/esm-final-config.js
+++ b/packages/eslint-config/test/generated/esm-final-config.js
@@ -200,7 +200,12 @@ export default [
       "import-x/export": "error",
       "import-x/extensions": [
         "error",
-        "ignorePackages"
+        "ignorePackages",
+        {
+          "mts": "never",
+          "ts": "never",
+          "tsx": "never"
+        }
       ],
       "import-x/named": "error",
       "import-x/namespace": "error",
@@ -1311,7 +1316,12 @@ export default [
       "import-x/export": "error",
       "import-x/extensions": [
         "error",
-        "ignorePackages"
+        "ignorePackages",
+        {
+          "mts": "never",
+          "ts": "never",
+          "tsx": "never"
+        }
       ],
       "import-x/named": "off",
       "import-x/namespace": "error",

--- a/packages/eslint-config/test/generated/react-final-config.js
+++ b/packages/eslint-config/test/generated/react-final-config.js
@@ -1342,6 +1342,8 @@ export default [
         "error",
         "ignorePackages",
         {
+          "cjs": "never",
+          "cts": "never",
           "js": "never",
           "jsx": "never",
           "mjs": "never",
@@ -4083,6 +4085,8 @@ export default [
         "error",
         "ignorePackages",
         {
+          "cjs": "never",
+          "cts": "never",
           "js": "never",
           "jsx": "never",
           "mjs": "never",

--- a/packages/eslint-config/test/generated/recommended-final-config.js
+++ b/packages/eslint-config/test/generated/recommended-final-config.js
@@ -1258,6 +1258,8 @@ export default [
         "error",
         "ignorePackages",
         {
+          "cjs": "never",
+          "cts": "never",
           "js": "never",
           "jsx": "never",
           "mjs": "never",
@@ -3435,6 +3437,8 @@ export default [
         "error",
         "ignorePackages",
         {
+          "cjs": "never",
+          "cts": "never",
           "js": "never",
           "jsx": "never",
           "mjs": "never",

--- a/packages/eslint-config/test/generated/svelte-final-config.js
+++ b/packages/eslint-config/test/generated/svelte-final-config.js
@@ -1258,6 +1258,8 @@ export default [
         "error",
         "ignorePackages",
         {
+          "cjs": "never",
+          "cts": "never",
           "js": "never",
           "jsx": "never",
           "mjs": "never",
@@ -3435,6 +3437,8 @@ export default [
         "error",
         "ignorePackages",
         {
+          "cjs": "never",
+          "cts": "never",
           "js": "never",
           "jsx": "never",
           "mjs": "never",


### PR DESCRIPTION
Enforces usage of file endings for esm configuration. But only for javascript files. Warnings will be disabled in typescript files.