### PR TITLE
feat: update configs to auto-handle cjs modules

### DIFF
--- a/.changeset/many-turkeys-stand.md
+++ b/.changeset/many-turkeys-stand.md
@@ -1,0 +1,5 @@
+---
+"@qlik/eslint-config": minor
+---
+
+feat: update configs to auto-handle cjs modules

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -22,10 +22,10 @@
     "test": "vitest run && ./test/verify-configs.sh"
   },
   "dependencies": {
-    "@eslint-react/eslint-plugin": "^1.37.2",
+    "@eslint-react/eslint-plugin": "^1.38.0",
     "@eslint/js": "^9.23.0",
-    "@typescript-eslint/parser": "^8.27.0",
-    "@typescript-eslint/utils": "^8.27.0",
+    "@typescript-eslint/parser": "^8.28.0",
+    "@typescript-eslint/utils": "^8.28.0",
     "@vitest/eslint-plugin": "^1.1.38",
     "confusing-browser-globals": "^1.0.11",
     "eslint-config-prettier": "^10.1.1",
@@ -40,7 +40,7 @@
     "eslint-plugin-testing-library": "^7.1.1",
     "globals": "^16.0.0",
     "svelte-eslint-parser": "^1.1.0",
-    "typescript-eslint": "^8.27.0"
+    "typescript-eslint": "^8.28.0"
   },
   "devDependencies": {
     "@qlik/tsconfig": "workspace:*",
@@ -48,7 +48,7 @@
     "@types/eslint-config-prettier": "^6.11.3",
     "@types/eslint-plugin-jsx-a11y": "^6.10.0",
     "@types/eslint__js": "^9.14.0",
-    "@types/node": "^22.13.11",
+    "@types/node": "^22.13.13",
     "eslint": "^9.23.0",
     "prettier": "^3.5.3",
     "vitest": "^3.0.9"

--- a/packages/eslint-config/src/configs/cjs.js
+++ b/packages/eslint-config/src/configs/cjs.js
@@ -1,58 +1,63 @@
 // @ts-check
 import prettier from "eslint-config-prettier";
-import globals from "globals";
 import { mergeConfigs } from "../utils/config.js";
-import { recommendedJS, recommendedTS } from "./recommended.js";
-import nodeRules from "./rules/node.js";
+import { baseCjsJS, baseCjsTS, baseEsmJS, baseEsmTS } from "./shared/node.js";
 
 /**
- * @satisfies {import("../types/index.js").ESLintFlatConfig['rules']}
- */
-const cjsRules = {
-  ...nodeRules,
-  // modify rules for node commonjs here
-};
-
-/**
+ * CJS config for javascript in node
  * @type {import("../types/index.js").ESLintFlatConfig}
  */
 const cjsJS = mergeConfigs(
   // base it on the recommended javascript config
-  recommendedJS,
+  baseCjsJS,
   // add qlik's recommended node commonjs config for javascript
   {
     name: "node-cjs-js",
     files: ["**/*.{js,cjs}"],
-    languageOptions: {
-      globals: globals.node,
-      sourceType: "commonjs",
-    },
-    rules: cjsRules,
   },
   prettier,
 );
 
 /**
+ * CJS config for typescript in node
  * @type {import("../types/index.js").ESLintFlatConfig}
  */
 const cjsTS = mergeConfigs(
   // base it on the recommended typescript config
-  recommendedTS,
+  baseCjsTS,
   // add qlik's recommended node commonjs config for typescript
   {
     name: "node-cjs-ts",
     files: ["**/*.{ts,cts}"],
-    languageOptions: {
-      globals: globals.node,
-      sourceType: "commonjs",
-    },
-    rules: {
-      ...cjsRules,
-      // modify ts specific rules for node here
-    },
   },
   prettier,
 );
 
-export default [cjsJS, cjsTS];
+/**
+ * Adding esm config for .mjs files
+ * @type {import("../types/index.js").ESLintFlatConfig}
+ */
+const cjsMJS = mergeConfigs(
+  baseEsmJS,
+  {
+    name: "node-cjs-mjs",
+    files: ["**/*.mjs"],
+  },
+  prettier,
+);
+
+/**
+ * Adding esm config for .mts files
+ * @type {import("../types/index.js").ESLintFlatConfig}
+ */
+const cjsMTS = mergeConfigs(
+  baseEsmTS,
+  {
+    name: "node-cjs-mts",
+    files: ["**/*.mts"],
+  },
+  prettier,
+);
+
+export default [cjsJS, cjsTS, cjsMJS, cjsMTS];
 export { cjsJS, cjsTS };

--- a/packages/eslint-config/src/configs/esbrowser.js
+++ b/packages/eslint-config/src/configs/esbrowser.js
@@ -2,7 +2,8 @@
 import prettier from "eslint-config-prettier";
 import globals from "globals";
 import { mergeConfigs } from "../utils/config.js";
-import { recommendedJS, recommendedTS } from "./recommended.js";
+import { baseConfigJS, baseConfigTS } from "./shared/base.js";
+import { baseCjsJS, baseCjsTS } from "./shared/node.js";
 
 /**
  * @satisfies {import("../types/index.js").ESLintFlatConfig["rules"]}
@@ -24,11 +25,12 @@ const browserEsmRules = {
 };
 
 /**
+ * ESM config for javascript in browsers
  * @type {import("../types/index.js").ESLintFlatConfig}
  */
 const esbrowserJS = mergeConfigs(
   // base it on the recommended javascript config
-  recommendedJS,
+  baseConfigJS,
   // add qlik's recommended node esm config for javascript
   {
     name: "esbrowser-js",
@@ -46,11 +48,12 @@ const esbrowserJS = mergeConfigs(
 );
 
 /**
+ * ESM config for typescript in browsers
  * @type {import("../types/index.js").ESLintFlatConfig}
  */
 const esbrowserTS = mergeConfigs(
   // base it on the recommended typescript config
-  recommendedTS,
+  baseConfigTS,
   // add qlik's recommended node esm config for typescript
   {
     name: "esbrowser-ts",
@@ -67,5 +70,31 @@ const esbrowserTS = mergeConfigs(
   prettier,
 );
 
-export default [esbrowserJS, esbrowserTS];
+/**
+ * Adding commonjs config for .cjs files
+ * @type {import("../types/index.js").ESLintFlatConfig}
+ */
+const esbrowserCJS = mergeConfigs(
+  baseCjsJS,
+  {
+    name: "browser-esm-cjs",
+    files: ["**/*.cjs"],
+  },
+  prettier,
+);
+
+/**
+ * Adding commonjs config for .cts files
+ * @type {import("../types/index.js").ESLintFlatConfig}
+ */
+const esbrowserCTS = mergeConfigs(
+  baseCjsTS,
+  {
+    name: "browser-esm-cts",
+    files: ["**/*.cts"],
+  },
+  prettier,
+);
+
+export default [esbrowserJS, esbrowserTS, esbrowserCJS, esbrowserCTS];
 export { esbrowserJS, esbrowserTS };

--- a/packages/eslint-config/src/configs/esm.js
+++ b/packages/eslint-config/src/configs/esm.js
@@ -2,8 +2,9 @@
 import prettier from "eslint-config-prettier";
 import globals from "globals";
 import { mergeConfigs } from "../utils/config.js";
-import { recommendedJS, recommendedTS } from "./recommended.js";
 import nodeRules from "./rules/node.js";
+import { baseConfigJS, baseConfigTS } from "./shared/base.js";
+import { baseCjsJS, baseCjsTS } from "./shared/node.js";
 
 /**
  * @satisfies {import("../types/index.js").ESLintFlatConfig["rules"]}
@@ -26,11 +27,12 @@ const nodeEsmRules = {
 };
 
 /**
+ * ESM config for javascript in node
  * @type {import("../types/index.js").ESLintFlatConfig}
  */
 const esmJS = mergeConfigs(
   // base it on the recommended javascript config
-  recommendedJS,
+  baseConfigJS,
   // add qlik's recommended node esm config for javascript
   {
     name: "node-esm-js",
@@ -45,11 +47,12 @@ const esmJS = mergeConfigs(
 );
 
 /**
+ * ESM config for typescript in node
  * @type {import("../types/index.js").ESLintFlatConfig}
  */
 const esmTS = mergeConfigs(
   // base it on the recommended typescript config
-  recommendedTS,
+  baseConfigTS,
   // add qlik's recommended node esm config for typescript
   {
     name: "node-esm-ts",
@@ -66,5 +69,31 @@ const esmTS = mergeConfigs(
   prettier,
 );
 
-export default [esmJS, esmTS];
+/**
+ * Adding commonjs config for .cjs files
+ * @type {import("../types/index.js").ESLintFlatConfig}
+ */
+const esmCJS = mergeConfigs(
+  baseCjsJS,
+  {
+    name: "node-esm-cjs",
+    files: ["**/*.cjs"],
+  },
+  prettier,
+);
+
+/**
+ * Adding commonjs config for .cts files
+ * @type {import("../types/index.js").ESLintFlatConfig}
+ */
+const esmCTS = mergeConfigs(
+  baseCjsTS,
+  {
+    name: "node-esm-cts",
+    files: ["**/*.cts"],
+  },
+  prettier,
+);
+
+export default [esmJS, esmTS, esmCJS, esmCTS];
 export { esmJS, esmTS };

--- a/packages/eslint-config/src/configs/react.js
+++ b/packages/eslint-config/src/configs/react.js
@@ -3,13 +3,13 @@ import react from "@eslint-react/eslint-plugin";
 import prettier from "eslint-config-prettier";
 import jsxA11y from "eslint-plugin-jsx-a11y";
 import eslintPluginReact from "eslint-plugin-react";
-// @ts-expect-error no types for this plugin yet
 import reactHooks from "eslint-plugin-react-hooks";
 import { mergeConfigs } from "../utils/config.js";
-import { recommendedJS, recommendedTS } from "./recommended.js";
 import reactA11yRules from "./rules/react-a11y.js";
 import reactHooksRules from "./rules/react-hooks.js";
 import reactRules from "./rules/react.js";
+import { baseConfigJS, baseConfigTS } from "./shared/base.js";
+import { baseCjsJS, baseCjsTS } from "./shared/node.js";
 
 /** @type {any} */
 const reactPlugin = eslintPluginReact;
@@ -62,7 +62,7 @@ const reactBaseConfig = mergeConfigs(
  */
 const reactJS = mergeConfigs(
   // base it on the recommended javascript config
-  recommendedJS,
+  baseConfigJS,
   // add the base react config
   reactBaseConfig,
   // add qlik's recommended react config for javascript
@@ -82,7 +82,7 @@ const reactJS = mergeConfigs(
  */
 const reactTS = mergeConfigs(
   // base it on the recommended typescript config
-  recommendedTS,
+  baseConfigTS,
   // add the base react config
   reactBaseConfig,
   // add qlik's recommended react config for typescript
@@ -100,5 +100,31 @@ const reactTS = mergeConfigs(
   prettier,
 );
 
-export default [reactJS, reactTS];
+/**
+ * Adding commonjs config for .cjs files
+ * @type {import("../types/index.js").ESLintFlatConfig}
+ */
+const reactCJS = mergeConfigs(
+  baseCjsJS,
+  {
+    name: "react-cjs",
+    files: ["**/*.cjs"],
+  },
+  prettier,
+);
+
+/**
+ * Adding commonjs config for .cts files
+ * @type {import("../types/index.js").ESLintFlatConfig}
+ */
+const reactCTS = mergeConfigs(
+  baseCjsTS,
+  {
+    name: "react-cts",
+    files: ["**/*.cts"],
+  },
+  prettier,
+);
+
+export default [reactJS, reactTS, reactCJS, reactCTS];
 export { reactJS, reactTS };

--- a/packages/eslint-config/src/configs/recommended.js
+++ b/packages/eslint-config/src/configs/recommended.js
@@ -1,48 +1,17 @@
 // @ts-check
-import js from "@eslint/js";
-import tsParser from "@typescript-eslint/parser";
 import prettier from "eslint-config-prettier";
-import eslintPluginImportX from "eslint-plugin-import-x";
-import globals from "globals";
-import tsconfig from "typescript-eslint";
 import { mergeConfigs } from "../utils/config.js";
-import eslintCoreRules from "./rules/eslint-core.js";
-import importXRules from "./rules/import-x.js";
-import typescriptRules from "./rules/typescript.js";
-
-const baseConfig = mergeConfigs(
-  // basic js config
-  js.configs.recommended,
-  // import-x plugin config
-  eslintPluginImportX.flatConfigs.recommended,
-  {
-    languageOptions: {
-      globals: globals.browser,
-      parserOptions: {
-        warnOnUnsupportedTypeScriptVersion: false,
-      },
-      ecmaVersion: "latest",
-      sourceType: "module",
-    },
-    rules: {
-      // add our recommended rules
-      ...eslintCoreRules,
-      ...importXRules,
-    },
-  },
-);
+import { baseConfigJS, baseConfigTS } from "./shared/base.js";
+import { baseCjsJS, baseCjsTS } from "./shared/node.js";
 
 /**
  * @type {import("../types/index.js").ESLintFlatConfig}
  */
 const recommendedJS = mergeConfigs(
-  baseConfig,
-  // tsconfig.configs.base sets eslint parser to use the typescript parser to parse .js files - handles all modern syntax
-  tsconfig.configs.base,
-  // add qlik's recommended javascript config
+  baseConfigJS,
   {
     name: "recommended-js",
-    files: ["**/*.js", "**/*.mjs", "**/*.cjs"],
+    files: ["**/*.js", "**/*.mjs"],
   },
   prettier,
 );
@@ -51,26 +20,39 @@ const recommendedJS = mergeConfigs(
  * @type {import("../types/index.js").ESLintFlatConfig}
  */
 const recommendedTS = mergeConfigs(
-  // base it on base config
-  baseConfig,
-  // add recommended typescript config
-  ...tsconfig.configs.recommended,
-  // add import-x recommended typescript config
-  eslintPluginImportX.flatConfigs.typescript,
-  // add qlik's recommended typescript config
+  baseConfigTS,
   {
     name: "recommended-ts",
-    files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts", "**/*.d.ts"],
-    languageOptions: {
-      parserOptions: {
-        parser: tsParser,
-        projectService: true,
-      },
-    },
-    rules: typescriptRules,
+    files: ["**/*.ts", "**/*.mts", "**/*.d.ts"],
   },
   prettier,
 );
 
-export default [recommendedJS, recommendedTS];
+/**
+ * A .cjs file is a CommonJS file, which is a module format used in Node.js.
+ * @type {import("../types/index.js").ESLintFlatConfig}
+ */
+const recommendedCJS = mergeConfigs(
+  baseCjsJS,
+  {
+    name: "recommended-cjs",
+    files: ["**/*.cjs"],
+  },
+  prettier,
+);
+
+/**
+ * A .cts file is a CommonJS file, which is a module format used in Node.js.
+ * @type {import("../types/index.js").ESLintFlatConfig}
+ */
+const recommendedCTS = mergeConfigs(
+  baseCjsTS,
+  {
+    name: "recommended-cts",
+    files: ["**/*.cts"],
+  },
+  prettier,
+);
+
+export default [recommendedJS, recommendedTS, recommendedCJS, recommendedCTS];
 export { recommendedJS, recommendedTS };

--- a/packages/eslint-config/src/configs/shared/base.js
+++ b/packages/eslint-config/src/configs/shared/base.js
@@ -1,0 +1,68 @@
+import js from "@eslint/js";
+import tsParser from "@typescript-eslint/parser";
+import eslintPluginImportX from "eslint-plugin-import-x";
+import globals from "globals";
+import tsconfig from "typescript-eslint";
+import { mergeConfigs } from "../../utils/config.js";
+import eslintCoreRules from "../rules/eslint-core.js";
+import importXRules from "../rules/import-x.js";
+import typescriptRules from "../rules/typescript.js";
+
+/**
+ * @type {import("../../types/index.js").ESLintFlatConfig}
+ */
+const baseConfig = mergeConfigs(
+  // basic js config
+  js.configs.recommended,
+  // import-x plugin config
+  eslintPluginImportX.flatConfigs.recommended,
+  {
+    languageOptions: {
+      globals: globals.browser,
+      parserOptions: {
+        warnOnUnsupportedTypeScriptVersion: false,
+      },
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
+    rules: {
+      // add our recommended rules
+      ...eslintCoreRules,
+      ...importXRules,
+    },
+  },
+);
+
+/**
+ * @type {import("../../types/index.js").ESLintFlatConfig}
+ */
+const baseConfigJS = mergeConfigs(
+  baseConfig,
+  // tsconfig.configs.base sets eslint parser to use the typescript parser to parse .js files - handles all modern syntax
+  tsconfig.configs.base,
+  // add qlik's recommended javascript config
+);
+
+/**
+ * @type {import("../../types/index.js").ESLintFlatConfig}
+ */
+const baseConfigTS = mergeConfigs(
+  // base it on base config
+  baseConfig,
+  // add recommended typescript config
+  ...tsconfig.configs.recommended,
+  // add import-x recommended typescript config
+  eslintPluginImportX.flatConfigs.typescript,
+  // add qlik's recommended typescript config
+  {
+    languageOptions: {
+      parserOptions: {
+        parser: tsParser,
+        projectService: true,
+      },
+    },
+    rules: typescriptRules,
+  },
+);
+
+export { baseConfigJS, baseConfigTS };

--- a/packages/eslint-config/src/configs/shared/node.js
+++ b/packages/eslint-config/src/configs/shared/node.js
@@ -1,0 +1,109 @@
+// @ts-check
+import globals from "globals";
+import { mergeConfigs } from "../../utils/config.js";
+import nodeRules from "../rules/node.js";
+import { baseConfigJS, baseConfigTS } from "./base.js";
+
+/**
+ * @satisfies {import("../../types/index.js").ESLintFlatConfig['rules']}
+ */
+const cjsRules = {
+  ...nodeRules,
+  // modify rules for node commonjs here
+};
+
+/**
+ * CJS config for javascript in node
+ * @type {import("../../types/index.js").ESLintFlatConfig}
+ */
+const baseCjsJS = mergeConfigs(
+  // base it on the recommended javascript config
+  baseConfigJS,
+  // add qlik's recommended node commonjs config for javascript
+  {
+    languageOptions: {
+      globals: globals.node,
+      sourceType: "commonjs",
+    },
+    rules: cjsRules,
+  },
+);
+
+/**
+ * CJS config for typescript in node
+ * @type {import("../../types/index.js").ESLintFlatConfig}
+ */
+const baseCjsTS = mergeConfigs(
+  // base it on the recommended typescript config
+  baseConfigTS,
+  // add qlik's recommended node commonjs config for typescript
+  {
+    languageOptions: {
+      globals: globals.node,
+      sourceType: "commonjs",
+    },
+    rules: {
+      ...cjsRules,
+      // modify ts specific rules for node here
+    },
+  },
+);
+
+/**
+ * @satisfies {import("../../types/index.js").ESLintFlatConfig["rules"]}
+ */
+const nodeEsmRules = {
+  ...nodeRules,
+  // modify rules for node esm here
+
+  // Ensure consistent use of file extension within the import path
+  // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/extensions.md
+  "import-x/extensions": [
+    "error",
+    "ignorePackages",
+    {
+      ts: "never",
+      mts: "never",
+      tsx: "never",
+    },
+  ],
+};
+
+/**
+ * ESM config for javascript in node
+ * @type {import("../../types/index.js").ESLintFlatConfig}
+ */
+const baseEsmJS = mergeConfigs(
+  // base it on the recommended javascript config
+  baseConfigJS,
+  // add qlik's recommended node esm config for javascript
+  {
+    languageOptions: {
+      globals: globals.node,
+      sourceType: "module",
+    },
+    rules: nodeEsmRules,
+  },
+);
+
+/**
+ * ESM config for typescript in node
+ * @type {import("../../types/index.js").ESLintFlatConfig}
+ */
+const baseEsmTS = mergeConfigs(
+  // base it on the recommended typescript config
+  baseConfigTS,
+  // add qlik's recommended node esm config for typescript
+  {
+    languageOptions: {
+      globals: globals.node,
+      sourceType: "module",
+    },
+    rules: {
+      ...nodeEsmRules,
+      // modify typescript specific rules for node esm here if needed
+    },
+  },
+);
+
+export { baseCjsJS, baseCjsTS, baseEsmJS, baseEsmTS };

--- a/packages/eslint-config/test/generated/cjs-final-config.js
+++ b/packages/eslint-config/test/generated/cjs-final-config.js
@@ -1284,9 +1284,9 @@ export default [
         "parser": {
           "meta": {
             "name": "typescript-eslint/parser",
-            "version": "8.27.0"
+            "version": "8.28.0"
           },
-          "version": "8.27.0"
+          "version": "8.28.0"
         },
         "projectService": true,
         "warnOnUnsupportedTypeScriptVersion": false
@@ -1688,6 +1688,2498 @@ export default [
           "js": "never",
           "jsx": "never",
           "mjs": "never",
+          "mts": "never",
+          "ts": "never",
+          "tsx": "never"
+        }
+      ],
+      "import-x/named": "off",
+      "import-x/namespace": "error",
+      "import-x/newline-after-import": "error",
+      "import-x/no-absolute-path": "error",
+      "import-x/no-amd": "error",
+      "import-x/no-cycle": [
+        "error",
+        {
+          "ignoreExternal": true
+        }
+      ],
+      "import-x/no-deprecated": "warn",
+      "import-x/no-duplicates": "error",
+      "import-x/no-dynamic-require": "error",
+      "import-x/no-empty-named-blocks": "off",
+      "import-x/no-extraneous-dependencies": [
+        "off",
+        {
+          "devDependencies": [
+            "**/test*/**",
+            "**/mocks/**",
+            "**/mock/**",
+            "test/**",
+            "tests/**",
+            "spec/**",
+            "**/__tests__/**",
+            "**/__mocks__/**",
+            "test.{js,jsx,ts,tsx}",
+            "test-*.{js,jsx,ts,tsx}",
+            "**/*{.,_}{test,spec}.{js,jsx,ts,tsx}",
+            "**/jest.config.{cjs,mjs,js,ts}",
+            "**/jest.setup.{cjs,mjs,js,ts}",
+            "**/vitest.config.{cjs,mjs,js,ts}",
+            "**/vue.config.{cjs,mjs,js,ts}",
+            "**/svelte.config.{cjs,mjs,js,ts}",
+            "**/tsup.config.{cjs,mjs,js,ts}",
+            "**/playwright.config.{cjs,mjs,js,ts}",
+            "**/webpack.config.{cjs,mjs,js,ts}",
+            "**/webpack.mod.{cjs,mjs,js,ts}",
+            "**/rollup.config.{cjs,mjs,js,ts}",
+            "**/rollup.config.*cjs,mjs,.{js,ts}",
+            "**/protractor.conf.{cjs,mjs,js,ts}",
+            "**/protractor.conf.*.{cjs,mjs,js,ts}",
+            "**/.eslintrc.{cjs,mjs,js,ts}",
+            "**/eslint.config.{cjs,mjs,js,ts}",
+            "**/.prettierrc.{cjs,mjs,js,ts}",
+            "**/.prettierrc"
+          ],
+          "optionalDependencies": false
+        }
+      ],
+      "import-x/no-import-module-exports": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "import-x/no-mutable-exports": "error",
+      "import-x/no-named-as-default": "error",
+      "import-x/no-named-as-default-member": "off",
+      "import-x/no-named-default": "error",
+      "import-x/no-nodejs-modules": "off",
+      "import-x/no-relative-packages": "error",
+      "import-x/no-self-import": "error",
+      "import-x/no-unresolved": [
+        "error",
+        {
+          "caseSensitive": true,
+          "commonjs": true
+        }
+      ],
+      "import-x/no-unused-modules": "error",
+      "import-x/no-useless-path-segments": [
+        "error",
+        {
+          "commonjs": true
+        }
+      ],
+      "import-x/no-webpack-loader-syntax": "error",
+      "import-x/prefer-default-export": "off",
+      "indent": "off",
+      "indent-legacy": "off",
+      "jsx-quotes": "off",
+      "key-spacing": "off",
+      "keyword-spacing": "off",
+      "linebreak-style": "off",
+      "lines-around-comment": 0,
+      "max-classes-per-file": [
+        "error",
+        1
+      ],
+      "max-len": 0,
+      "max-statements-per-line": "off",
+      "multiline-ternary": "off",
+      "new-cap": [
+        "error",
+        {
+          "capIsNew": false,
+          "capIsNewExceptions": [
+            "Immutable.Map",
+            "Immutable.Set",
+            "Immutable.List"
+          ],
+          "newIsCap": true,
+          "newIsCapExceptions": []
+        }
+      ],
+      "new-parens": "off",
+      "newline-per-chained-call": "off",
+      "no-alert": "error",
+      "no-array-constructor": "off",
+      "no-arrow-condition": "off",
+      "no-async-promise-executor": "error",
+      "no-await-in-loop": "error",
+      "no-bitwise": "error",
+      "no-caller": "error",
+      "no-case-declarations": "error",
+      "no-class-assign": "off",
+      "no-comma-dangle": "off",
+      "no-compare-neg-zero": "error",
+      "no-cond-assign": [
+        "error",
+        "always"
+      ],
+      "no-confusing-arrow": 0,
+      "no-console": "off",
+      "no-const-assign": "off",
+      "no-constant-binary-expression": "error",
+      "no-constant-condition": "warn",
+      "no-constructor-return": "error",
+      "no-continue": "error",
+      "no-control-regex": "error",
+      "no-debugger": "error",
+      "no-delete-var": "error",
+      "no-dupe-args": "off",
+      "no-dupe-class-members": "off",
+      "no-dupe-else-if": "error",
+      "no-dupe-keys": "off",
+      "no-duplicate-case": "error",
+      "no-else-return": [
+        "error",
+        {
+          "allowElseIf": false
+        }
+      ],
+      "no-empty": "error",
+      "no-empty-character-class": "error",
+      "no-empty-function": [
+        "error",
+        {
+          "allow": [
+            "arrowFunctions",
+            "functions",
+            "methods"
+          ]
+        }
+      ],
+      "no-empty-pattern": "error",
+      "no-empty-static-block": "error",
+      "no-eval": "error",
+      "no-ex-assign": "error",
+      "no-extend-native": "error",
+      "no-extra-bind": "error",
+      "no-extra-boolean-cast": "error",
+      "no-extra-label": "error",
+      "no-extra-parens": "off",
+      "no-extra-semi": "off",
+      "no-fallthrough": "error",
+      "no-floating-decimal": "off",
+      "no-func-assign": "off",
+      "no-global-assign": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "no-implied-eval": "error",
+      "no-import-assign": "off",
+      "no-inner-declarations": "error",
+      "no-invalid-regexp": "error",
+      "no-irregular-whitespace": "error",
+      "no-iterator": "error",
+      "no-label-var": "error",
+      "no-labels": [
+        "error",
+        {
+          "allowLoop": false,
+          "allowSwitch": false
+        }
+      ],
+      "no-lone-blocks": "error",
+      "no-lonely-if": "error",
+      "no-loop-func": "off",
+      "no-loss-of-precision": "error",
+      "no-magic-numbers": "off",
+      "no-misleading-character-class": "error",
+      "no-mixed-operators": 0,
+      "no-mixed-spaces-and-tabs": "off",
+      "no-multi-assign": [
+        "error"
+      ],
+      "no-multi-spaces": "off",
+      "no-multi-str": "error",
+      "no-multiple-empty-lines": "off",
+      "no-nested-ternary": "error",
+      "no-new": "error",
+      "no-new-func": "error",
+      "no-new-native-nonconstructor": "off",
+      "no-new-symbol": "off",
+      "no-new-wrappers": "error",
+      "no-nonoctal-decimal-escape": "error",
+      "no-obj-calls": "off",
+      "no-object-constructor": "error",
+      "no-octal": "error",
+      "no-octal-escape": "error",
+      "no-param-reassign": [
+        "error",
+        {
+          "ignorePropertyModificationsFor": [
+            "prev",
+            "acc",
+            "accumulator",
+            "e",
+            "ctx",
+            "context",
+            "req",
+            "request",
+            "res",
+            "response",
+            "$scope",
+            "staticContext",
+            "sharedState",
+            "state"
+          ],
+          "props": true
+        }
+      ],
+      "no-promise-executor-return": "error",
+      "no-proto": "error",
+      "no-prototype-builtins": "error",
+      "no-redeclare": "off",
+      "no-regex-spaces": "error",
+      "no-reserved-keys": "off",
+      "no-restricted-exports": [
+        "error",
+        {
+          "restrictedNamedExports": [
+            "default",
+            "then"
+          ]
+        }
+      ],
+      "no-restricted-globals": [
+        "error",
+        {
+          "message": "Use Number.isFinite instead",
+          "name": "isFinite"
+        },
+        {
+          "message": "Use Number.isNaN instead",
+          "name": "isNaN"
+        },
+        {
+          "message": "Use window.addEventListener instead",
+          "name": "addEventListener"
+        },
+        {
+          "message": "Use window.blur instead",
+          "name": "blur"
+        },
+        {
+          "message": "Use window.close instead",
+          "name": "close"
+        },
+        {
+          "message": "Use window.closed instead",
+          "name": "closed"
+        },
+        {
+          "message": "Use window.confirm instead",
+          "name": "confirm"
+        },
+        {
+          "message": "Use window.defaultStatus instead",
+          "name": "defaultStatus"
+        },
+        {
+          "message": "Use window.defaultstatus instead",
+          "name": "defaultstatus"
+        },
+        {
+          "message": "Use window.event instead",
+          "name": "event"
+        },
+        {
+          "message": "Use window.external instead",
+          "name": "external"
+        },
+        {
+          "message": "Use window.find instead",
+          "name": "find"
+        },
+        {
+          "message": "Use window.focus instead",
+          "name": "focus"
+        },
+        {
+          "message": "Use window.frameElement instead",
+          "name": "frameElement"
+        },
+        {
+          "message": "Use window.frames instead",
+          "name": "frames"
+        },
+        {
+          "message": "Use window.history instead",
+          "name": "history"
+        },
+        {
+          "message": "Use window.innerHeight instead",
+          "name": "innerHeight"
+        },
+        {
+          "message": "Use window.innerWidth instead",
+          "name": "innerWidth"
+        },
+        {
+          "message": "Use window.length instead",
+          "name": "length"
+        },
+        {
+          "message": "Use window.location instead",
+          "name": "location"
+        },
+        {
+          "message": "Use window.locationbar instead",
+          "name": "locationbar"
+        },
+        {
+          "message": "Use window.menubar instead",
+          "name": "menubar"
+        },
+        {
+          "message": "Use window.moveBy instead",
+          "name": "moveBy"
+        },
+        {
+          "message": "Use window.moveTo instead",
+          "name": "moveTo"
+        },
+        {
+          "message": "Use window.name instead",
+          "name": "name"
+        },
+        {
+          "message": "Use window.onblur instead",
+          "name": "onblur"
+        },
+        {
+          "message": "Use window.onerror instead",
+          "name": "onerror"
+        },
+        {
+          "message": "Use window.onfocus instead",
+          "name": "onfocus"
+        },
+        {
+          "message": "Use window.onload instead",
+          "name": "onload"
+        },
+        {
+          "message": "Use window.onresize instead",
+          "name": "onresize"
+        },
+        {
+          "message": "Use window.onunload instead",
+          "name": "onunload"
+        },
+        {
+          "message": "Use window.open instead",
+          "name": "open"
+        },
+        {
+          "message": "Use window.opener instead",
+          "name": "opener"
+        },
+        {
+          "message": "Use window.opera instead",
+          "name": "opera"
+        },
+        {
+          "message": "Use window.outerHeight instead",
+          "name": "outerHeight"
+        },
+        {
+          "message": "Use window.outerWidth instead",
+          "name": "outerWidth"
+        },
+        {
+          "message": "Use window.pageXOffset instead",
+          "name": "pageXOffset"
+        },
+        {
+          "message": "Use window.pageYOffset instead",
+          "name": "pageYOffset"
+        },
+        {
+          "message": "Use window.parent instead",
+          "name": "parent"
+        },
+        {
+          "message": "Use window.print instead",
+          "name": "print"
+        },
+        {
+          "message": "Use window.removeEventListener instead",
+          "name": "removeEventListener"
+        },
+        {
+          "message": "Use window.resizeBy instead",
+          "name": "resizeBy"
+        },
+        {
+          "message": "Use window.resizeTo instead",
+          "name": "resizeTo"
+        },
+        {
+          "message": "Use window.screen instead",
+          "name": "screen"
+        },
+        {
+          "message": "Use window.screenLeft instead",
+          "name": "screenLeft"
+        },
+        {
+          "message": "Use window.screenTop instead",
+          "name": "screenTop"
+        },
+        {
+          "message": "Use window.screenX instead",
+          "name": "screenX"
+        },
+        {
+          "message": "Use window.screenY instead",
+          "name": "screenY"
+        },
+        {
+          "message": "Use window.scroll instead",
+          "name": "scroll"
+        },
+        {
+          "message": "Use window.scrollbars instead",
+          "name": "scrollbars"
+        },
+        {
+          "message": "Use window.scrollBy instead",
+          "name": "scrollBy"
+        },
+        {
+          "message": "Use window.scrollTo instead",
+          "name": "scrollTo"
+        },
+        {
+          "message": "Use window.scrollX instead",
+          "name": "scrollX"
+        },
+        {
+          "message": "Use window.scrollY instead",
+          "name": "scrollY"
+        },
+        {
+          "message": "Use window.self instead",
+          "name": "self"
+        },
+        {
+          "message": "Use window.status instead",
+          "name": "status"
+        },
+        {
+          "message": "Use window.statusbar instead",
+          "name": "statusbar"
+        },
+        {
+          "message": "Use window.stop instead",
+          "name": "stop"
+        },
+        {
+          "message": "Use window.toolbar instead",
+          "name": "toolbar"
+        },
+        {
+          "message": "Use window.top instead",
+          "name": "top"
+        }
+      ],
+      "no-restricted-imports": "off",
+      "no-restricted-properties": [
+        "error",
+        {
+          "message": "arguments.callee is deprecated",
+          "object": "arguments",
+          "property": "callee"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "global",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "self",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "window",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "global",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "self",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "window",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineGetter__"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineSetter__"
+        },
+        {
+          "message": "Use the exponentiation operator (**) instead.",
+          "object": "Math",
+          "property": "pow"
+        }
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.",
+          "selector": "LabeledStatement"
+        },
+        {
+          "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
+          "selector": "WithStatement"
+        }
+      ],
+      "no-return-assign": [
+        "error",
+        "always"
+      ],
+      "no-return-await": "off",
+      "no-script-url": "error",
+      "no-self-assign": [
+        "error",
+        {
+          "props": true
+        }
+      ],
+      "no-self-compare": "error",
+      "no-sequences": "error",
+      "no-setter-return": "off",
+      "no-shadow": "off",
+      "no-shadow-restricted-names": "error",
+      "no-space-before-semi": "off",
+      "no-spaced-func": "off",
+      "no-sparse-arrays": "error",
+      "no-tabs": 0,
+      "no-template-curly-in-string": "error",
+      "no-this-before-super": "off",
+      "no-throw-literal": "error",
+      "no-trailing-spaces": "off",
+      "no-undef": "off",
+      "no-undef-init": "error",
+      "no-underscore-dangle": "off",
+      "no-unexpected-multiline": 0,
+      "no-unmodified-loop-condition": "error",
+      "no-unneeded-ternary": [
+        "error",
+        {
+          "defaultAssignment": false
+        }
+      ],
+      "no-unreachable": "off",
+      "no-unreachable-loop": [
+        "error",
+        {
+          "ignore": []
+        }
+      ],
+      "no-unsafe-finally": "error",
+      "no-unsafe-negation": "off",
+      "no-unsafe-optional-chaining": [
+        "error",
+        {
+          "disallowArithmeticOperators": true
+        }
+      ],
+      "no-unused-expressions": "off",
+      "no-unused-labels": "error",
+      "no-unused-private-class-members": "error",
+      "no-unused-vars": "off",
+      "no-useless-backreference": "error",
+      "no-useless-call": "error",
+      "no-useless-catch": "error",
+      "no-useless-computed-key": "error",
+      "no-useless-concat": "error",
+      "no-useless-constructor": "off",
+      "no-useless-escape": "error",
+      "no-useless-rename": [
+        "error",
+        {
+          "ignoreDestructuring": false,
+          "ignoreExport": false,
+          "ignoreImport": false
+        }
+      ],
+      "no-useless-return": "error",
+      "no-var": "error",
+      "no-whitespace-before-property": "off",
+      "no-with": "error",
+      "no-wrap-func": "off",
+      "nonblock-statement-body-position": "off",
+      "object-curly-newline": "off",
+      "object-curly-spacing": "off",
+      "object-property-newline": "off",
+      "object-shorthand": [
+        "error",
+        "always",
+        {
+          "avoidQuotes": true,
+          "ignoreConstructors": false
+        }
+      ],
+      "one-var": [
+        "error",
+        "never"
+      ],
+      "one-var-declaration-per-line": "off",
+      "operator-assignment": [
+        "error",
+        "always"
+      ],
+      "operator-linebreak": "off",
+      "padded-blocks": "off",
+      "prefer-arrow-callback": "off",
+      "prefer-const": "error",
+      "prefer-exponentiation-operator": "error",
+      "prefer-numeric-literals": "error",
+      "prefer-object-has-own": "error",
+      "prefer-object-spread": "error",
+      "prefer-promise-reject-errors": [
+        "error",
+        {
+          "allowEmptyReject": true
+        }
+      ],
+      "prefer-regex-literals": [
+        "error",
+        {
+          "disallowRedundantWrapping": true
+        }
+      ],
+      "prefer-rest-params": "error",
+      "prefer-spread": "error",
+      "prefer-template": "error",
+      "quote-props": "off",
+      "quotes": 0,
+      "radix": "error",
+      "react/jsx-child-element-spacing": "off",
+      "react/jsx-closing-bracket-location": "off",
+      "react/jsx-closing-tag-location": "off",
+      "react/jsx-curly-newline": "off",
+      "react/jsx-curly-spacing": "off",
+      "react/jsx-equals-spacing": "off",
+      "react/jsx-first-prop-new-line": "off",
+      "react/jsx-indent": "off",
+      "react/jsx-indent-props": "off",
+      "react/jsx-max-props-per-line": "off",
+      "react/jsx-newline": "off",
+      "react/jsx-one-expression-per-line": "off",
+      "react/jsx-props-no-multi-spaces": "off",
+      "react/jsx-space-before-closing": "off",
+      "react/jsx-tag-spacing": "off",
+      "react/jsx-wrap-multilines": "off",
+      "require-atomic-updates": "error",
+      "require-yield": "error",
+      "rest-spread-spacing": "off",
+      "semi": "off",
+      "semi-spacing": "off",
+      "semi-style": "off",
+      "space-after-function-name": "off",
+      "space-after-keywords": "off",
+      "space-before-blocks": "off",
+      "space-before-function-paren": "off",
+      "space-before-function-parentheses": "off",
+      "space-before-keywords": "off",
+      "space-in-brackets": "off",
+      "space-in-parens": "off",
+      "space-infix-ops": "off",
+      "space-return-throw-case": "off",
+      "space-unary-ops": "off",
+      "space-unary-word-ops": "off",
+      "standard/array-bracket-even-spacing": "off",
+      "standard/computed-property-even-spacing": "off",
+      "standard/object-curly-even-spacing": "off",
+      "switch-colon-spacing": "off",
+      "symbol-description": "error",
+      "template-curly-spacing": "off",
+      "template-tag-spacing": "off",
+      "unicode-bom": [
+        "error",
+        "never"
+      ],
+      "unicorn/empty-brace-spaces": "off",
+      "unicorn/no-nested-ternary": "off",
+      "unicorn/number-literal-case": "off",
+      "unicorn/template-indent": 0,
+      "use-isnan": "error",
+      "valid-typeof": [
+        "error",
+        {
+          "requireStringLiterals": true
+        }
+      ],
+      "vue/array-bracket-newline": "off",
+      "vue/array-bracket-spacing": "off",
+      "vue/array-element-newline": "off",
+      "vue/arrow-spacing": "off",
+      "vue/block-spacing": "off",
+      "vue/block-tag-newline": "off",
+      "vue/brace-style": "off",
+      "vue/comma-dangle": "off",
+      "vue/comma-spacing": "off",
+      "vue/comma-style": "off",
+      "vue/dot-location": "off",
+      "vue/func-call-spacing": "off",
+      "vue/html-closing-bracket-newline": "off",
+      "vue/html-closing-bracket-spacing": "off",
+      "vue/html-end-tags": "off",
+      "vue/html-indent": "off",
+      "vue/html-quotes": "off",
+      "vue/html-self-closing": 0,
+      "vue/key-spacing": "off",
+      "vue/keyword-spacing": "off",
+      "vue/max-attributes-per-line": "off",
+      "vue/max-len": 0,
+      "vue/multiline-html-element-content-newline": "off",
+      "vue/multiline-ternary": "off",
+      "vue/mustache-interpolation-spacing": "off",
+      "vue/no-extra-parens": "off",
+      "vue/no-multi-spaces": "off",
+      "vue/no-spaces-around-equal-signs-in-attribute": "off",
+      "vue/object-curly-newline": "off",
+      "vue/object-curly-spacing": "off",
+      "vue/object-property-newline": "off",
+      "vue/operator-linebreak": "off",
+      "vue/quote-props": "off",
+      "vue/script-indent": "off",
+      "vue/singleline-html-element-content-newline": "off",
+      "vue/space-in-parens": "off",
+      "vue/space-infix-ops": "off",
+      "vue/space-unary-ops": "off",
+      "vue/template-curly-spacing": "off",
+      "wrap-iife": "off",
+      "wrap-regex": "off",
+      "yield-star-spacing": "off",
+      "yoda": "error"
+    },
+    "settings": {
+      "import-x/extensions": [
+        ".ts",
+        ".tsx",
+        ".cts",
+        ".mts",
+        ".js",
+        ".jsx",
+        ".cjs",
+        ".mjs"
+      ],
+      "import-x/external-module-folders": [
+        "node_modules",
+        "node_modules/@types"
+      ],
+      "import-x/parsers": {
+        "@typescript-eslint/parser": [
+          ".ts",
+          ".tsx",
+          ".cts",
+          ".mts"
+        ]
+      },
+      "import-x/resolver": {
+        "typescript": true
+      }
+    }
+  },
+  {
+    "files": [
+      "**/*.mjs"
+    ],
+    "languageOptions": {
+      "ecmaVersion": "latest",
+      "globals": {
+        "AbortController": false,
+        "AbortSignal": false,
+        "Blob": false,
+        "BroadcastChannel": false,
+        "Buffer": false,
+        "ByteLengthQueuingStrategy": false,
+        "CloseEvent": false,
+        "CompressionStream": false,
+        "CountQueuingStrategy": false,
+        "Crypto": false,
+        "CryptoKey": false,
+        "CustomEvent": false,
+        "DOMException": false,
+        "DecompressionStream": false,
+        "Event": false,
+        "EventTarget": false,
+        "File": false,
+        "FormData": false,
+        "Headers": false,
+        "MessageChannel": false,
+        "MessageEvent": false,
+        "MessagePort": false,
+        "Navigator": false,
+        "Performance": false,
+        "PerformanceEntry": false,
+        "PerformanceMark": false,
+        "PerformanceMeasure": false,
+        "PerformanceObserver": false,
+        "PerformanceObserverEntryList": false,
+        "PerformanceResourceTiming": false,
+        "ReadableByteStreamController": false,
+        "ReadableStream": false,
+        "ReadableStreamBYOBReader": false,
+        "ReadableStreamBYOBRequest": false,
+        "ReadableStreamDefaultController": false,
+        "ReadableStreamDefaultReader": false,
+        "Request": false,
+        "Response": false,
+        "SubtleCrypto": false,
+        "TextDecoder": false,
+        "TextDecoderStream": false,
+        "TextEncoder": false,
+        "TextEncoderStream": false,
+        "TransformStream": false,
+        "TransformStreamDefaultController": false,
+        "URL": false,
+        "URLSearchParams": false,
+        "WebAssembly": false,
+        "WebSocket": false,
+        "WritableStream": false,
+        "WritableStreamDefaultController": false,
+        "WritableStreamDefaultWriter": false,
+        "__dirname": false,
+        "__filename": false,
+        "atob": false,
+        "btoa": false,
+        "clearImmediate": false,
+        "clearInterval": false,
+        "clearTimeout": false,
+        "console": false,
+        "crypto": false,
+        "exports": true,
+        "fetch": false,
+        "global": false,
+        "module": false,
+        "navigator": false,
+        "performance": false,
+        "process": false,
+        "queueMicrotask": false,
+        "require": false,
+        "setImmediate": false,
+        "setInterval": false,
+        "setTimeout": false,
+        "structuredClone": false
+      },
+      "parser": "@qlik/eslint-config/node-cjs-mjs-parser",
+      "parserOptions": {
+        "warnOnUnsupportedTypeScriptVersion": false
+      },
+      "sourceType": "module"
+    },
+    "name": "@qlik/eslint-config/node-cjs-mjs",
+    "plugins": {
+      "@typescript-eslint": "@typescript-eslint-plugin",
+      "import-x": "import-x-plugin"
+    },
+    "rules": {
+      "@babel/object-curly-spacing": "off",
+      "@babel/semi": "off",
+      "@stylistic/array-bracket-newline": "off",
+      "@stylistic/array-bracket-spacing": "off",
+      "@stylistic/array-element-newline": "off",
+      "@stylistic/arrow-parens": "off",
+      "@stylistic/arrow-spacing": "off",
+      "@stylistic/block-spacing": "off",
+      "@stylistic/brace-style": "off",
+      "@stylistic/comma-dangle": "off",
+      "@stylistic/comma-spacing": "off",
+      "@stylistic/comma-style": "off",
+      "@stylistic/computed-property-spacing": "off",
+      "@stylistic/dot-location": "off",
+      "@stylistic/eol-last": "off",
+      "@stylistic/func-call-spacing": "off",
+      "@stylistic/function-call-argument-newline": "off",
+      "@stylistic/function-call-spacing": "off",
+      "@stylistic/function-paren-newline": "off",
+      "@stylistic/generator-star-spacing": "off",
+      "@stylistic/implicit-arrow-linebreak": "off",
+      "@stylistic/indent": "off",
+      "@stylistic/indent-binary-ops": "off",
+      "@stylistic/js/array-bracket-newline": "off",
+      "@stylistic/js/array-bracket-spacing": "off",
+      "@stylistic/js/array-element-newline": "off",
+      "@stylistic/js/arrow-parens": "off",
+      "@stylistic/js/arrow-spacing": "off",
+      "@stylistic/js/block-spacing": "off",
+      "@stylistic/js/brace-style": "off",
+      "@stylistic/js/comma-dangle": "off",
+      "@stylistic/js/comma-spacing": "off",
+      "@stylistic/js/comma-style": "off",
+      "@stylistic/js/computed-property-spacing": "off",
+      "@stylistic/js/dot-location": "off",
+      "@stylistic/js/eol-last": "off",
+      "@stylistic/js/func-call-spacing": "off",
+      "@stylistic/js/function-call-argument-newline": "off",
+      "@stylistic/js/function-call-spacing": "off",
+      "@stylistic/js/function-paren-newline": "off",
+      "@stylistic/js/generator-star-spacing": "off",
+      "@stylistic/js/implicit-arrow-linebreak": "off",
+      "@stylistic/js/indent": "off",
+      "@stylistic/js/jsx-quotes": "off",
+      "@stylistic/js/key-spacing": "off",
+      "@stylistic/js/keyword-spacing": "off",
+      "@stylistic/js/linebreak-style": "off",
+      "@stylistic/js/lines-around-comment": 0,
+      "@stylistic/js/max-len": 0,
+      "@stylistic/js/max-statements-per-line": "off",
+      "@stylistic/js/multiline-ternary": "off",
+      "@stylistic/js/new-parens": "off",
+      "@stylistic/js/newline-per-chained-call": "off",
+      "@stylistic/js/no-confusing-arrow": 0,
+      "@stylistic/js/no-extra-parens": "off",
+      "@stylistic/js/no-extra-semi": "off",
+      "@stylistic/js/no-floating-decimal": "off",
+      "@stylistic/js/no-mixed-operators": 0,
+      "@stylistic/js/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/js/no-multi-spaces": "off",
+      "@stylistic/js/no-multiple-empty-lines": "off",
+      "@stylistic/js/no-tabs": 0,
+      "@stylistic/js/no-trailing-spaces": "off",
+      "@stylistic/js/no-whitespace-before-property": "off",
+      "@stylistic/js/nonblock-statement-body-position": "off",
+      "@stylistic/js/object-curly-newline": "off",
+      "@stylistic/js/object-curly-spacing": "off",
+      "@stylistic/js/object-property-newline": "off",
+      "@stylistic/js/one-var-declaration-per-line": "off",
+      "@stylistic/js/operator-linebreak": "off",
+      "@stylistic/js/padded-blocks": "off",
+      "@stylistic/js/quote-props": "off",
+      "@stylistic/js/quotes": 0,
+      "@stylistic/js/rest-spread-spacing": "off",
+      "@stylistic/js/semi": "off",
+      "@stylistic/js/semi-spacing": "off",
+      "@stylistic/js/semi-style": "off",
+      "@stylistic/js/space-before-blocks": "off",
+      "@stylistic/js/space-before-function-paren": "off",
+      "@stylistic/js/space-in-parens": "off",
+      "@stylistic/js/space-infix-ops": "off",
+      "@stylistic/js/space-unary-ops": "off",
+      "@stylistic/js/switch-colon-spacing": "off",
+      "@stylistic/js/template-curly-spacing": "off",
+      "@stylistic/js/template-tag-spacing": "off",
+      "@stylistic/js/wrap-iife": "off",
+      "@stylistic/js/wrap-regex": "off",
+      "@stylistic/js/yield-star-spacing": "off",
+      "@stylistic/jsx-child-element-spacing": "off",
+      "@stylistic/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx-closing-tag-location": "off",
+      "@stylistic/jsx-curly-newline": "off",
+      "@stylistic/jsx-curly-spacing": "off",
+      "@stylistic/jsx-equals-spacing": "off",
+      "@stylistic/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx-indent": "off",
+      "@stylistic/jsx-indent-props": "off",
+      "@stylistic/jsx-max-props-per-line": "off",
+      "@stylistic/jsx-newline": "off",
+      "@stylistic/jsx-one-expression-per-line": "off",
+      "@stylistic/jsx-props-no-multi-spaces": "off",
+      "@stylistic/jsx-quotes": "off",
+      "@stylistic/jsx-tag-spacing": "off",
+      "@stylistic/jsx-wrap-multilines": "off",
+      "@stylistic/jsx/jsx-child-element-spacing": "off",
+      "@stylistic/jsx/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx/jsx-closing-tag-location": "off",
+      "@stylistic/jsx/jsx-curly-newline": "off",
+      "@stylistic/jsx/jsx-curly-spacing": "off",
+      "@stylistic/jsx/jsx-equals-spacing": "off",
+      "@stylistic/jsx/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx/jsx-indent": "off",
+      "@stylistic/jsx/jsx-indent-props": "off",
+      "@stylistic/jsx/jsx-max-props-per-line": "off",
+      "@stylistic/key-spacing": "off",
+      "@stylistic/keyword-spacing": "off",
+      "@stylistic/linebreak-style": "off",
+      "@stylistic/lines-around-comment": 0,
+      "@stylistic/max-len": 0,
+      "@stylistic/max-statements-per-line": "off",
+      "@stylistic/member-delimiter-style": "off",
+      "@stylistic/multiline-ternary": "off",
+      "@stylistic/new-parens": "off",
+      "@stylistic/newline-per-chained-call": "off",
+      "@stylistic/no-confusing-arrow": 0,
+      "@stylistic/no-extra-parens": "off",
+      "@stylistic/no-extra-semi": "off",
+      "@stylistic/no-floating-decimal": "off",
+      "@stylistic/no-mixed-operators": 0,
+      "@stylistic/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/no-multi-spaces": "off",
+      "@stylistic/no-multiple-empty-lines": "off",
+      "@stylistic/no-tabs": 0,
+      "@stylistic/no-trailing-spaces": "off",
+      "@stylistic/no-whitespace-before-property": "off",
+      "@stylistic/nonblock-statement-body-position": "off",
+      "@stylistic/object-curly-newline": "off",
+      "@stylistic/object-curly-spacing": "off",
+      "@stylistic/object-property-newline": "off",
+      "@stylistic/one-var-declaration-per-line": "off",
+      "@stylistic/operator-linebreak": "off",
+      "@stylistic/padded-blocks": "off",
+      "@stylistic/quote-props": "off",
+      "@stylistic/quotes": 0,
+      "@stylistic/rest-spread-spacing": "off",
+      "@stylistic/semi": "off",
+      "@stylistic/semi-spacing": "off",
+      "@stylistic/semi-style": "off",
+      "@stylistic/space-before-blocks": "off",
+      "@stylistic/space-before-function-paren": "off",
+      "@stylistic/space-in-parens": "off",
+      "@stylistic/space-infix-ops": "off",
+      "@stylistic/space-unary-ops": "off",
+      "@stylistic/switch-colon-spacing": "off",
+      "@stylistic/template-curly-spacing": "off",
+      "@stylistic/template-tag-spacing": "off",
+      "@stylistic/ts/block-spacing": "off",
+      "@stylistic/ts/brace-style": "off",
+      "@stylistic/ts/comma-dangle": "off",
+      "@stylistic/ts/comma-spacing": "off",
+      "@stylistic/ts/func-call-spacing": "off",
+      "@stylistic/ts/function-call-spacing": "off",
+      "@stylistic/ts/indent": "off",
+      "@stylistic/ts/key-spacing": "off",
+      "@stylistic/ts/keyword-spacing": "off",
+      "@stylistic/ts/lines-around-comment": 0,
+      "@stylistic/ts/member-delimiter-style": "off",
+      "@stylistic/ts/no-extra-parens": "off",
+      "@stylistic/ts/no-extra-semi": "off",
+      "@stylistic/ts/object-curly-spacing": "off",
+      "@stylistic/ts/quotes": 0,
+      "@stylistic/ts/semi": "off",
+      "@stylistic/ts/space-before-blocks": "off",
+      "@stylistic/ts/space-before-function-paren": "off",
+      "@stylistic/ts/space-infix-ops": "off",
+      "@stylistic/ts/type-annotation-spacing": "off",
+      "@stylistic/type-annotation-spacing": "off",
+      "@stylistic/type-generic-spacing": "off",
+      "@stylistic/type-named-tuple-spacing": "off",
+      "@stylistic/wrap-iife": "off",
+      "@stylistic/wrap-regex": "off",
+      "@stylistic/yield-star-spacing": "off",
+      "@typescript-eslint/block-spacing": "off",
+      "@typescript-eslint/brace-style": "off",
+      "@typescript-eslint/comma-dangle": "off",
+      "@typescript-eslint/comma-spacing": "off",
+      "@typescript-eslint/func-call-spacing": "off",
+      "@typescript-eslint/indent": "off",
+      "@typescript-eslint/key-spacing": "off",
+      "@typescript-eslint/keyword-spacing": "off",
+      "@typescript-eslint/lines-around-comment": 0,
+      "@typescript-eslint/member-delimiter-style": "off",
+      "@typescript-eslint/no-extra-parens": "off",
+      "@typescript-eslint/no-extra-semi": "off",
+      "@typescript-eslint/object-curly-spacing": "off",
+      "@typescript-eslint/quotes": 0,
+      "@typescript-eslint/semi": "off",
+      "@typescript-eslint/space-before-blocks": "off",
+      "@typescript-eslint/space-before-function-paren": "off",
+      "@typescript-eslint/space-infix-ops": "off",
+      "@typescript-eslint/type-annotation-spacing": "off",
+      "array-bracket-newline": "off",
+      "array-bracket-spacing": "off",
+      "array-callback-return": [
+        "error",
+        {
+          "allowImplicit": true
+        }
+      ],
+      "array-element-newline": "off",
+      "arrow-body-style": "off",
+      "arrow-parens": "off",
+      "arrow-spacing": "off",
+      "babel/object-curly-spacing": "off",
+      "babel/quotes": 0,
+      "babel/semi": "off",
+      "block-scoped-var": "error",
+      "block-spacing": "off",
+      "brace-style": "off",
+      "camelcase": [
+        "error",
+        {
+          "ignoreDestructuring": false,
+          "properties": "never"
+        }
+      ],
+      "class-methods-use-this": [
+        "warn",
+        {
+          "exceptMethods": []
+        }
+      ],
+      "comma-dangle": "off",
+      "comma-spacing": "off",
+      "comma-style": "off",
+      "computed-property-spacing": "off",
+      "consistent-return": "error",
+      "constructor-super": "error",
+      "curly": 0,
+      "default-case": [
+        "error",
+        {
+          "commentPattern": "^no default$"
+        }
+      ],
+      "default-case-last": "error",
+      "default-param-last": "error",
+      "dot-location": "off",
+      "eol-last": "off",
+      "eqeqeq": [
+        "error",
+        "always",
+        {
+          "null": "ignore"
+        }
+      ],
+      "flowtype/boolean-style": "off",
+      "flowtype/delimiter-dangle": "off",
+      "flowtype/generic-spacing": "off",
+      "flowtype/object-type-curly-spacing": "off",
+      "flowtype/object-type-delimiter": "off",
+      "flowtype/quotes": "off",
+      "flowtype/semi": "off",
+      "flowtype/space-after-type-colon": "off",
+      "flowtype/space-before-generic-bracket": "off",
+      "flowtype/space-before-type-colon": "off",
+      "flowtype/union-intersection-spacing": "off",
+      "for-direction": "error",
+      "func-call-spacing": "off",
+      "func-names": "warn",
+      "function-call-argument-newline": "off",
+      "function-paren-newline": "off",
+      "generator-star": "off",
+      "generator-star-spacing": "off",
+      "getter-return": [
+        "error",
+        {
+          "allowImplicit": true
+        }
+      ],
+      "grouped-accessor-pairs": "error",
+      "implicit-arrow-linebreak": "off",
+      "import-x/consistent-type-specifier-style": "off",
+      "import-x/default": "error",
+      "import-x/export": "error",
+      "import-x/extensions": [
+        "error",
+        "ignorePackages",
+        {
+          "mts": "never",
+          "ts": "never",
+          "tsx": "never"
+        }
+      ],
+      "import-x/named": "error",
+      "import-x/namespace": "error",
+      "import-x/newline-after-import": "error",
+      "import-x/no-absolute-path": "error",
+      "import-x/no-amd": "error",
+      "import-x/no-cycle": [
+        "error",
+        {
+          "ignoreExternal": true
+        }
+      ],
+      "import-x/no-deprecated": "warn",
+      "import-x/no-duplicates": "error",
+      "import-x/no-dynamic-require": "error",
+      "import-x/no-empty-named-blocks": "off",
+      "import-x/no-extraneous-dependencies": [
+        "off",
+        {
+          "devDependencies": [
+            "**/test*/**",
+            "**/mocks/**",
+            "**/mock/**",
+            "test/**",
+            "tests/**",
+            "spec/**",
+            "**/__tests__/**",
+            "**/__mocks__/**",
+            "test.{js,jsx,ts,tsx}",
+            "test-*.{js,jsx,ts,tsx}",
+            "**/*{.,_}{test,spec}.{js,jsx,ts,tsx}",
+            "**/jest.config.{cjs,mjs,js,ts}",
+            "**/jest.setup.{cjs,mjs,js,ts}",
+            "**/vitest.config.{cjs,mjs,js,ts}",
+            "**/vue.config.{cjs,mjs,js,ts}",
+            "**/svelte.config.{cjs,mjs,js,ts}",
+            "**/tsup.config.{cjs,mjs,js,ts}",
+            "**/playwright.config.{cjs,mjs,js,ts}",
+            "**/webpack.config.{cjs,mjs,js,ts}",
+            "**/webpack.mod.{cjs,mjs,js,ts}",
+            "**/rollup.config.{cjs,mjs,js,ts}",
+            "**/rollup.config.*cjs,mjs,.{js,ts}",
+            "**/protractor.conf.{cjs,mjs,js,ts}",
+            "**/protractor.conf.*.{cjs,mjs,js,ts}",
+            "**/.eslintrc.{cjs,mjs,js,ts}",
+            "**/eslint.config.{cjs,mjs,js,ts}",
+            "**/.prettierrc.{cjs,mjs,js,ts}",
+            "**/.prettierrc"
+          ],
+          "optionalDependencies": false
+        }
+      ],
+      "import-x/no-import-module-exports": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "import-x/no-mutable-exports": "error",
+      "import-x/no-named-as-default": "error",
+      "import-x/no-named-as-default-member": "off",
+      "import-x/no-named-default": "error",
+      "import-x/no-nodejs-modules": "off",
+      "import-x/no-relative-packages": "error",
+      "import-x/no-self-import": "error",
+      "import-x/no-unresolved": [
+        "error",
+        {
+          "caseSensitive": true,
+          "commonjs": true
+        }
+      ],
+      "import-x/no-unused-modules": "error",
+      "import-x/no-useless-path-segments": [
+        "error",
+        {
+          "commonjs": true
+        }
+      ],
+      "import-x/no-webpack-loader-syntax": "error",
+      "import-x/prefer-default-export": "off",
+      "indent": "off",
+      "indent-legacy": "off",
+      "jsx-quotes": "off",
+      "key-spacing": "off",
+      "keyword-spacing": "off",
+      "linebreak-style": "off",
+      "lines-around-comment": 0,
+      "max-classes-per-file": [
+        "error",
+        1
+      ],
+      "max-len": 0,
+      "max-statements-per-line": "off",
+      "multiline-ternary": "off",
+      "new-cap": [
+        "error",
+        {
+          "capIsNew": false,
+          "capIsNewExceptions": [
+            "Immutable.Map",
+            "Immutable.Set",
+            "Immutable.List"
+          ],
+          "newIsCap": true,
+          "newIsCapExceptions": []
+        }
+      ],
+      "new-parens": "off",
+      "newline-per-chained-call": "off",
+      "no-alert": "error",
+      "no-array-constructor": "error",
+      "no-arrow-condition": "off",
+      "no-async-promise-executor": "error",
+      "no-await-in-loop": "error",
+      "no-bitwise": "error",
+      "no-caller": "error",
+      "no-case-declarations": "error",
+      "no-class-assign": "error",
+      "no-comma-dangle": "off",
+      "no-compare-neg-zero": "error",
+      "no-cond-assign": [
+        "error",
+        "always"
+      ],
+      "no-confusing-arrow": 0,
+      "no-console": "off",
+      "no-const-assign": "error",
+      "no-constant-binary-expression": "error",
+      "no-constant-condition": "warn",
+      "no-constructor-return": "error",
+      "no-continue": "error",
+      "no-control-regex": "error",
+      "no-debugger": "error",
+      "no-delete-var": "error",
+      "no-dupe-args": "error",
+      "no-dupe-class-members": "error",
+      "no-dupe-else-if": "error",
+      "no-dupe-keys": "error",
+      "no-duplicate-case": "error",
+      "no-else-return": [
+        "error",
+        {
+          "allowElseIf": false
+        }
+      ],
+      "no-empty": "error",
+      "no-empty-character-class": "error",
+      "no-empty-function": [
+        "error",
+        {
+          "allow": [
+            "arrowFunctions",
+            "functions",
+            "methods"
+          ]
+        }
+      ],
+      "no-empty-pattern": "error",
+      "no-empty-static-block": "error",
+      "no-eval": "error",
+      "no-ex-assign": "error",
+      "no-extend-native": "error",
+      "no-extra-bind": "error",
+      "no-extra-boolean-cast": "error",
+      "no-extra-label": "error",
+      "no-extra-parens": "off",
+      "no-extra-semi": "off",
+      "no-fallthrough": "error",
+      "no-floating-decimal": "off",
+      "no-func-assign": "error",
+      "no-global-assign": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "no-implied-eval": "error",
+      "no-import-assign": "error",
+      "no-inner-declarations": "error",
+      "no-invalid-regexp": "error",
+      "no-irregular-whitespace": "error",
+      "no-iterator": "error",
+      "no-label-var": "error",
+      "no-labels": [
+        "error",
+        {
+          "allowLoop": false,
+          "allowSwitch": false
+        }
+      ],
+      "no-lone-blocks": "error",
+      "no-lonely-if": "error",
+      "no-loop-func": "error",
+      "no-loss-of-precision": "error",
+      "no-magic-numbers": "off",
+      "no-misleading-character-class": "error",
+      "no-mixed-operators": 0,
+      "no-mixed-spaces-and-tabs": "off",
+      "no-multi-assign": [
+        "error"
+      ],
+      "no-multi-spaces": "off",
+      "no-multi-str": "error",
+      "no-multiple-empty-lines": "off",
+      "no-nested-ternary": "error",
+      "no-new": "error",
+      "no-new-func": "error",
+      "no-new-native-nonconstructor": "error",
+      "no-new-wrappers": "error",
+      "no-nonoctal-decimal-escape": "error",
+      "no-obj-calls": "error",
+      "no-object-constructor": "error",
+      "no-octal": "error",
+      "no-octal-escape": "error",
+      "no-param-reassign": [
+        "error",
+        {
+          "ignorePropertyModificationsFor": [
+            "prev",
+            "acc",
+            "accumulator",
+            "e",
+            "ctx",
+            "context",
+            "req",
+            "request",
+            "res",
+            "response",
+            "$scope",
+            "staticContext",
+            "sharedState",
+            "state"
+          ],
+          "props": true
+        }
+      ],
+      "no-promise-executor-return": "error",
+      "no-proto": "error",
+      "no-prototype-builtins": "error",
+      "no-redeclare": "error",
+      "no-regex-spaces": "error",
+      "no-reserved-keys": "off",
+      "no-restricted-exports": [
+        "error",
+        {
+          "restrictedNamedExports": [
+            "default",
+            "then"
+          ]
+        }
+      ],
+      "no-restricted-globals": [
+        "error",
+        {
+          "message": "Use Number.isFinite instead",
+          "name": "isFinite"
+        },
+        {
+          "message": "Use Number.isNaN instead",
+          "name": "isNaN"
+        },
+        {
+          "message": "Use window.addEventListener instead",
+          "name": "addEventListener"
+        },
+        {
+          "message": "Use window.blur instead",
+          "name": "blur"
+        },
+        {
+          "message": "Use window.close instead",
+          "name": "close"
+        },
+        {
+          "message": "Use window.closed instead",
+          "name": "closed"
+        },
+        {
+          "message": "Use window.confirm instead",
+          "name": "confirm"
+        },
+        {
+          "message": "Use window.defaultStatus instead",
+          "name": "defaultStatus"
+        },
+        {
+          "message": "Use window.defaultstatus instead",
+          "name": "defaultstatus"
+        },
+        {
+          "message": "Use window.event instead",
+          "name": "event"
+        },
+        {
+          "message": "Use window.external instead",
+          "name": "external"
+        },
+        {
+          "message": "Use window.find instead",
+          "name": "find"
+        },
+        {
+          "message": "Use window.focus instead",
+          "name": "focus"
+        },
+        {
+          "message": "Use window.frameElement instead",
+          "name": "frameElement"
+        },
+        {
+          "message": "Use window.frames instead",
+          "name": "frames"
+        },
+        {
+          "message": "Use window.history instead",
+          "name": "history"
+        },
+        {
+          "message": "Use window.innerHeight instead",
+          "name": "innerHeight"
+        },
+        {
+          "message": "Use window.innerWidth instead",
+          "name": "innerWidth"
+        },
+        {
+          "message": "Use window.length instead",
+          "name": "length"
+        },
+        {
+          "message": "Use window.location instead",
+          "name": "location"
+        },
+        {
+          "message": "Use window.locationbar instead",
+          "name": "locationbar"
+        },
+        {
+          "message": "Use window.menubar instead",
+          "name": "menubar"
+        },
+        {
+          "message": "Use window.moveBy instead",
+          "name": "moveBy"
+        },
+        {
+          "message": "Use window.moveTo instead",
+          "name": "moveTo"
+        },
+        {
+          "message": "Use window.name instead",
+          "name": "name"
+        },
+        {
+          "message": "Use window.onblur instead",
+          "name": "onblur"
+        },
+        {
+          "message": "Use window.onerror instead",
+          "name": "onerror"
+        },
+        {
+          "message": "Use window.onfocus instead",
+          "name": "onfocus"
+        },
+        {
+          "message": "Use window.onload instead",
+          "name": "onload"
+        },
+        {
+          "message": "Use window.onresize instead",
+          "name": "onresize"
+        },
+        {
+          "message": "Use window.onunload instead",
+          "name": "onunload"
+        },
+        {
+          "message": "Use window.open instead",
+          "name": "open"
+        },
+        {
+          "message": "Use window.opener instead",
+          "name": "opener"
+        },
+        {
+          "message": "Use window.opera instead",
+          "name": "opera"
+        },
+        {
+          "message": "Use window.outerHeight instead",
+          "name": "outerHeight"
+        },
+        {
+          "message": "Use window.outerWidth instead",
+          "name": "outerWidth"
+        },
+        {
+          "message": "Use window.pageXOffset instead",
+          "name": "pageXOffset"
+        },
+        {
+          "message": "Use window.pageYOffset instead",
+          "name": "pageYOffset"
+        },
+        {
+          "message": "Use window.parent instead",
+          "name": "parent"
+        },
+        {
+          "message": "Use window.print instead",
+          "name": "print"
+        },
+        {
+          "message": "Use window.removeEventListener instead",
+          "name": "removeEventListener"
+        },
+        {
+          "message": "Use window.resizeBy instead",
+          "name": "resizeBy"
+        },
+        {
+          "message": "Use window.resizeTo instead",
+          "name": "resizeTo"
+        },
+        {
+          "message": "Use window.screen instead",
+          "name": "screen"
+        },
+        {
+          "message": "Use window.screenLeft instead",
+          "name": "screenLeft"
+        },
+        {
+          "message": "Use window.screenTop instead",
+          "name": "screenTop"
+        },
+        {
+          "message": "Use window.screenX instead",
+          "name": "screenX"
+        },
+        {
+          "message": "Use window.screenY instead",
+          "name": "screenY"
+        },
+        {
+          "message": "Use window.scroll instead",
+          "name": "scroll"
+        },
+        {
+          "message": "Use window.scrollbars instead",
+          "name": "scrollbars"
+        },
+        {
+          "message": "Use window.scrollBy instead",
+          "name": "scrollBy"
+        },
+        {
+          "message": "Use window.scrollTo instead",
+          "name": "scrollTo"
+        },
+        {
+          "message": "Use window.scrollX instead",
+          "name": "scrollX"
+        },
+        {
+          "message": "Use window.scrollY instead",
+          "name": "scrollY"
+        },
+        {
+          "message": "Use window.self instead",
+          "name": "self"
+        },
+        {
+          "message": "Use window.status instead",
+          "name": "status"
+        },
+        {
+          "message": "Use window.statusbar instead",
+          "name": "statusbar"
+        },
+        {
+          "message": "Use window.stop instead",
+          "name": "stop"
+        },
+        {
+          "message": "Use window.toolbar instead",
+          "name": "toolbar"
+        },
+        {
+          "message": "Use window.top instead",
+          "name": "top"
+        }
+      ],
+      "no-restricted-imports": [
+        "off",
+        {
+          "paths": [],
+          "patterns": []
+        }
+      ],
+      "no-restricted-properties": [
+        "error",
+        {
+          "message": "arguments.callee is deprecated",
+          "object": "arguments",
+          "property": "callee"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "global",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "self",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "window",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "global",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "self",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "window",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineGetter__"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineSetter__"
+        },
+        {
+          "message": "Use the exponentiation operator (**) instead.",
+          "object": "Math",
+          "property": "pow"
+        }
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.",
+          "selector": "LabeledStatement"
+        },
+        {
+          "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
+          "selector": "WithStatement"
+        }
+      ],
+      "no-return-assign": [
+        "error",
+        "always"
+      ],
+      "no-script-url": "error",
+      "no-self-assign": [
+        "error",
+        {
+          "props": true
+        }
+      ],
+      "no-self-compare": "error",
+      "no-sequences": "error",
+      "no-setter-return": "error",
+      "no-shadow": "error",
+      "no-shadow-restricted-names": "error",
+      "no-space-before-semi": "off",
+      "no-spaced-func": "off",
+      "no-sparse-arrays": "error",
+      "no-tabs": 0,
+      "no-template-curly-in-string": "error",
+      "no-this-before-super": "error",
+      "no-throw-literal": "error",
+      "no-trailing-spaces": "off",
+      "no-undef": "error",
+      "no-undef-init": "error",
+      "no-underscore-dangle": "off",
+      "no-unexpected-multiline": 0,
+      "no-unmodified-loop-condition": "error",
+      "no-unneeded-ternary": [
+        "error",
+        {
+          "defaultAssignment": false
+        }
+      ],
+      "no-unreachable": "error",
+      "no-unreachable-loop": [
+        "error",
+        {
+          "ignore": []
+        }
+      ],
+      "no-unsafe-finally": "error",
+      "no-unsafe-negation": "error",
+      "no-unsafe-optional-chaining": [
+        "error",
+        {
+          "disallowArithmeticOperators": true
+        }
+      ],
+      "no-unused-expressions": [
+        "error",
+        {
+          "allowShortCircuit": false,
+          "allowTaggedTemplates": false,
+          "allowTernary": false
+        }
+      ],
+      "no-unused-labels": "error",
+      "no-unused-private-class-members": "error",
+      "no-unused-vars": [
+        "error",
+        {
+          "args": "after-used",
+          "ignoreRestSiblings": true,
+          "vars": "all"
+        }
+      ],
+      "no-useless-backreference": "error",
+      "no-useless-call": "error",
+      "no-useless-catch": "error",
+      "no-useless-computed-key": "error",
+      "no-useless-concat": "error",
+      "no-useless-constructor": "error",
+      "no-useless-escape": "error",
+      "no-useless-rename": [
+        "error",
+        {
+          "ignoreDestructuring": false,
+          "ignoreExport": false,
+          "ignoreImport": false
+        }
+      ],
+      "no-useless-return": "error",
+      "no-var": "error",
+      "no-whitespace-before-property": "off",
+      "no-with": "error",
+      "no-wrap-func": "off",
+      "nonblock-statement-body-position": "off",
+      "object-curly-newline": "off",
+      "object-curly-spacing": "off",
+      "object-property-newline": "off",
+      "object-shorthand": [
+        "error",
+        "always",
+        {
+          "avoidQuotes": true,
+          "ignoreConstructors": false
+        }
+      ],
+      "one-var": [
+        "error",
+        "never"
+      ],
+      "one-var-declaration-per-line": "off",
+      "operator-assignment": [
+        "error",
+        "always"
+      ],
+      "operator-linebreak": "off",
+      "padded-blocks": "off",
+      "prefer-arrow-callback": "off",
+      "prefer-const": [
+        "error",
+        {
+          "destructuring": "any",
+          "ignoreReadBeforeAssign": true
+        }
+      ],
+      "prefer-exponentiation-operator": "error",
+      "prefer-numeric-literals": "error",
+      "prefer-object-has-own": "error",
+      "prefer-object-spread": "error",
+      "prefer-promise-reject-errors": [
+        "error",
+        {
+          "allowEmptyReject": true
+        }
+      ],
+      "prefer-regex-literals": [
+        "error",
+        {
+          "disallowRedundantWrapping": true
+        }
+      ],
+      "prefer-rest-params": "error",
+      "prefer-spread": "error",
+      "prefer-template": "error",
+      "quote-props": "off",
+      "quotes": 0,
+      "radix": "error",
+      "react/jsx-child-element-spacing": "off",
+      "react/jsx-closing-bracket-location": "off",
+      "react/jsx-closing-tag-location": "off",
+      "react/jsx-curly-newline": "off",
+      "react/jsx-curly-spacing": "off",
+      "react/jsx-equals-spacing": "off",
+      "react/jsx-first-prop-new-line": "off",
+      "react/jsx-indent": "off",
+      "react/jsx-indent-props": "off",
+      "react/jsx-max-props-per-line": "off",
+      "react/jsx-newline": "off",
+      "react/jsx-one-expression-per-line": "off",
+      "react/jsx-props-no-multi-spaces": "off",
+      "react/jsx-space-before-closing": "off",
+      "react/jsx-tag-spacing": "off",
+      "react/jsx-wrap-multilines": "off",
+      "require-atomic-updates": "error",
+      "require-yield": "error",
+      "rest-spread-spacing": "off",
+      "semi": "off",
+      "semi-spacing": "off",
+      "semi-style": "off",
+      "space-after-function-name": "off",
+      "space-after-keywords": "off",
+      "space-before-blocks": "off",
+      "space-before-function-paren": "off",
+      "space-before-function-parentheses": "off",
+      "space-before-keywords": "off",
+      "space-in-brackets": "off",
+      "space-in-parens": "off",
+      "space-infix-ops": "off",
+      "space-return-throw-case": "off",
+      "space-unary-ops": "off",
+      "space-unary-word-ops": "off",
+      "standard/array-bracket-even-spacing": "off",
+      "standard/computed-property-even-spacing": "off",
+      "standard/object-curly-even-spacing": "off",
+      "switch-colon-spacing": "off",
+      "symbol-description": "error",
+      "template-curly-spacing": "off",
+      "template-tag-spacing": "off",
+      "unicode-bom": [
+        "error",
+        "never"
+      ],
+      "unicorn/empty-brace-spaces": "off",
+      "unicorn/no-nested-ternary": "off",
+      "unicorn/number-literal-case": "off",
+      "unicorn/template-indent": 0,
+      "use-isnan": "error",
+      "valid-typeof": [
+        "error",
+        {
+          "requireStringLiterals": true
+        }
+      ],
+      "vue/array-bracket-newline": "off",
+      "vue/array-bracket-spacing": "off",
+      "vue/array-element-newline": "off",
+      "vue/arrow-spacing": "off",
+      "vue/block-spacing": "off",
+      "vue/block-tag-newline": "off",
+      "vue/brace-style": "off",
+      "vue/comma-dangle": "off",
+      "vue/comma-spacing": "off",
+      "vue/comma-style": "off",
+      "vue/dot-location": "off",
+      "vue/func-call-spacing": "off",
+      "vue/html-closing-bracket-newline": "off",
+      "vue/html-closing-bracket-spacing": "off",
+      "vue/html-end-tags": "off",
+      "vue/html-indent": "off",
+      "vue/html-quotes": "off",
+      "vue/html-self-closing": 0,
+      "vue/key-spacing": "off",
+      "vue/keyword-spacing": "off",
+      "vue/max-attributes-per-line": "off",
+      "vue/max-len": 0,
+      "vue/multiline-html-element-content-newline": "off",
+      "vue/multiline-ternary": "off",
+      "vue/mustache-interpolation-spacing": "off",
+      "vue/no-extra-parens": "off",
+      "vue/no-multi-spaces": "off",
+      "vue/no-spaces-around-equal-signs-in-attribute": "off",
+      "vue/object-curly-newline": "off",
+      "vue/object-curly-spacing": "off",
+      "vue/object-property-newline": "off",
+      "vue/operator-linebreak": "off",
+      "vue/quote-props": "off",
+      "vue/script-indent": "off",
+      "vue/singleline-html-element-content-newline": "off",
+      "vue/space-in-parens": "off",
+      "vue/space-infix-ops": "off",
+      "vue/space-unary-ops": "off",
+      "vue/template-curly-spacing": "off",
+      "wrap-iife": "off",
+      "wrap-regex": "off",
+      "yield-star-spacing": "off",
+      "yoda": "error"
+    }
+  },
+  {
+    "files": [
+      "**/*.mts"
+    ],
+    "languageOptions": {
+      "ecmaVersion": "latest",
+      "globals": {
+        "AbortController": false,
+        "AbortSignal": false,
+        "Blob": false,
+        "BroadcastChannel": false,
+        "Buffer": false,
+        "ByteLengthQueuingStrategy": false,
+        "CloseEvent": false,
+        "CompressionStream": false,
+        "CountQueuingStrategy": false,
+        "Crypto": false,
+        "CryptoKey": false,
+        "CustomEvent": false,
+        "DOMException": false,
+        "DecompressionStream": false,
+        "Event": false,
+        "EventTarget": false,
+        "File": false,
+        "FormData": false,
+        "Headers": false,
+        "MessageChannel": false,
+        "MessageEvent": false,
+        "MessagePort": false,
+        "Navigator": false,
+        "Performance": false,
+        "PerformanceEntry": false,
+        "PerformanceMark": false,
+        "PerformanceMeasure": false,
+        "PerformanceObserver": false,
+        "PerformanceObserverEntryList": false,
+        "PerformanceResourceTiming": false,
+        "ReadableByteStreamController": false,
+        "ReadableStream": false,
+        "ReadableStreamBYOBReader": false,
+        "ReadableStreamBYOBRequest": false,
+        "ReadableStreamDefaultController": false,
+        "ReadableStreamDefaultReader": false,
+        "Request": false,
+        "Response": false,
+        "SubtleCrypto": false,
+        "TextDecoder": false,
+        "TextDecoderStream": false,
+        "TextEncoder": false,
+        "TextEncoderStream": false,
+        "TransformStream": false,
+        "TransformStreamDefaultController": false,
+        "URL": false,
+        "URLSearchParams": false,
+        "WebAssembly": false,
+        "WebSocket": false,
+        "WritableStream": false,
+        "WritableStreamDefaultController": false,
+        "WritableStreamDefaultWriter": false,
+        "__dirname": false,
+        "__filename": false,
+        "atob": false,
+        "btoa": false,
+        "clearImmediate": false,
+        "clearInterval": false,
+        "clearTimeout": false,
+        "console": false,
+        "crypto": false,
+        "exports": true,
+        "fetch": false,
+        "global": false,
+        "module": false,
+        "navigator": false,
+        "performance": false,
+        "process": false,
+        "queueMicrotask": false,
+        "require": false,
+        "setImmediate": false,
+        "setInterval": false,
+        "setTimeout": false,
+        "structuredClone": false
+      },
+      "parser": "@qlik/eslint-config/node-cjs-mts-parser",
+      "parserOptions": {
+        "parser": {
+          "meta": {
+            "name": "typescript-eslint/parser",
+            "version": "8.28.0"
+          },
+          "version": "8.28.0"
+        },
+        "projectService": true,
+        "warnOnUnsupportedTypeScriptVersion": false
+      },
+      "sourceType": "module"
+    },
+    "name": "@qlik/eslint-config/node-cjs-mts",
+    "plugins": {
+      "@typescript-eslint": "@typescript-eslint-plugin",
+      "import-x": "import-x-plugin"
+    },
+    "rules": {
+      "@babel/object-curly-spacing": "off",
+      "@babel/semi": "off",
+      "@stylistic/array-bracket-newline": "off",
+      "@stylistic/array-bracket-spacing": "off",
+      "@stylistic/array-element-newline": "off",
+      "@stylistic/arrow-parens": "off",
+      "@stylistic/arrow-spacing": "off",
+      "@stylistic/block-spacing": "off",
+      "@stylistic/brace-style": "off",
+      "@stylistic/comma-dangle": "off",
+      "@stylistic/comma-spacing": "off",
+      "@stylistic/comma-style": "off",
+      "@stylistic/computed-property-spacing": "off",
+      "@stylistic/dot-location": "off",
+      "@stylistic/eol-last": "off",
+      "@stylistic/func-call-spacing": "off",
+      "@stylistic/function-call-argument-newline": "off",
+      "@stylistic/function-call-spacing": "off",
+      "@stylistic/function-paren-newline": "off",
+      "@stylistic/generator-star-spacing": "off",
+      "@stylistic/implicit-arrow-linebreak": "off",
+      "@stylistic/indent": "off",
+      "@stylistic/indent-binary-ops": "off",
+      "@stylistic/js/array-bracket-newline": "off",
+      "@stylistic/js/array-bracket-spacing": "off",
+      "@stylistic/js/array-element-newline": "off",
+      "@stylistic/js/arrow-parens": "off",
+      "@stylistic/js/arrow-spacing": "off",
+      "@stylistic/js/block-spacing": "off",
+      "@stylistic/js/brace-style": "off",
+      "@stylistic/js/comma-dangle": "off",
+      "@stylistic/js/comma-spacing": "off",
+      "@stylistic/js/comma-style": "off",
+      "@stylistic/js/computed-property-spacing": "off",
+      "@stylistic/js/dot-location": "off",
+      "@stylistic/js/eol-last": "off",
+      "@stylistic/js/func-call-spacing": "off",
+      "@stylistic/js/function-call-argument-newline": "off",
+      "@stylistic/js/function-call-spacing": "off",
+      "@stylistic/js/function-paren-newline": "off",
+      "@stylistic/js/generator-star-spacing": "off",
+      "@stylistic/js/implicit-arrow-linebreak": "off",
+      "@stylistic/js/indent": "off",
+      "@stylistic/js/jsx-quotes": "off",
+      "@stylistic/js/key-spacing": "off",
+      "@stylistic/js/keyword-spacing": "off",
+      "@stylistic/js/linebreak-style": "off",
+      "@stylistic/js/lines-around-comment": 0,
+      "@stylistic/js/max-len": 0,
+      "@stylistic/js/max-statements-per-line": "off",
+      "@stylistic/js/multiline-ternary": "off",
+      "@stylistic/js/new-parens": "off",
+      "@stylistic/js/newline-per-chained-call": "off",
+      "@stylistic/js/no-confusing-arrow": 0,
+      "@stylistic/js/no-extra-parens": "off",
+      "@stylistic/js/no-extra-semi": "off",
+      "@stylistic/js/no-floating-decimal": "off",
+      "@stylistic/js/no-mixed-operators": 0,
+      "@stylistic/js/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/js/no-multi-spaces": "off",
+      "@stylistic/js/no-multiple-empty-lines": "off",
+      "@stylistic/js/no-tabs": 0,
+      "@stylistic/js/no-trailing-spaces": "off",
+      "@stylistic/js/no-whitespace-before-property": "off",
+      "@stylistic/js/nonblock-statement-body-position": "off",
+      "@stylistic/js/object-curly-newline": "off",
+      "@stylistic/js/object-curly-spacing": "off",
+      "@stylistic/js/object-property-newline": "off",
+      "@stylistic/js/one-var-declaration-per-line": "off",
+      "@stylistic/js/operator-linebreak": "off",
+      "@stylistic/js/padded-blocks": "off",
+      "@stylistic/js/quote-props": "off",
+      "@stylistic/js/quotes": 0,
+      "@stylistic/js/rest-spread-spacing": "off",
+      "@stylistic/js/semi": "off",
+      "@stylistic/js/semi-spacing": "off",
+      "@stylistic/js/semi-style": "off",
+      "@stylistic/js/space-before-blocks": "off",
+      "@stylistic/js/space-before-function-paren": "off",
+      "@stylistic/js/space-in-parens": "off",
+      "@stylistic/js/space-infix-ops": "off",
+      "@stylistic/js/space-unary-ops": "off",
+      "@stylistic/js/switch-colon-spacing": "off",
+      "@stylistic/js/template-curly-spacing": "off",
+      "@stylistic/js/template-tag-spacing": "off",
+      "@stylistic/js/wrap-iife": "off",
+      "@stylistic/js/wrap-regex": "off",
+      "@stylistic/js/yield-star-spacing": "off",
+      "@stylistic/jsx-child-element-spacing": "off",
+      "@stylistic/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx-closing-tag-location": "off",
+      "@stylistic/jsx-curly-newline": "off",
+      "@stylistic/jsx-curly-spacing": "off",
+      "@stylistic/jsx-equals-spacing": "off",
+      "@stylistic/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx-indent": "off",
+      "@stylistic/jsx-indent-props": "off",
+      "@stylistic/jsx-max-props-per-line": "off",
+      "@stylistic/jsx-newline": "off",
+      "@stylistic/jsx-one-expression-per-line": "off",
+      "@stylistic/jsx-props-no-multi-spaces": "off",
+      "@stylistic/jsx-quotes": "off",
+      "@stylistic/jsx-tag-spacing": "off",
+      "@stylistic/jsx-wrap-multilines": "off",
+      "@stylistic/jsx/jsx-child-element-spacing": "off",
+      "@stylistic/jsx/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx/jsx-closing-tag-location": "off",
+      "@stylistic/jsx/jsx-curly-newline": "off",
+      "@stylistic/jsx/jsx-curly-spacing": "off",
+      "@stylistic/jsx/jsx-equals-spacing": "off",
+      "@stylistic/jsx/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx/jsx-indent": "off",
+      "@stylistic/jsx/jsx-indent-props": "off",
+      "@stylistic/jsx/jsx-max-props-per-line": "off",
+      "@stylistic/key-spacing": "off",
+      "@stylistic/keyword-spacing": "off",
+      "@stylistic/linebreak-style": "off",
+      "@stylistic/lines-around-comment": 0,
+      "@stylistic/max-len": 0,
+      "@stylistic/max-statements-per-line": "off",
+      "@stylistic/member-delimiter-style": "off",
+      "@stylistic/multiline-ternary": "off",
+      "@stylistic/new-parens": "off",
+      "@stylistic/newline-per-chained-call": "off",
+      "@stylistic/no-confusing-arrow": 0,
+      "@stylistic/no-extra-parens": "off",
+      "@stylistic/no-extra-semi": "off",
+      "@stylistic/no-floating-decimal": "off",
+      "@stylistic/no-mixed-operators": 0,
+      "@stylistic/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/no-multi-spaces": "off",
+      "@stylistic/no-multiple-empty-lines": "off",
+      "@stylistic/no-tabs": 0,
+      "@stylistic/no-trailing-spaces": "off",
+      "@stylistic/no-whitespace-before-property": "off",
+      "@stylistic/nonblock-statement-body-position": "off",
+      "@stylistic/object-curly-newline": "off",
+      "@stylistic/object-curly-spacing": "off",
+      "@stylistic/object-property-newline": "off",
+      "@stylistic/one-var-declaration-per-line": "off",
+      "@stylistic/operator-linebreak": "off",
+      "@stylistic/padded-blocks": "off",
+      "@stylistic/quote-props": "off",
+      "@stylistic/quotes": 0,
+      "@stylistic/rest-spread-spacing": "off",
+      "@stylistic/semi": "off",
+      "@stylistic/semi-spacing": "off",
+      "@stylistic/semi-style": "off",
+      "@stylistic/space-before-blocks": "off",
+      "@stylistic/space-before-function-paren": "off",
+      "@stylistic/space-in-parens": "off",
+      "@stylistic/space-infix-ops": "off",
+      "@stylistic/space-unary-ops": "off",
+      "@stylistic/switch-colon-spacing": "off",
+      "@stylistic/template-curly-spacing": "off",
+      "@stylistic/template-tag-spacing": "off",
+      "@stylistic/ts/block-spacing": "off",
+      "@stylistic/ts/brace-style": "off",
+      "@stylistic/ts/comma-dangle": "off",
+      "@stylistic/ts/comma-spacing": "off",
+      "@stylistic/ts/func-call-spacing": "off",
+      "@stylistic/ts/function-call-spacing": "off",
+      "@stylistic/ts/indent": "off",
+      "@stylistic/ts/key-spacing": "off",
+      "@stylistic/ts/keyword-spacing": "off",
+      "@stylistic/ts/lines-around-comment": 0,
+      "@stylistic/ts/member-delimiter-style": "off",
+      "@stylistic/ts/no-extra-parens": "off",
+      "@stylistic/ts/no-extra-semi": "off",
+      "@stylistic/ts/object-curly-spacing": "off",
+      "@stylistic/ts/quotes": 0,
+      "@stylistic/ts/semi": "off",
+      "@stylistic/ts/space-before-blocks": "off",
+      "@stylistic/ts/space-before-function-paren": "off",
+      "@stylistic/ts/space-infix-ops": "off",
+      "@stylistic/ts/type-annotation-spacing": "off",
+      "@stylistic/type-annotation-spacing": "off",
+      "@stylistic/type-generic-spacing": "off",
+      "@stylistic/type-named-tuple-spacing": "off",
+      "@stylistic/wrap-iife": "off",
+      "@stylistic/wrap-regex": "off",
+      "@stylistic/yield-star-spacing": "off",
+      "@typescript-eslint/ban-ts-comment": "error",
+      "@typescript-eslint/block-spacing": "off",
+      "@typescript-eslint/brace-style": "off",
+      "@typescript-eslint/class-methods-use-this": [
+        "warn",
+        {
+          "exceptMethods": []
+        }
+      ],
+      "@typescript-eslint/comma-dangle": "off",
+      "@typescript-eslint/comma-spacing": "off",
+      "@typescript-eslint/consistent-type-exports": "error",
+      "@typescript-eslint/consistent-type-imports": "error",
+      "@typescript-eslint/default-param-last": "error",
+      "@typescript-eslint/explicit-module-boundary-types": "off",
+      "@typescript-eslint/func-call-spacing": "off",
+      "@typescript-eslint/indent": "off",
+      "@typescript-eslint/key-spacing": "off",
+      "@typescript-eslint/keyword-spacing": "off",
+      "@typescript-eslint/lines-around-comment": 0,
+      "@typescript-eslint/member-delimiter-style": "off",
+      "@typescript-eslint/method-signature-style": "error",
+      "@typescript-eslint/naming-convention": [
+        "error",
+        {
+          "format": [
+            "camelCase",
+            "PascalCase",
+            "UPPER_CASE"
+          ],
+          "selector": "variable"
+        },
+        {
+          "format": [
+            "camelCase",
+            "PascalCase"
+          ],
+          "selector": "function"
+        },
+        {
+          "format": [
+            "PascalCase"
+          ],
+          "selector": "typeLike"
+        }
+      ],
+      "@typescript-eslint/no-array-constructor": "error",
+      "@typescript-eslint/no-confusing-void-expression": "error",
+      "@typescript-eslint/no-duplicate-enum-values": "error",
+      "@typescript-eslint/no-dynamic-delete": "error",
+      "@typescript-eslint/no-empty-object-type": "error",
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/no-extra-non-null-assertion": "error",
+      "@typescript-eslint/no-extra-parens": "off",
+      "@typescript-eslint/no-extra-semi": "off",
+      "@typescript-eslint/no-extraneous-class": "error",
+      "@typescript-eslint/no-floating-promises": [
+        "error",
+        {
+          "ignoreIIFE": true
+        }
+      ],
+      "@typescript-eslint/no-import-type-side-effects": "error",
+      "@typescript-eslint/no-invalid-void-type": "error",
+      "@typescript-eslint/no-loop-func": "error",
+      "@typescript-eslint/no-magic-numbers": "off",
+      "@typescript-eslint/no-meaningless-void-operator": "error",
+      "@typescript-eslint/no-misused-new": "error",
+      "@typescript-eslint/no-misused-promises": [
+        "error",
+        {
+          "checksConditionals": false
+        }
+      ],
+      "@typescript-eslint/no-mixed-enums": "error",
+      "@typescript-eslint/no-namespace": "error",
+      "@typescript-eslint/no-non-null-asserted-nullish-coalescing": "error",
+      "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
+      "@typescript-eslint/no-non-null-assertion": "error",
+      "@typescript-eslint/no-redeclare": "error",
+      "@typescript-eslint/no-require-imports": "error",
+      "@typescript-eslint/no-restricted-imports": [
+        "off",
+        {
+          "paths": [],
+          "patterns": []
+        }
+      ],
+      "@typescript-eslint/no-restricted-types": [
+        "error",
+        {}
+      ],
+      "@typescript-eslint/no-shadow": "error",
+      "@typescript-eslint/no-this-alias": "error",
+      "@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
+      "@typescript-eslint/no-unnecessary-condition": "error",
+      "@typescript-eslint/no-unnecessary-parameter-property-assignment": "error",
+      "@typescript-eslint/no-unnecessary-qualifier": "error",
+      "@typescript-eslint/no-unnecessary-template-expression": "error",
+      "@typescript-eslint/no-unnecessary-type-arguments": "error",
+      "@typescript-eslint/no-unnecessary-type-constraint": "error",
+      "@typescript-eslint/no-unnecessary-type-parameters": "off",
+      "@typescript-eslint/no-unsafe-declaration-merging": "error",
+      "@typescript-eslint/no-unsafe-function-type": "error",
+      "@typescript-eslint/no-unused-expressions": "error",
+      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/no-useless-constructor": "error",
+      "@typescript-eslint/no-useless-empty-export": "error",
+      "@typescript-eslint/no-wrapper-object-types": "error",
+      "@typescript-eslint/object-curly-spacing": "off",
+      "@typescript-eslint/prefer-as-const": "error",
+      "@typescript-eslint/prefer-enum-initializers": "error",
+      "@typescript-eslint/prefer-for-of": "off",
+      "@typescript-eslint/prefer-literal-enum-member": "error",
+      "@typescript-eslint/prefer-namespace-keyword": "error",
+      "@typescript-eslint/prefer-reduce-type-parameter": "error",
+      "@typescript-eslint/prefer-return-this-type": "error",
+      "@typescript-eslint/quotes": 0,
+      "@typescript-eslint/require-array-sort-compare": "error",
+      "@typescript-eslint/return-await": "error",
+      "@typescript-eslint/semi": "off",
+      "@typescript-eslint/space-before-blocks": "off",
+      "@typescript-eslint/space-before-function-paren": "off",
+      "@typescript-eslint/space-infix-ops": "off",
+      "@typescript-eslint/strict-boolean-expressions": "off",
+      "@typescript-eslint/switch-exhaustiveness-check": "error",
+      "@typescript-eslint/triple-slash-reference": "error",
+      "@typescript-eslint/type-annotation-spacing": "off",
+      "@typescript-eslint/unified-signatures": "error",
+      "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
+      "array-bracket-newline": "off",
+      "array-bracket-spacing": "off",
+      "array-callback-return": [
+        "error",
+        {
+          "allowImplicit": true
+        }
+      ],
+      "array-element-newline": "off",
+      "arrow-body-style": "off",
+      "arrow-parens": "off",
+      "arrow-spacing": "off",
+      "babel/object-curly-spacing": "off",
+      "babel/quotes": 0,
+      "babel/semi": "off",
+      "block-scoped-var": "error",
+      "block-spacing": "off",
+      "brace-style": "off",
+      "camelcase": "off",
+      "class-methods-use-this": "off",
+      "comma-dangle": "off",
+      "comma-spacing": "off",
+      "comma-style": "off",
+      "computed-property-spacing": "off",
+      "consistent-return": "error",
+      "constructor-super": "off",
+      "curly": 0,
+      "default-case": [
+        "error",
+        {
+          "commentPattern": "^no default$"
+        }
+      ],
+      "default-case-last": "error",
+      "default-param-last": "off",
+      "dot-location": "off",
+      "eol-last": "off",
+      "eqeqeq": [
+        "error",
+        "always",
+        {
+          "null": "ignore"
+        }
+      ],
+      "flowtype/boolean-style": "off",
+      "flowtype/delimiter-dangle": "off",
+      "flowtype/generic-spacing": "off",
+      "flowtype/object-type-curly-spacing": "off",
+      "flowtype/object-type-delimiter": "off",
+      "flowtype/quotes": "off",
+      "flowtype/semi": "off",
+      "flowtype/space-after-type-colon": "off",
+      "flowtype/space-before-generic-bracket": "off",
+      "flowtype/space-before-type-colon": "off",
+      "flowtype/union-intersection-spacing": "off",
+      "for-direction": "error",
+      "func-call-spacing": "off",
+      "func-names": "warn",
+      "function-call-argument-newline": "off",
+      "function-paren-newline": "off",
+      "generator-star": "off",
+      "generator-star-spacing": "off",
+      "getter-return": "off",
+      "grouped-accessor-pairs": "error",
+      "implicit-arrow-linebreak": "off",
+      "import-x/consistent-type-specifier-style": "off",
+      "import-x/default": "error",
+      "import-x/export": "error",
+      "import-x/extensions": [
+        "error",
+        "ignorePackages",
+        {
           "mts": "never",
           "ts": "never",
           "tsx": "never"

--- a/packages/eslint-config/test/generated/esbrowser-final-config.js
+++ b/packages/eslint-config/test/generated/esbrowser-final-config.js
@@ -3387,9 +3387,9 @@ export default [
         "parser": {
           "meta": {
             "name": "typescript-eslint/parser",
-            "version": "8.27.0"
+            "version": "8.28.0"
           },
-          "version": "8.27.0"
+          "version": "8.28.0"
         },
         "projectService": true,
         "warnOnUnsupportedTypeScriptVersion": false
@@ -3917,6 +3917,2508 @@ export default [
       ],
       "no-confusing-arrow": 0,
       "no-console": "warn",
+      "no-const-assign": "off",
+      "no-constant-binary-expression": "error",
+      "no-constant-condition": "warn",
+      "no-constructor-return": "error",
+      "no-continue": "error",
+      "no-control-regex": "error",
+      "no-debugger": "error",
+      "no-delete-var": "error",
+      "no-dupe-args": "off",
+      "no-dupe-class-members": "off",
+      "no-dupe-else-if": "error",
+      "no-dupe-keys": "off",
+      "no-duplicate-case": "error",
+      "no-else-return": [
+        "error",
+        {
+          "allowElseIf": false
+        }
+      ],
+      "no-empty": "error",
+      "no-empty-character-class": "error",
+      "no-empty-function": [
+        "error",
+        {
+          "allow": [
+            "arrowFunctions",
+            "functions",
+            "methods"
+          ]
+        }
+      ],
+      "no-empty-pattern": "error",
+      "no-empty-static-block": "error",
+      "no-eval": "error",
+      "no-ex-assign": "error",
+      "no-extend-native": "error",
+      "no-extra-bind": "error",
+      "no-extra-boolean-cast": "error",
+      "no-extra-label": "error",
+      "no-extra-parens": "off",
+      "no-extra-semi": "off",
+      "no-fallthrough": "error",
+      "no-floating-decimal": "off",
+      "no-func-assign": "off",
+      "no-global-assign": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "no-implied-eval": "error",
+      "no-import-assign": "off",
+      "no-inner-declarations": "error",
+      "no-invalid-regexp": "error",
+      "no-irregular-whitespace": "error",
+      "no-iterator": "error",
+      "no-label-var": "error",
+      "no-labels": [
+        "error",
+        {
+          "allowLoop": false,
+          "allowSwitch": false
+        }
+      ],
+      "no-lone-blocks": "error",
+      "no-lonely-if": "error",
+      "no-loop-func": "off",
+      "no-loss-of-precision": "error",
+      "no-magic-numbers": "off",
+      "no-misleading-character-class": "error",
+      "no-mixed-operators": 0,
+      "no-mixed-spaces-and-tabs": "off",
+      "no-multi-assign": [
+        "error"
+      ],
+      "no-multi-spaces": "off",
+      "no-multi-str": "error",
+      "no-multiple-empty-lines": "off",
+      "no-nested-ternary": "error",
+      "no-new": "error",
+      "no-new-func": "error",
+      "no-new-native-nonconstructor": "off",
+      "no-new-symbol": "off",
+      "no-new-wrappers": "error",
+      "no-nonoctal-decimal-escape": "error",
+      "no-obj-calls": "off",
+      "no-object-constructor": "error",
+      "no-octal": "error",
+      "no-octal-escape": "error",
+      "no-param-reassign": [
+        "error",
+        {
+          "ignorePropertyModificationsFor": [
+            "prev",
+            "acc",
+            "accumulator",
+            "e",
+            "ctx",
+            "context",
+            "req",
+            "request",
+            "res",
+            "response",
+            "$scope",
+            "staticContext",
+            "sharedState",
+            "state"
+          ],
+          "props": true
+        }
+      ],
+      "no-promise-executor-return": "error",
+      "no-proto": "error",
+      "no-prototype-builtins": "error",
+      "no-redeclare": "off",
+      "no-regex-spaces": "error",
+      "no-reserved-keys": "off",
+      "no-restricted-exports": [
+        "error",
+        {
+          "restrictedNamedExports": [
+            "default",
+            "then"
+          ]
+        }
+      ],
+      "no-restricted-globals": [
+        "error",
+        {
+          "message": "Use Number.isFinite instead",
+          "name": "isFinite"
+        },
+        {
+          "message": "Use Number.isNaN instead",
+          "name": "isNaN"
+        },
+        {
+          "message": "Use window.addEventListener instead",
+          "name": "addEventListener"
+        },
+        {
+          "message": "Use window.blur instead",
+          "name": "blur"
+        },
+        {
+          "message": "Use window.close instead",
+          "name": "close"
+        },
+        {
+          "message": "Use window.closed instead",
+          "name": "closed"
+        },
+        {
+          "message": "Use window.confirm instead",
+          "name": "confirm"
+        },
+        {
+          "message": "Use window.defaultStatus instead",
+          "name": "defaultStatus"
+        },
+        {
+          "message": "Use window.defaultstatus instead",
+          "name": "defaultstatus"
+        },
+        {
+          "message": "Use window.event instead",
+          "name": "event"
+        },
+        {
+          "message": "Use window.external instead",
+          "name": "external"
+        },
+        {
+          "message": "Use window.find instead",
+          "name": "find"
+        },
+        {
+          "message": "Use window.focus instead",
+          "name": "focus"
+        },
+        {
+          "message": "Use window.frameElement instead",
+          "name": "frameElement"
+        },
+        {
+          "message": "Use window.frames instead",
+          "name": "frames"
+        },
+        {
+          "message": "Use window.history instead",
+          "name": "history"
+        },
+        {
+          "message": "Use window.innerHeight instead",
+          "name": "innerHeight"
+        },
+        {
+          "message": "Use window.innerWidth instead",
+          "name": "innerWidth"
+        },
+        {
+          "message": "Use window.length instead",
+          "name": "length"
+        },
+        {
+          "message": "Use window.location instead",
+          "name": "location"
+        },
+        {
+          "message": "Use window.locationbar instead",
+          "name": "locationbar"
+        },
+        {
+          "message": "Use window.menubar instead",
+          "name": "menubar"
+        },
+        {
+          "message": "Use window.moveBy instead",
+          "name": "moveBy"
+        },
+        {
+          "message": "Use window.moveTo instead",
+          "name": "moveTo"
+        },
+        {
+          "message": "Use window.name instead",
+          "name": "name"
+        },
+        {
+          "message": "Use window.onblur instead",
+          "name": "onblur"
+        },
+        {
+          "message": "Use window.onerror instead",
+          "name": "onerror"
+        },
+        {
+          "message": "Use window.onfocus instead",
+          "name": "onfocus"
+        },
+        {
+          "message": "Use window.onload instead",
+          "name": "onload"
+        },
+        {
+          "message": "Use window.onresize instead",
+          "name": "onresize"
+        },
+        {
+          "message": "Use window.onunload instead",
+          "name": "onunload"
+        },
+        {
+          "message": "Use window.open instead",
+          "name": "open"
+        },
+        {
+          "message": "Use window.opener instead",
+          "name": "opener"
+        },
+        {
+          "message": "Use window.opera instead",
+          "name": "opera"
+        },
+        {
+          "message": "Use window.outerHeight instead",
+          "name": "outerHeight"
+        },
+        {
+          "message": "Use window.outerWidth instead",
+          "name": "outerWidth"
+        },
+        {
+          "message": "Use window.pageXOffset instead",
+          "name": "pageXOffset"
+        },
+        {
+          "message": "Use window.pageYOffset instead",
+          "name": "pageYOffset"
+        },
+        {
+          "message": "Use window.parent instead",
+          "name": "parent"
+        },
+        {
+          "message": "Use window.print instead",
+          "name": "print"
+        },
+        {
+          "message": "Use window.removeEventListener instead",
+          "name": "removeEventListener"
+        },
+        {
+          "message": "Use window.resizeBy instead",
+          "name": "resizeBy"
+        },
+        {
+          "message": "Use window.resizeTo instead",
+          "name": "resizeTo"
+        },
+        {
+          "message": "Use window.screen instead",
+          "name": "screen"
+        },
+        {
+          "message": "Use window.screenLeft instead",
+          "name": "screenLeft"
+        },
+        {
+          "message": "Use window.screenTop instead",
+          "name": "screenTop"
+        },
+        {
+          "message": "Use window.screenX instead",
+          "name": "screenX"
+        },
+        {
+          "message": "Use window.screenY instead",
+          "name": "screenY"
+        },
+        {
+          "message": "Use window.scroll instead",
+          "name": "scroll"
+        },
+        {
+          "message": "Use window.scrollbars instead",
+          "name": "scrollbars"
+        },
+        {
+          "message": "Use window.scrollBy instead",
+          "name": "scrollBy"
+        },
+        {
+          "message": "Use window.scrollTo instead",
+          "name": "scrollTo"
+        },
+        {
+          "message": "Use window.scrollX instead",
+          "name": "scrollX"
+        },
+        {
+          "message": "Use window.scrollY instead",
+          "name": "scrollY"
+        },
+        {
+          "message": "Use window.self instead",
+          "name": "self"
+        },
+        {
+          "message": "Use window.status instead",
+          "name": "status"
+        },
+        {
+          "message": "Use window.statusbar instead",
+          "name": "statusbar"
+        },
+        {
+          "message": "Use window.stop instead",
+          "name": "stop"
+        },
+        {
+          "message": "Use window.toolbar instead",
+          "name": "toolbar"
+        },
+        {
+          "message": "Use window.top instead",
+          "name": "top"
+        }
+      ],
+      "no-restricted-imports": "off",
+      "no-restricted-properties": [
+        "error",
+        {
+          "message": "arguments.callee is deprecated",
+          "object": "arguments",
+          "property": "callee"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "global",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "self",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "window",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "global",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "self",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "window",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineGetter__"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineSetter__"
+        },
+        {
+          "message": "Use the exponentiation operator (**) instead.",
+          "object": "Math",
+          "property": "pow"
+        }
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.",
+          "selector": "LabeledStatement"
+        },
+        {
+          "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
+          "selector": "WithStatement"
+        }
+      ],
+      "no-return-assign": [
+        "error",
+        "always"
+      ],
+      "no-return-await": "off",
+      "no-script-url": "error",
+      "no-self-assign": [
+        "error",
+        {
+          "props": true
+        }
+      ],
+      "no-self-compare": "error",
+      "no-sequences": "error",
+      "no-setter-return": "off",
+      "no-shadow": "off",
+      "no-shadow-restricted-names": "error",
+      "no-space-before-semi": "off",
+      "no-spaced-func": "off",
+      "no-sparse-arrays": "error",
+      "no-tabs": 0,
+      "no-template-curly-in-string": "error",
+      "no-this-before-super": "off",
+      "no-throw-literal": "error",
+      "no-trailing-spaces": "off",
+      "no-undef": "off",
+      "no-undef-init": "error",
+      "no-underscore-dangle": "off",
+      "no-unexpected-multiline": 0,
+      "no-unmodified-loop-condition": "error",
+      "no-unneeded-ternary": [
+        "error",
+        {
+          "defaultAssignment": false
+        }
+      ],
+      "no-unreachable": "off",
+      "no-unreachable-loop": [
+        "error",
+        {
+          "ignore": []
+        }
+      ],
+      "no-unsafe-finally": "error",
+      "no-unsafe-negation": "off",
+      "no-unsafe-optional-chaining": [
+        "error",
+        {
+          "disallowArithmeticOperators": true
+        }
+      ],
+      "no-unused-expressions": "off",
+      "no-unused-labels": "error",
+      "no-unused-private-class-members": "error",
+      "no-unused-vars": "off",
+      "no-useless-backreference": "error",
+      "no-useless-call": "error",
+      "no-useless-catch": "error",
+      "no-useless-computed-key": "error",
+      "no-useless-concat": "error",
+      "no-useless-constructor": "off",
+      "no-useless-escape": "error",
+      "no-useless-rename": [
+        "error",
+        {
+          "ignoreDestructuring": false,
+          "ignoreExport": false,
+          "ignoreImport": false
+        }
+      ],
+      "no-useless-return": "error",
+      "no-var": "error",
+      "no-whitespace-before-property": "off",
+      "no-with": "error",
+      "no-wrap-func": "off",
+      "nonblock-statement-body-position": "off",
+      "object-curly-newline": "off",
+      "object-curly-spacing": "off",
+      "object-property-newline": "off",
+      "object-shorthand": [
+        "error",
+        "always",
+        {
+          "avoidQuotes": true,
+          "ignoreConstructors": false
+        }
+      ],
+      "one-var": [
+        "error",
+        "never"
+      ],
+      "one-var-declaration-per-line": "off",
+      "operator-assignment": [
+        "error",
+        "always"
+      ],
+      "operator-linebreak": "off",
+      "padded-blocks": "off",
+      "prefer-arrow-callback": "off",
+      "prefer-const": "error",
+      "prefer-exponentiation-operator": "error",
+      "prefer-numeric-literals": "error",
+      "prefer-object-has-own": "error",
+      "prefer-object-spread": "error",
+      "prefer-promise-reject-errors": [
+        "error",
+        {
+          "allowEmptyReject": true
+        }
+      ],
+      "prefer-regex-literals": [
+        "error",
+        {
+          "disallowRedundantWrapping": true
+        }
+      ],
+      "prefer-rest-params": "error",
+      "prefer-spread": "error",
+      "prefer-template": "error",
+      "quote-props": "off",
+      "quotes": 0,
+      "radix": "error",
+      "react/jsx-child-element-spacing": "off",
+      "react/jsx-closing-bracket-location": "off",
+      "react/jsx-closing-tag-location": "off",
+      "react/jsx-curly-newline": "off",
+      "react/jsx-curly-spacing": "off",
+      "react/jsx-equals-spacing": "off",
+      "react/jsx-first-prop-new-line": "off",
+      "react/jsx-indent": "off",
+      "react/jsx-indent-props": "off",
+      "react/jsx-max-props-per-line": "off",
+      "react/jsx-newline": "off",
+      "react/jsx-one-expression-per-line": "off",
+      "react/jsx-props-no-multi-spaces": "off",
+      "react/jsx-space-before-closing": "off",
+      "react/jsx-tag-spacing": "off",
+      "react/jsx-wrap-multilines": "off",
+      "require-atomic-updates": "error",
+      "require-yield": "error",
+      "rest-spread-spacing": "off",
+      "semi": "off",
+      "semi-spacing": "off",
+      "semi-style": "off",
+      "space-after-function-name": "off",
+      "space-after-keywords": "off",
+      "space-before-blocks": "off",
+      "space-before-function-paren": "off",
+      "space-before-function-parentheses": "off",
+      "space-before-keywords": "off",
+      "space-in-brackets": "off",
+      "space-in-parens": "off",
+      "space-infix-ops": "off",
+      "space-return-throw-case": "off",
+      "space-unary-ops": "off",
+      "space-unary-word-ops": "off",
+      "standard/array-bracket-even-spacing": "off",
+      "standard/computed-property-even-spacing": "off",
+      "standard/object-curly-even-spacing": "off",
+      "switch-colon-spacing": "off",
+      "symbol-description": "error",
+      "template-curly-spacing": "off",
+      "template-tag-spacing": "off",
+      "unicode-bom": [
+        "error",
+        "never"
+      ],
+      "unicorn/empty-brace-spaces": "off",
+      "unicorn/no-nested-ternary": "off",
+      "unicorn/number-literal-case": "off",
+      "unicorn/template-indent": 0,
+      "use-isnan": "error",
+      "valid-typeof": [
+        "error",
+        {
+          "requireStringLiterals": true
+        }
+      ],
+      "vue/array-bracket-newline": "off",
+      "vue/array-bracket-spacing": "off",
+      "vue/array-element-newline": "off",
+      "vue/arrow-spacing": "off",
+      "vue/block-spacing": "off",
+      "vue/block-tag-newline": "off",
+      "vue/brace-style": "off",
+      "vue/comma-dangle": "off",
+      "vue/comma-spacing": "off",
+      "vue/comma-style": "off",
+      "vue/dot-location": "off",
+      "vue/func-call-spacing": "off",
+      "vue/html-closing-bracket-newline": "off",
+      "vue/html-closing-bracket-spacing": "off",
+      "vue/html-end-tags": "off",
+      "vue/html-indent": "off",
+      "vue/html-quotes": "off",
+      "vue/html-self-closing": 0,
+      "vue/key-spacing": "off",
+      "vue/keyword-spacing": "off",
+      "vue/max-attributes-per-line": "off",
+      "vue/max-len": 0,
+      "vue/multiline-html-element-content-newline": "off",
+      "vue/multiline-ternary": "off",
+      "vue/mustache-interpolation-spacing": "off",
+      "vue/no-extra-parens": "off",
+      "vue/no-multi-spaces": "off",
+      "vue/no-spaces-around-equal-signs-in-attribute": "off",
+      "vue/object-curly-newline": "off",
+      "vue/object-curly-spacing": "off",
+      "vue/object-property-newline": "off",
+      "vue/operator-linebreak": "off",
+      "vue/quote-props": "off",
+      "vue/script-indent": "off",
+      "vue/singleline-html-element-content-newline": "off",
+      "vue/space-in-parens": "off",
+      "vue/space-infix-ops": "off",
+      "vue/space-unary-ops": "off",
+      "vue/template-curly-spacing": "off",
+      "wrap-iife": "off",
+      "wrap-regex": "off",
+      "yield-star-spacing": "off",
+      "yoda": "error"
+    },
+    "settings": {
+      "import-x/extensions": [
+        ".ts",
+        ".tsx",
+        ".cts",
+        ".mts",
+        ".js",
+        ".jsx",
+        ".cjs",
+        ".mjs"
+      ],
+      "import-x/external-module-folders": [
+        "node_modules",
+        "node_modules/@types"
+      ],
+      "import-x/parsers": {
+        "@typescript-eslint/parser": [
+          ".ts",
+          ".tsx",
+          ".cts",
+          ".mts"
+        ]
+      },
+      "import-x/resolver": {
+        "typescript": true
+      }
+    }
+  },
+  {
+    "files": [
+      "**/*.cjs"
+    ],
+    "languageOptions": {
+      "ecmaVersion": "latest",
+      "globals": {
+        "AbortController": false,
+        "AbortSignal": false,
+        "Blob": false,
+        "BroadcastChannel": false,
+        "Buffer": false,
+        "ByteLengthQueuingStrategy": false,
+        "CloseEvent": false,
+        "CompressionStream": false,
+        "CountQueuingStrategy": false,
+        "Crypto": false,
+        "CryptoKey": false,
+        "CustomEvent": false,
+        "DOMException": false,
+        "DecompressionStream": false,
+        "Event": false,
+        "EventTarget": false,
+        "File": false,
+        "FormData": false,
+        "Headers": false,
+        "MessageChannel": false,
+        "MessageEvent": false,
+        "MessagePort": false,
+        "Navigator": false,
+        "Performance": false,
+        "PerformanceEntry": false,
+        "PerformanceMark": false,
+        "PerformanceMeasure": false,
+        "PerformanceObserver": false,
+        "PerformanceObserverEntryList": false,
+        "PerformanceResourceTiming": false,
+        "ReadableByteStreamController": false,
+        "ReadableStream": false,
+        "ReadableStreamBYOBReader": false,
+        "ReadableStreamBYOBRequest": false,
+        "ReadableStreamDefaultController": false,
+        "ReadableStreamDefaultReader": false,
+        "Request": false,
+        "Response": false,
+        "SubtleCrypto": false,
+        "TextDecoder": false,
+        "TextDecoderStream": false,
+        "TextEncoder": false,
+        "TextEncoderStream": false,
+        "TransformStream": false,
+        "TransformStreamDefaultController": false,
+        "URL": false,
+        "URLSearchParams": false,
+        "WebAssembly": false,
+        "WebSocket": false,
+        "WritableStream": false,
+        "WritableStreamDefaultController": false,
+        "WritableStreamDefaultWriter": false,
+        "__dirname": false,
+        "__filename": false,
+        "atob": false,
+        "btoa": false,
+        "clearImmediate": false,
+        "clearInterval": false,
+        "clearTimeout": false,
+        "console": false,
+        "crypto": false,
+        "exports": true,
+        "fetch": false,
+        "global": false,
+        "module": false,
+        "navigator": false,
+        "performance": false,
+        "process": false,
+        "queueMicrotask": false,
+        "require": false,
+        "setImmediate": false,
+        "setInterval": false,
+        "setTimeout": false,
+        "structuredClone": false
+      },
+      "parser": "@qlik/eslint-config/browser-esm-cjs-parser",
+      "parserOptions": {
+        "warnOnUnsupportedTypeScriptVersion": false
+      },
+      "sourceType": "commonjs"
+    },
+    "name": "@qlik/eslint-config/browser-esm-cjs",
+    "plugins": {
+      "@typescript-eslint": "@typescript-eslint-plugin",
+      "import-x": "import-x-plugin"
+    },
+    "rules": {
+      "@babel/object-curly-spacing": "off",
+      "@babel/semi": "off",
+      "@stylistic/array-bracket-newline": "off",
+      "@stylistic/array-bracket-spacing": "off",
+      "@stylistic/array-element-newline": "off",
+      "@stylistic/arrow-parens": "off",
+      "@stylistic/arrow-spacing": "off",
+      "@stylistic/block-spacing": "off",
+      "@stylistic/brace-style": "off",
+      "@stylistic/comma-dangle": "off",
+      "@stylistic/comma-spacing": "off",
+      "@stylistic/comma-style": "off",
+      "@stylistic/computed-property-spacing": "off",
+      "@stylistic/dot-location": "off",
+      "@stylistic/eol-last": "off",
+      "@stylistic/func-call-spacing": "off",
+      "@stylistic/function-call-argument-newline": "off",
+      "@stylistic/function-call-spacing": "off",
+      "@stylistic/function-paren-newline": "off",
+      "@stylistic/generator-star-spacing": "off",
+      "@stylistic/implicit-arrow-linebreak": "off",
+      "@stylistic/indent": "off",
+      "@stylistic/indent-binary-ops": "off",
+      "@stylistic/js/array-bracket-newline": "off",
+      "@stylistic/js/array-bracket-spacing": "off",
+      "@stylistic/js/array-element-newline": "off",
+      "@stylistic/js/arrow-parens": "off",
+      "@stylistic/js/arrow-spacing": "off",
+      "@stylistic/js/block-spacing": "off",
+      "@stylistic/js/brace-style": "off",
+      "@stylistic/js/comma-dangle": "off",
+      "@stylistic/js/comma-spacing": "off",
+      "@stylistic/js/comma-style": "off",
+      "@stylistic/js/computed-property-spacing": "off",
+      "@stylistic/js/dot-location": "off",
+      "@stylistic/js/eol-last": "off",
+      "@stylistic/js/func-call-spacing": "off",
+      "@stylistic/js/function-call-argument-newline": "off",
+      "@stylistic/js/function-call-spacing": "off",
+      "@stylistic/js/function-paren-newline": "off",
+      "@stylistic/js/generator-star-spacing": "off",
+      "@stylistic/js/implicit-arrow-linebreak": "off",
+      "@stylistic/js/indent": "off",
+      "@stylistic/js/jsx-quotes": "off",
+      "@stylistic/js/key-spacing": "off",
+      "@stylistic/js/keyword-spacing": "off",
+      "@stylistic/js/linebreak-style": "off",
+      "@stylistic/js/lines-around-comment": 0,
+      "@stylistic/js/max-len": 0,
+      "@stylistic/js/max-statements-per-line": "off",
+      "@stylistic/js/multiline-ternary": "off",
+      "@stylistic/js/new-parens": "off",
+      "@stylistic/js/newline-per-chained-call": "off",
+      "@stylistic/js/no-confusing-arrow": 0,
+      "@stylistic/js/no-extra-parens": "off",
+      "@stylistic/js/no-extra-semi": "off",
+      "@stylistic/js/no-floating-decimal": "off",
+      "@stylistic/js/no-mixed-operators": 0,
+      "@stylistic/js/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/js/no-multi-spaces": "off",
+      "@stylistic/js/no-multiple-empty-lines": "off",
+      "@stylistic/js/no-tabs": 0,
+      "@stylistic/js/no-trailing-spaces": "off",
+      "@stylistic/js/no-whitespace-before-property": "off",
+      "@stylistic/js/nonblock-statement-body-position": "off",
+      "@stylistic/js/object-curly-newline": "off",
+      "@stylistic/js/object-curly-spacing": "off",
+      "@stylistic/js/object-property-newline": "off",
+      "@stylistic/js/one-var-declaration-per-line": "off",
+      "@stylistic/js/operator-linebreak": "off",
+      "@stylistic/js/padded-blocks": "off",
+      "@stylistic/js/quote-props": "off",
+      "@stylistic/js/quotes": 0,
+      "@stylistic/js/rest-spread-spacing": "off",
+      "@stylistic/js/semi": "off",
+      "@stylistic/js/semi-spacing": "off",
+      "@stylistic/js/semi-style": "off",
+      "@stylistic/js/space-before-blocks": "off",
+      "@stylistic/js/space-before-function-paren": "off",
+      "@stylistic/js/space-in-parens": "off",
+      "@stylistic/js/space-infix-ops": "off",
+      "@stylistic/js/space-unary-ops": "off",
+      "@stylistic/js/switch-colon-spacing": "off",
+      "@stylistic/js/template-curly-spacing": "off",
+      "@stylistic/js/template-tag-spacing": "off",
+      "@stylistic/js/wrap-iife": "off",
+      "@stylistic/js/wrap-regex": "off",
+      "@stylistic/js/yield-star-spacing": "off",
+      "@stylistic/jsx-child-element-spacing": "off",
+      "@stylistic/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx-closing-tag-location": "off",
+      "@stylistic/jsx-curly-newline": "off",
+      "@stylistic/jsx-curly-spacing": "off",
+      "@stylistic/jsx-equals-spacing": "off",
+      "@stylistic/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx-indent": "off",
+      "@stylistic/jsx-indent-props": "off",
+      "@stylistic/jsx-max-props-per-line": "off",
+      "@stylistic/jsx-newline": "off",
+      "@stylistic/jsx-one-expression-per-line": "off",
+      "@stylistic/jsx-props-no-multi-spaces": "off",
+      "@stylistic/jsx-quotes": "off",
+      "@stylistic/jsx-tag-spacing": "off",
+      "@stylistic/jsx-wrap-multilines": "off",
+      "@stylistic/jsx/jsx-child-element-spacing": "off",
+      "@stylistic/jsx/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx/jsx-closing-tag-location": "off",
+      "@stylistic/jsx/jsx-curly-newline": "off",
+      "@stylistic/jsx/jsx-curly-spacing": "off",
+      "@stylistic/jsx/jsx-equals-spacing": "off",
+      "@stylistic/jsx/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx/jsx-indent": "off",
+      "@stylistic/jsx/jsx-indent-props": "off",
+      "@stylistic/jsx/jsx-max-props-per-line": "off",
+      "@stylistic/key-spacing": "off",
+      "@stylistic/keyword-spacing": "off",
+      "@stylistic/linebreak-style": "off",
+      "@stylistic/lines-around-comment": 0,
+      "@stylistic/max-len": 0,
+      "@stylistic/max-statements-per-line": "off",
+      "@stylistic/member-delimiter-style": "off",
+      "@stylistic/multiline-ternary": "off",
+      "@stylistic/new-parens": "off",
+      "@stylistic/newline-per-chained-call": "off",
+      "@stylistic/no-confusing-arrow": 0,
+      "@stylistic/no-extra-parens": "off",
+      "@stylistic/no-extra-semi": "off",
+      "@stylistic/no-floating-decimal": "off",
+      "@stylistic/no-mixed-operators": 0,
+      "@stylistic/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/no-multi-spaces": "off",
+      "@stylistic/no-multiple-empty-lines": "off",
+      "@stylistic/no-tabs": 0,
+      "@stylistic/no-trailing-spaces": "off",
+      "@stylistic/no-whitespace-before-property": "off",
+      "@stylistic/nonblock-statement-body-position": "off",
+      "@stylistic/object-curly-newline": "off",
+      "@stylistic/object-curly-spacing": "off",
+      "@stylistic/object-property-newline": "off",
+      "@stylistic/one-var-declaration-per-line": "off",
+      "@stylistic/operator-linebreak": "off",
+      "@stylistic/padded-blocks": "off",
+      "@stylistic/quote-props": "off",
+      "@stylistic/quotes": 0,
+      "@stylistic/rest-spread-spacing": "off",
+      "@stylistic/semi": "off",
+      "@stylistic/semi-spacing": "off",
+      "@stylistic/semi-style": "off",
+      "@stylistic/space-before-blocks": "off",
+      "@stylistic/space-before-function-paren": "off",
+      "@stylistic/space-in-parens": "off",
+      "@stylistic/space-infix-ops": "off",
+      "@stylistic/space-unary-ops": "off",
+      "@stylistic/switch-colon-spacing": "off",
+      "@stylistic/template-curly-spacing": "off",
+      "@stylistic/template-tag-spacing": "off",
+      "@stylistic/ts/block-spacing": "off",
+      "@stylistic/ts/brace-style": "off",
+      "@stylistic/ts/comma-dangle": "off",
+      "@stylistic/ts/comma-spacing": "off",
+      "@stylistic/ts/func-call-spacing": "off",
+      "@stylistic/ts/function-call-spacing": "off",
+      "@stylistic/ts/indent": "off",
+      "@stylistic/ts/key-spacing": "off",
+      "@stylistic/ts/keyword-spacing": "off",
+      "@stylistic/ts/lines-around-comment": 0,
+      "@stylistic/ts/member-delimiter-style": "off",
+      "@stylistic/ts/no-extra-parens": "off",
+      "@stylistic/ts/no-extra-semi": "off",
+      "@stylistic/ts/object-curly-spacing": "off",
+      "@stylistic/ts/quotes": 0,
+      "@stylistic/ts/semi": "off",
+      "@stylistic/ts/space-before-blocks": "off",
+      "@stylistic/ts/space-before-function-paren": "off",
+      "@stylistic/ts/space-infix-ops": "off",
+      "@stylistic/ts/type-annotation-spacing": "off",
+      "@stylistic/type-annotation-spacing": "off",
+      "@stylistic/type-generic-spacing": "off",
+      "@stylistic/type-named-tuple-spacing": "off",
+      "@stylistic/wrap-iife": "off",
+      "@stylistic/wrap-regex": "off",
+      "@stylistic/yield-star-spacing": "off",
+      "@typescript-eslint/block-spacing": "off",
+      "@typescript-eslint/brace-style": "off",
+      "@typescript-eslint/comma-dangle": "off",
+      "@typescript-eslint/comma-spacing": "off",
+      "@typescript-eslint/func-call-spacing": "off",
+      "@typescript-eslint/indent": "off",
+      "@typescript-eslint/key-spacing": "off",
+      "@typescript-eslint/keyword-spacing": "off",
+      "@typescript-eslint/lines-around-comment": 0,
+      "@typescript-eslint/member-delimiter-style": "off",
+      "@typescript-eslint/no-extra-parens": "off",
+      "@typescript-eslint/no-extra-semi": "off",
+      "@typescript-eslint/object-curly-spacing": "off",
+      "@typescript-eslint/quotes": 0,
+      "@typescript-eslint/semi": "off",
+      "@typescript-eslint/space-before-blocks": "off",
+      "@typescript-eslint/space-before-function-paren": "off",
+      "@typescript-eslint/space-infix-ops": "off",
+      "@typescript-eslint/type-annotation-spacing": "off",
+      "array-bracket-newline": "off",
+      "array-bracket-spacing": "off",
+      "array-callback-return": [
+        "error",
+        {
+          "allowImplicit": true
+        }
+      ],
+      "array-element-newline": "off",
+      "arrow-body-style": "off",
+      "arrow-parens": "off",
+      "arrow-spacing": "off",
+      "babel/object-curly-spacing": "off",
+      "babel/quotes": 0,
+      "babel/semi": "off",
+      "block-scoped-var": "error",
+      "block-spacing": "off",
+      "brace-style": "off",
+      "camelcase": [
+        "error",
+        {
+          "ignoreDestructuring": false,
+          "properties": "never"
+        }
+      ],
+      "class-methods-use-this": [
+        "warn",
+        {
+          "exceptMethods": []
+        }
+      ],
+      "comma-dangle": "off",
+      "comma-spacing": "off",
+      "comma-style": "off",
+      "computed-property-spacing": "off",
+      "consistent-return": "error",
+      "constructor-super": "error",
+      "curly": 0,
+      "default-case": [
+        "error",
+        {
+          "commentPattern": "^no default$"
+        }
+      ],
+      "default-case-last": "error",
+      "default-param-last": "error",
+      "dot-location": "off",
+      "eol-last": "off",
+      "eqeqeq": [
+        "error",
+        "always",
+        {
+          "null": "ignore"
+        }
+      ],
+      "flowtype/boolean-style": "off",
+      "flowtype/delimiter-dangle": "off",
+      "flowtype/generic-spacing": "off",
+      "flowtype/object-type-curly-spacing": "off",
+      "flowtype/object-type-delimiter": "off",
+      "flowtype/quotes": "off",
+      "flowtype/semi": "off",
+      "flowtype/space-after-type-colon": "off",
+      "flowtype/space-before-generic-bracket": "off",
+      "flowtype/space-before-type-colon": "off",
+      "flowtype/union-intersection-spacing": "off",
+      "for-direction": "error",
+      "func-call-spacing": "off",
+      "func-names": "warn",
+      "function-call-argument-newline": "off",
+      "function-paren-newline": "off",
+      "generator-star": "off",
+      "generator-star-spacing": "off",
+      "getter-return": [
+        "error",
+        {
+          "allowImplicit": true
+        }
+      ],
+      "grouped-accessor-pairs": "error",
+      "implicit-arrow-linebreak": "off",
+      "import-x/consistent-type-specifier-style": "off",
+      "import-x/default": "error",
+      "import-x/export": "error",
+      "import-x/extensions": [
+        "error",
+        "ignorePackages",
+        {
+          "cjs": "never",
+          "cts": "never",
+          "js": "never",
+          "jsx": "never",
+          "mjs": "never",
+          "mts": "never",
+          "ts": "never",
+          "tsx": "never"
+        }
+      ],
+      "import-x/named": "error",
+      "import-x/namespace": "error",
+      "import-x/newline-after-import": "error",
+      "import-x/no-absolute-path": "error",
+      "import-x/no-amd": "error",
+      "import-x/no-cycle": [
+        "error",
+        {
+          "ignoreExternal": true
+        }
+      ],
+      "import-x/no-deprecated": "warn",
+      "import-x/no-duplicates": "error",
+      "import-x/no-dynamic-require": "error",
+      "import-x/no-empty-named-blocks": "off",
+      "import-x/no-extraneous-dependencies": [
+        "off",
+        {
+          "devDependencies": [
+            "**/test*/**",
+            "**/mocks/**",
+            "**/mock/**",
+            "test/**",
+            "tests/**",
+            "spec/**",
+            "**/__tests__/**",
+            "**/__mocks__/**",
+            "test.{js,jsx,ts,tsx}",
+            "test-*.{js,jsx,ts,tsx}",
+            "**/*{.,_}{test,spec}.{js,jsx,ts,tsx}",
+            "**/jest.config.{cjs,mjs,js,ts}",
+            "**/jest.setup.{cjs,mjs,js,ts}",
+            "**/vitest.config.{cjs,mjs,js,ts}",
+            "**/vue.config.{cjs,mjs,js,ts}",
+            "**/svelte.config.{cjs,mjs,js,ts}",
+            "**/tsup.config.{cjs,mjs,js,ts}",
+            "**/playwright.config.{cjs,mjs,js,ts}",
+            "**/webpack.config.{cjs,mjs,js,ts}",
+            "**/webpack.mod.{cjs,mjs,js,ts}",
+            "**/rollup.config.{cjs,mjs,js,ts}",
+            "**/rollup.config.*cjs,mjs,.{js,ts}",
+            "**/protractor.conf.{cjs,mjs,js,ts}",
+            "**/protractor.conf.*.{cjs,mjs,js,ts}",
+            "**/.eslintrc.{cjs,mjs,js,ts}",
+            "**/eslint.config.{cjs,mjs,js,ts}",
+            "**/.prettierrc.{cjs,mjs,js,ts}",
+            "**/.prettierrc"
+          ],
+          "optionalDependencies": false
+        }
+      ],
+      "import-x/no-import-module-exports": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "import-x/no-mutable-exports": "error",
+      "import-x/no-named-as-default": "error",
+      "import-x/no-named-as-default-member": "off",
+      "import-x/no-named-default": "error",
+      "import-x/no-nodejs-modules": "off",
+      "import-x/no-relative-packages": "error",
+      "import-x/no-self-import": "error",
+      "import-x/no-unresolved": [
+        "error",
+        {
+          "caseSensitive": true,
+          "commonjs": true
+        }
+      ],
+      "import-x/no-unused-modules": "error",
+      "import-x/no-useless-path-segments": [
+        "error",
+        {
+          "commonjs": true
+        }
+      ],
+      "import-x/no-webpack-loader-syntax": "error",
+      "import-x/prefer-default-export": "off",
+      "indent": "off",
+      "indent-legacy": "off",
+      "jsx-quotes": "off",
+      "key-spacing": "off",
+      "keyword-spacing": "off",
+      "linebreak-style": "off",
+      "lines-around-comment": 0,
+      "max-classes-per-file": [
+        "error",
+        1
+      ],
+      "max-len": 0,
+      "max-statements-per-line": "off",
+      "multiline-ternary": "off",
+      "new-cap": [
+        "error",
+        {
+          "capIsNew": false,
+          "capIsNewExceptions": [
+            "Immutable.Map",
+            "Immutable.Set",
+            "Immutable.List"
+          ],
+          "newIsCap": true,
+          "newIsCapExceptions": []
+        }
+      ],
+      "new-parens": "off",
+      "newline-per-chained-call": "off",
+      "no-alert": "error",
+      "no-array-constructor": "error",
+      "no-arrow-condition": "off",
+      "no-async-promise-executor": "error",
+      "no-await-in-loop": "error",
+      "no-bitwise": "error",
+      "no-caller": "error",
+      "no-case-declarations": "error",
+      "no-class-assign": "error",
+      "no-comma-dangle": "off",
+      "no-compare-neg-zero": "error",
+      "no-cond-assign": [
+        "error",
+        "always"
+      ],
+      "no-confusing-arrow": 0,
+      "no-console": "off",
+      "no-const-assign": "error",
+      "no-constant-binary-expression": "error",
+      "no-constant-condition": "warn",
+      "no-constructor-return": "error",
+      "no-continue": "error",
+      "no-control-regex": "error",
+      "no-debugger": "error",
+      "no-delete-var": "error",
+      "no-dupe-args": "error",
+      "no-dupe-class-members": "error",
+      "no-dupe-else-if": "error",
+      "no-dupe-keys": "error",
+      "no-duplicate-case": "error",
+      "no-else-return": [
+        "error",
+        {
+          "allowElseIf": false
+        }
+      ],
+      "no-empty": "error",
+      "no-empty-character-class": "error",
+      "no-empty-function": [
+        "error",
+        {
+          "allow": [
+            "arrowFunctions",
+            "functions",
+            "methods"
+          ]
+        }
+      ],
+      "no-empty-pattern": "error",
+      "no-empty-static-block": "error",
+      "no-eval": "error",
+      "no-ex-assign": "error",
+      "no-extend-native": "error",
+      "no-extra-bind": "error",
+      "no-extra-boolean-cast": "error",
+      "no-extra-label": "error",
+      "no-extra-parens": "off",
+      "no-extra-semi": "off",
+      "no-fallthrough": "error",
+      "no-floating-decimal": "off",
+      "no-func-assign": "error",
+      "no-global-assign": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "no-implied-eval": "error",
+      "no-import-assign": "error",
+      "no-inner-declarations": "error",
+      "no-invalid-regexp": "error",
+      "no-irregular-whitespace": "error",
+      "no-iterator": "error",
+      "no-label-var": "error",
+      "no-labels": [
+        "error",
+        {
+          "allowLoop": false,
+          "allowSwitch": false
+        }
+      ],
+      "no-lone-blocks": "error",
+      "no-lonely-if": "error",
+      "no-loop-func": "error",
+      "no-loss-of-precision": "error",
+      "no-magic-numbers": "off",
+      "no-misleading-character-class": "error",
+      "no-mixed-operators": 0,
+      "no-mixed-spaces-and-tabs": "off",
+      "no-multi-assign": [
+        "error"
+      ],
+      "no-multi-spaces": "off",
+      "no-multi-str": "error",
+      "no-multiple-empty-lines": "off",
+      "no-nested-ternary": "error",
+      "no-new": "error",
+      "no-new-func": "error",
+      "no-new-native-nonconstructor": "error",
+      "no-new-wrappers": "error",
+      "no-nonoctal-decimal-escape": "error",
+      "no-obj-calls": "error",
+      "no-object-constructor": "error",
+      "no-octal": "error",
+      "no-octal-escape": "error",
+      "no-param-reassign": [
+        "error",
+        {
+          "ignorePropertyModificationsFor": [
+            "prev",
+            "acc",
+            "accumulator",
+            "e",
+            "ctx",
+            "context",
+            "req",
+            "request",
+            "res",
+            "response",
+            "$scope",
+            "staticContext",
+            "sharedState",
+            "state"
+          ],
+          "props": true
+        }
+      ],
+      "no-promise-executor-return": "error",
+      "no-proto": "error",
+      "no-prototype-builtins": "error",
+      "no-redeclare": "error",
+      "no-regex-spaces": "error",
+      "no-reserved-keys": "off",
+      "no-restricted-exports": [
+        "error",
+        {
+          "restrictedNamedExports": [
+            "default",
+            "then"
+          ]
+        }
+      ],
+      "no-restricted-globals": [
+        "error",
+        {
+          "message": "Use Number.isFinite instead",
+          "name": "isFinite"
+        },
+        {
+          "message": "Use Number.isNaN instead",
+          "name": "isNaN"
+        },
+        {
+          "message": "Use window.addEventListener instead",
+          "name": "addEventListener"
+        },
+        {
+          "message": "Use window.blur instead",
+          "name": "blur"
+        },
+        {
+          "message": "Use window.close instead",
+          "name": "close"
+        },
+        {
+          "message": "Use window.closed instead",
+          "name": "closed"
+        },
+        {
+          "message": "Use window.confirm instead",
+          "name": "confirm"
+        },
+        {
+          "message": "Use window.defaultStatus instead",
+          "name": "defaultStatus"
+        },
+        {
+          "message": "Use window.defaultstatus instead",
+          "name": "defaultstatus"
+        },
+        {
+          "message": "Use window.event instead",
+          "name": "event"
+        },
+        {
+          "message": "Use window.external instead",
+          "name": "external"
+        },
+        {
+          "message": "Use window.find instead",
+          "name": "find"
+        },
+        {
+          "message": "Use window.focus instead",
+          "name": "focus"
+        },
+        {
+          "message": "Use window.frameElement instead",
+          "name": "frameElement"
+        },
+        {
+          "message": "Use window.frames instead",
+          "name": "frames"
+        },
+        {
+          "message": "Use window.history instead",
+          "name": "history"
+        },
+        {
+          "message": "Use window.innerHeight instead",
+          "name": "innerHeight"
+        },
+        {
+          "message": "Use window.innerWidth instead",
+          "name": "innerWidth"
+        },
+        {
+          "message": "Use window.length instead",
+          "name": "length"
+        },
+        {
+          "message": "Use window.location instead",
+          "name": "location"
+        },
+        {
+          "message": "Use window.locationbar instead",
+          "name": "locationbar"
+        },
+        {
+          "message": "Use window.menubar instead",
+          "name": "menubar"
+        },
+        {
+          "message": "Use window.moveBy instead",
+          "name": "moveBy"
+        },
+        {
+          "message": "Use window.moveTo instead",
+          "name": "moveTo"
+        },
+        {
+          "message": "Use window.name instead",
+          "name": "name"
+        },
+        {
+          "message": "Use window.onblur instead",
+          "name": "onblur"
+        },
+        {
+          "message": "Use window.onerror instead",
+          "name": "onerror"
+        },
+        {
+          "message": "Use window.onfocus instead",
+          "name": "onfocus"
+        },
+        {
+          "message": "Use window.onload instead",
+          "name": "onload"
+        },
+        {
+          "message": "Use window.onresize instead",
+          "name": "onresize"
+        },
+        {
+          "message": "Use window.onunload instead",
+          "name": "onunload"
+        },
+        {
+          "message": "Use window.open instead",
+          "name": "open"
+        },
+        {
+          "message": "Use window.opener instead",
+          "name": "opener"
+        },
+        {
+          "message": "Use window.opera instead",
+          "name": "opera"
+        },
+        {
+          "message": "Use window.outerHeight instead",
+          "name": "outerHeight"
+        },
+        {
+          "message": "Use window.outerWidth instead",
+          "name": "outerWidth"
+        },
+        {
+          "message": "Use window.pageXOffset instead",
+          "name": "pageXOffset"
+        },
+        {
+          "message": "Use window.pageYOffset instead",
+          "name": "pageYOffset"
+        },
+        {
+          "message": "Use window.parent instead",
+          "name": "parent"
+        },
+        {
+          "message": "Use window.print instead",
+          "name": "print"
+        },
+        {
+          "message": "Use window.removeEventListener instead",
+          "name": "removeEventListener"
+        },
+        {
+          "message": "Use window.resizeBy instead",
+          "name": "resizeBy"
+        },
+        {
+          "message": "Use window.resizeTo instead",
+          "name": "resizeTo"
+        },
+        {
+          "message": "Use window.screen instead",
+          "name": "screen"
+        },
+        {
+          "message": "Use window.screenLeft instead",
+          "name": "screenLeft"
+        },
+        {
+          "message": "Use window.screenTop instead",
+          "name": "screenTop"
+        },
+        {
+          "message": "Use window.screenX instead",
+          "name": "screenX"
+        },
+        {
+          "message": "Use window.screenY instead",
+          "name": "screenY"
+        },
+        {
+          "message": "Use window.scroll instead",
+          "name": "scroll"
+        },
+        {
+          "message": "Use window.scrollbars instead",
+          "name": "scrollbars"
+        },
+        {
+          "message": "Use window.scrollBy instead",
+          "name": "scrollBy"
+        },
+        {
+          "message": "Use window.scrollTo instead",
+          "name": "scrollTo"
+        },
+        {
+          "message": "Use window.scrollX instead",
+          "name": "scrollX"
+        },
+        {
+          "message": "Use window.scrollY instead",
+          "name": "scrollY"
+        },
+        {
+          "message": "Use window.self instead",
+          "name": "self"
+        },
+        {
+          "message": "Use window.status instead",
+          "name": "status"
+        },
+        {
+          "message": "Use window.statusbar instead",
+          "name": "statusbar"
+        },
+        {
+          "message": "Use window.stop instead",
+          "name": "stop"
+        },
+        {
+          "message": "Use window.toolbar instead",
+          "name": "toolbar"
+        },
+        {
+          "message": "Use window.top instead",
+          "name": "top"
+        }
+      ],
+      "no-restricted-imports": [
+        "off",
+        {
+          "paths": [],
+          "patterns": []
+        }
+      ],
+      "no-restricted-properties": [
+        "error",
+        {
+          "message": "arguments.callee is deprecated",
+          "object": "arguments",
+          "property": "callee"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "global",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "self",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "window",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "global",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "self",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "window",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineGetter__"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineSetter__"
+        },
+        {
+          "message": "Use the exponentiation operator (**) instead.",
+          "object": "Math",
+          "property": "pow"
+        }
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.",
+          "selector": "LabeledStatement"
+        },
+        {
+          "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
+          "selector": "WithStatement"
+        }
+      ],
+      "no-return-assign": [
+        "error",
+        "always"
+      ],
+      "no-script-url": "error",
+      "no-self-assign": [
+        "error",
+        {
+          "props": true
+        }
+      ],
+      "no-self-compare": "error",
+      "no-sequences": "error",
+      "no-setter-return": "error",
+      "no-shadow": "error",
+      "no-shadow-restricted-names": "error",
+      "no-space-before-semi": "off",
+      "no-spaced-func": "off",
+      "no-sparse-arrays": "error",
+      "no-tabs": 0,
+      "no-template-curly-in-string": "error",
+      "no-this-before-super": "error",
+      "no-throw-literal": "error",
+      "no-trailing-spaces": "off",
+      "no-undef": "error",
+      "no-undef-init": "error",
+      "no-underscore-dangle": "off",
+      "no-unexpected-multiline": 0,
+      "no-unmodified-loop-condition": "error",
+      "no-unneeded-ternary": [
+        "error",
+        {
+          "defaultAssignment": false
+        }
+      ],
+      "no-unreachable": "error",
+      "no-unreachable-loop": [
+        "error",
+        {
+          "ignore": []
+        }
+      ],
+      "no-unsafe-finally": "error",
+      "no-unsafe-negation": "error",
+      "no-unsafe-optional-chaining": [
+        "error",
+        {
+          "disallowArithmeticOperators": true
+        }
+      ],
+      "no-unused-expressions": [
+        "error",
+        {
+          "allowShortCircuit": false,
+          "allowTaggedTemplates": false,
+          "allowTernary": false
+        }
+      ],
+      "no-unused-labels": "error",
+      "no-unused-private-class-members": "error",
+      "no-unused-vars": [
+        "error",
+        {
+          "args": "after-used",
+          "ignoreRestSiblings": true,
+          "vars": "all"
+        }
+      ],
+      "no-useless-backreference": "error",
+      "no-useless-call": "error",
+      "no-useless-catch": "error",
+      "no-useless-computed-key": "error",
+      "no-useless-concat": "error",
+      "no-useless-constructor": "error",
+      "no-useless-escape": "error",
+      "no-useless-rename": [
+        "error",
+        {
+          "ignoreDestructuring": false,
+          "ignoreExport": false,
+          "ignoreImport": false
+        }
+      ],
+      "no-useless-return": "error",
+      "no-var": "error",
+      "no-whitespace-before-property": "off",
+      "no-with": "error",
+      "no-wrap-func": "off",
+      "nonblock-statement-body-position": "off",
+      "object-curly-newline": "off",
+      "object-curly-spacing": "off",
+      "object-property-newline": "off",
+      "object-shorthand": [
+        "error",
+        "always",
+        {
+          "avoidQuotes": true,
+          "ignoreConstructors": false
+        }
+      ],
+      "one-var": [
+        "error",
+        "never"
+      ],
+      "one-var-declaration-per-line": "off",
+      "operator-assignment": [
+        "error",
+        "always"
+      ],
+      "operator-linebreak": "off",
+      "padded-blocks": "off",
+      "prefer-arrow-callback": "off",
+      "prefer-const": [
+        "error",
+        {
+          "destructuring": "any",
+          "ignoreReadBeforeAssign": true
+        }
+      ],
+      "prefer-exponentiation-operator": "error",
+      "prefer-numeric-literals": "error",
+      "prefer-object-has-own": "error",
+      "prefer-object-spread": "error",
+      "prefer-promise-reject-errors": [
+        "error",
+        {
+          "allowEmptyReject": true
+        }
+      ],
+      "prefer-regex-literals": [
+        "error",
+        {
+          "disallowRedundantWrapping": true
+        }
+      ],
+      "prefer-rest-params": "error",
+      "prefer-spread": "error",
+      "prefer-template": "error",
+      "quote-props": "off",
+      "quotes": 0,
+      "radix": "error",
+      "react/jsx-child-element-spacing": "off",
+      "react/jsx-closing-bracket-location": "off",
+      "react/jsx-closing-tag-location": "off",
+      "react/jsx-curly-newline": "off",
+      "react/jsx-curly-spacing": "off",
+      "react/jsx-equals-spacing": "off",
+      "react/jsx-first-prop-new-line": "off",
+      "react/jsx-indent": "off",
+      "react/jsx-indent-props": "off",
+      "react/jsx-max-props-per-line": "off",
+      "react/jsx-newline": "off",
+      "react/jsx-one-expression-per-line": "off",
+      "react/jsx-props-no-multi-spaces": "off",
+      "react/jsx-space-before-closing": "off",
+      "react/jsx-tag-spacing": "off",
+      "react/jsx-wrap-multilines": "off",
+      "require-atomic-updates": "error",
+      "require-yield": "error",
+      "rest-spread-spacing": "off",
+      "semi": "off",
+      "semi-spacing": "off",
+      "semi-style": "off",
+      "space-after-function-name": "off",
+      "space-after-keywords": "off",
+      "space-before-blocks": "off",
+      "space-before-function-paren": "off",
+      "space-before-function-parentheses": "off",
+      "space-before-keywords": "off",
+      "space-in-brackets": "off",
+      "space-in-parens": "off",
+      "space-infix-ops": "off",
+      "space-return-throw-case": "off",
+      "space-unary-ops": "off",
+      "space-unary-word-ops": "off",
+      "standard/array-bracket-even-spacing": "off",
+      "standard/computed-property-even-spacing": "off",
+      "standard/object-curly-even-spacing": "off",
+      "switch-colon-spacing": "off",
+      "symbol-description": "error",
+      "template-curly-spacing": "off",
+      "template-tag-spacing": "off",
+      "unicode-bom": [
+        "error",
+        "never"
+      ],
+      "unicorn/empty-brace-spaces": "off",
+      "unicorn/no-nested-ternary": "off",
+      "unicorn/number-literal-case": "off",
+      "unicorn/template-indent": 0,
+      "use-isnan": "error",
+      "valid-typeof": [
+        "error",
+        {
+          "requireStringLiterals": true
+        }
+      ],
+      "vue/array-bracket-newline": "off",
+      "vue/array-bracket-spacing": "off",
+      "vue/array-element-newline": "off",
+      "vue/arrow-spacing": "off",
+      "vue/block-spacing": "off",
+      "vue/block-tag-newline": "off",
+      "vue/brace-style": "off",
+      "vue/comma-dangle": "off",
+      "vue/comma-spacing": "off",
+      "vue/comma-style": "off",
+      "vue/dot-location": "off",
+      "vue/func-call-spacing": "off",
+      "vue/html-closing-bracket-newline": "off",
+      "vue/html-closing-bracket-spacing": "off",
+      "vue/html-end-tags": "off",
+      "vue/html-indent": "off",
+      "vue/html-quotes": "off",
+      "vue/html-self-closing": 0,
+      "vue/key-spacing": "off",
+      "vue/keyword-spacing": "off",
+      "vue/max-attributes-per-line": "off",
+      "vue/max-len": 0,
+      "vue/multiline-html-element-content-newline": "off",
+      "vue/multiline-ternary": "off",
+      "vue/mustache-interpolation-spacing": "off",
+      "vue/no-extra-parens": "off",
+      "vue/no-multi-spaces": "off",
+      "vue/no-spaces-around-equal-signs-in-attribute": "off",
+      "vue/object-curly-newline": "off",
+      "vue/object-curly-spacing": "off",
+      "vue/object-property-newline": "off",
+      "vue/operator-linebreak": "off",
+      "vue/quote-props": "off",
+      "vue/script-indent": "off",
+      "vue/singleline-html-element-content-newline": "off",
+      "vue/space-in-parens": "off",
+      "vue/space-infix-ops": "off",
+      "vue/space-unary-ops": "off",
+      "vue/template-curly-spacing": "off",
+      "wrap-iife": "off",
+      "wrap-regex": "off",
+      "yield-star-spacing": "off",
+      "yoda": "error"
+    }
+  },
+  {
+    "files": [
+      "**/*.cts"
+    ],
+    "languageOptions": {
+      "ecmaVersion": "latest",
+      "globals": {
+        "AbortController": false,
+        "AbortSignal": false,
+        "Blob": false,
+        "BroadcastChannel": false,
+        "Buffer": false,
+        "ByteLengthQueuingStrategy": false,
+        "CloseEvent": false,
+        "CompressionStream": false,
+        "CountQueuingStrategy": false,
+        "Crypto": false,
+        "CryptoKey": false,
+        "CustomEvent": false,
+        "DOMException": false,
+        "DecompressionStream": false,
+        "Event": false,
+        "EventTarget": false,
+        "File": false,
+        "FormData": false,
+        "Headers": false,
+        "MessageChannel": false,
+        "MessageEvent": false,
+        "MessagePort": false,
+        "Navigator": false,
+        "Performance": false,
+        "PerformanceEntry": false,
+        "PerformanceMark": false,
+        "PerformanceMeasure": false,
+        "PerformanceObserver": false,
+        "PerformanceObserverEntryList": false,
+        "PerformanceResourceTiming": false,
+        "ReadableByteStreamController": false,
+        "ReadableStream": false,
+        "ReadableStreamBYOBReader": false,
+        "ReadableStreamBYOBRequest": false,
+        "ReadableStreamDefaultController": false,
+        "ReadableStreamDefaultReader": false,
+        "Request": false,
+        "Response": false,
+        "SubtleCrypto": false,
+        "TextDecoder": false,
+        "TextDecoderStream": false,
+        "TextEncoder": false,
+        "TextEncoderStream": false,
+        "TransformStream": false,
+        "TransformStreamDefaultController": false,
+        "URL": false,
+        "URLSearchParams": false,
+        "WebAssembly": false,
+        "WebSocket": false,
+        "WritableStream": false,
+        "WritableStreamDefaultController": false,
+        "WritableStreamDefaultWriter": false,
+        "__dirname": false,
+        "__filename": false,
+        "atob": false,
+        "btoa": false,
+        "clearImmediate": false,
+        "clearInterval": false,
+        "clearTimeout": false,
+        "console": false,
+        "crypto": false,
+        "exports": true,
+        "fetch": false,
+        "global": false,
+        "module": false,
+        "navigator": false,
+        "performance": false,
+        "process": false,
+        "queueMicrotask": false,
+        "require": false,
+        "setImmediate": false,
+        "setInterval": false,
+        "setTimeout": false,
+        "structuredClone": false
+      },
+      "parser": "@qlik/eslint-config/browser-esm-cts-parser",
+      "parserOptions": {
+        "parser": {
+          "meta": {
+            "name": "typescript-eslint/parser",
+            "version": "8.28.0"
+          },
+          "version": "8.28.0"
+        },
+        "projectService": true,
+        "warnOnUnsupportedTypeScriptVersion": false
+      },
+      "sourceType": "commonjs"
+    },
+    "name": "@qlik/eslint-config/browser-esm-cts",
+    "plugins": {
+      "@typescript-eslint": "@typescript-eslint-plugin",
+      "import-x": "import-x-plugin"
+    },
+    "rules": {
+      "@babel/object-curly-spacing": "off",
+      "@babel/semi": "off",
+      "@stylistic/array-bracket-newline": "off",
+      "@stylistic/array-bracket-spacing": "off",
+      "@stylistic/array-element-newline": "off",
+      "@stylistic/arrow-parens": "off",
+      "@stylistic/arrow-spacing": "off",
+      "@stylistic/block-spacing": "off",
+      "@stylistic/brace-style": "off",
+      "@stylistic/comma-dangle": "off",
+      "@stylistic/comma-spacing": "off",
+      "@stylistic/comma-style": "off",
+      "@stylistic/computed-property-spacing": "off",
+      "@stylistic/dot-location": "off",
+      "@stylistic/eol-last": "off",
+      "@stylistic/func-call-spacing": "off",
+      "@stylistic/function-call-argument-newline": "off",
+      "@stylistic/function-call-spacing": "off",
+      "@stylistic/function-paren-newline": "off",
+      "@stylistic/generator-star-spacing": "off",
+      "@stylistic/implicit-arrow-linebreak": "off",
+      "@stylistic/indent": "off",
+      "@stylistic/indent-binary-ops": "off",
+      "@stylistic/js/array-bracket-newline": "off",
+      "@stylistic/js/array-bracket-spacing": "off",
+      "@stylistic/js/array-element-newline": "off",
+      "@stylistic/js/arrow-parens": "off",
+      "@stylistic/js/arrow-spacing": "off",
+      "@stylistic/js/block-spacing": "off",
+      "@stylistic/js/brace-style": "off",
+      "@stylistic/js/comma-dangle": "off",
+      "@stylistic/js/comma-spacing": "off",
+      "@stylistic/js/comma-style": "off",
+      "@stylistic/js/computed-property-spacing": "off",
+      "@stylistic/js/dot-location": "off",
+      "@stylistic/js/eol-last": "off",
+      "@stylistic/js/func-call-spacing": "off",
+      "@stylistic/js/function-call-argument-newline": "off",
+      "@stylistic/js/function-call-spacing": "off",
+      "@stylistic/js/function-paren-newline": "off",
+      "@stylistic/js/generator-star-spacing": "off",
+      "@stylistic/js/implicit-arrow-linebreak": "off",
+      "@stylistic/js/indent": "off",
+      "@stylistic/js/jsx-quotes": "off",
+      "@stylistic/js/key-spacing": "off",
+      "@stylistic/js/keyword-spacing": "off",
+      "@stylistic/js/linebreak-style": "off",
+      "@stylistic/js/lines-around-comment": 0,
+      "@stylistic/js/max-len": 0,
+      "@stylistic/js/max-statements-per-line": "off",
+      "@stylistic/js/multiline-ternary": "off",
+      "@stylistic/js/new-parens": "off",
+      "@stylistic/js/newline-per-chained-call": "off",
+      "@stylistic/js/no-confusing-arrow": 0,
+      "@stylistic/js/no-extra-parens": "off",
+      "@stylistic/js/no-extra-semi": "off",
+      "@stylistic/js/no-floating-decimal": "off",
+      "@stylistic/js/no-mixed-operators": 0,
+      "@stylistic/js/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/js/no-multi-spaces": "off",
+      "@stylistic/js/no-multiple-empty-lines": "off",
+      "@stylistic/js/no-tabs": 0,
+      "@stylistic/js/no-trailing-spaces": "off",
+      "@stylistic/js/no-whitespace-before-property": "off",
+      "@stylistic/js/nonblock-statement-body-position": "off",
+      "@stylistic/js/object-curly-newline": "off",
+      "@stylistic/js/object-curly-spacing": "off",
+      "@stylistic/js/object-property-newline": "off",
+      "@stylistic/js/one-var-declaration-per-line": "off",
+      "@stylistic/js/operator-linebreak": "off",
+      "@stylistic/js/padded-blocks": "off",
+      "@stylistic/js/quote-props": "off",
+      "@stylistic/js/quotes": 0,
+      "@stylistic/js/rest-spread-spacing": "off",
+      "@stylistic/js/semi": "off",
+      "@stylistic/js/semi-spacing": "off",
+      "@stylistic/js/semi-style": "off",
+      "@stylistic/js/space-before-blocks": "off",
+      "@stylistic/js/space-before-function-paren": "off",
+      "@stylistic/js/space-in-parens": "off",
+      "@stylistic/js/space-infix-ops": "off",
+      "@stylistic/js/space-unary-ops": "off",
+      "@stylistic/js/switch-colon-spacing": "off",
+      "@stylistic/js/template-curly-spacing": "off",
+      "@stylistic/js/template-tag-spacing": "off",
+      "@stylistic/js/wrap-iife": "off",
+      "@stylistic/js/wrap-regex": "off",
+      "@stylistic/js/yield-star-spacing": "off",
+      "@stylistic/jsx-child-element-spacing": "off",
+      "@stylistic/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx-closing-tag-location": "off",
+      "@stylistic/jsx-curly-newline": "off",
+      "@stylistic/jsx-curly-spacing": "off",
+      "@stylistic/jsx-equals-spacing": "off",
+      "@stylistic/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx-indent": "off",
+      "@stylistic/jsx-indent-props": "off",
+      "@stylistic/jsx-max-props-per-line": "off",
+      "@stylistic/jsx-newline": "off",
+      "@stylistic/jsx-one-expression-per-line": "off",
+      "@stylistic/jsx-props-no-multi-spaces": "off",
+      "@stylistic/jsx-quotes": "off",
+      "@stylistic/jsx-tag-spacing": "off",
+      "@stylistic/jsx-wrap-multilines": "off",
+      "@stylistic/jsx/jsx-child-element-spacing": "off",
+      "@stylistic/jsx/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx/jsx-closing-tag-location": "off",
+      "@stylistic/jsx/jsx-curly-newline": "off",
+      "@stylistic/jsx/jsx-curly-spacing": "off",
+      "@stylistic/jsx/jsx-equals-spacing": "off",
+      "@stylistic/jsx/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx/jsx-indent": "off",
+      "@stylistic/jsx/jsx-indent-props": "off",
+      "@stylistic/jsx/jsx-max-props-per-line": "off",
+      "@stylistic/key-spacing": "off",
+      "@stylistic/keyword-spacing": "off",
+      "@stylistic/linebreak-style": "off",
+      "@stylistic/lines-around-comment": 0,
+      "@stylistic/max-len": 0,
+      "@stylistic/max-statements-per-line": "off",
+      "@stylistic/member-delimiter-style": "off",
+      "@stylistic/multiline-ternary": "off",
+      "@stylistic/new-parens": "off",
+      "@stylistic/newline-per-chained-call": "off",
+      "@stylistic/no-confusing-arrow": 0,
+      "@stylistic/no-extra-parens": "off",
+      "@stylistic/no-extra-semi": "off",
+      "@stylistic/no-floating-decimal": "off",
+      "@stylistic/no-mixed-operators": 0,
+      "@stylistic/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/no-multi-spaces": "off",
+      "@stylistic/no-multiple-empty-lines": "off",
+      "@stylistic/no-tabs": 0,
+      "@stylistic/no-trailing-spaces": "off",
+      "@stylistic/no-whitespace-before-property": "off",
+      "@stylistic/nonblock-statement-body-position": "off",
+      "@stylistic/object-curly-newline": "off",
+      "@stylistic/object-curly-spacing": "off",
+      "@stylistic/object-property-newline": "off",
+      "@stylistic/one-var-declaration-per-line": "off",
+      "@stylistic/operator-linebreak": "off",
+      "@stylistic/padded-blocks": "off",
+      "@stylistic/quote-props": "off",
+      "@stylistic/quotes": 0,
+      "@stylistic/rest-spread-spacing": "off",
+      "@stylistic/semi": "off",
+      "@stylistic/semi-spacing": "off",
+      "@stylistic/semi-style": "off",
+      "@stylistic/space-before-blocks": "off",
+      "@stylistic/space-before-function-paren": "off",
+      "@stylistic/space-in-parens": "off",
+      "@stylistic/space-infix-ops": "off",
+      "@stylistic/space-unary-ops": "off",
+      "@stylistic/switch-colon-spacing": "off",
+      "@stylistic/template-curly-spacing": "off",
+      "@stylistic/template-tag-spacing": "off",
+      "@stylistic/ts/block-spacing": "off",
+      "@stylistic/ts/brace-style": "off",
+      "@stylistic/ts/comma-dangle": "off",
+      "@stylistic/ts/comma-spacing": "off",
+      "@stylistic/ts/func-call-spacing": "off",
+      "@stylistic/ts/function-call-spacing": "off",
+      "@stylistic/ts/indent": "off",
+      "@stylistic/ts/key-spacing": "off",
+      "@stylistic/ts/keyword-spacing": "off",
+      "@stylistic/ts/lines-around-comment": 0,
+      "@stylistic/ts/member-delimiter-style": "off",
+      "@stylistic/ts/no-extra-parens": "off",
+      "@stylistic/ts/no-extra-semi": "off",
+      "@stylistic/ts/object-curly-spacing": "off",
+      "@stylistic/ts/quotes": 0,
+      "@stylistic/ts/semi": "off",
+      "@stylistic/ts/space-before-blocks": "off",
+      "@stylistic/ts/space-before-function-paren": "off",
+      "@stylistic/ts/space-infix-ops": "off",
+      "@stylistic/ts/type-annotation-spacing": "off",
+      "@stylistic/type-annotation-spacing": "off",
+      "@stylistic/type-generic-spacing": "off",
+      "@stylistic/type-named-tuple-spacing": "off",
+      "@stylistic/wrap-iife": "off",
+      "@stylistic/wrap-regex": "off",
+      "@stylistic/yield-star-spacing": "off",
+      "@typescript-eslint/ban-ts-comment": "error",
+      "@typescript-eslint/block-spacing": "off",
+      "@typescript-eslint/brace-style": "off",
+      "@typescript-eslint/class-methods-use-this": [
+        "warn",
+        {
+          "exceptMethods": []
+        }
+      ],
+      "@typescript-eslint/comma-dangle": "off",
+      "@typescript-eslint/comma-spacing": "off",
+      "@typescript-eslint/consistent-type-exports": "error",
+      "@typescript-eslint/consistent-type-imports": "error",
+      "@typescript-eslint/default-param-last": "error",
+      "@typescript-eslint/explicit-module-boundary-types": "off",
+      "@typescript-eslint/func-call-spacing": "off",
+      "@typescript-eslint/indent": "off",
+      "@typescript-eslint/key-spacing": "off",
+      "@typescript-eslint/keyword-spacing": "off",
+      "@typescript-eslint/lines-around-comment": 0,
+      "@typescript-eslint/member-delimiter-style": "off",
+      "@typescript-eslint/method-signature-style": "error",
+      "@typescript-eslint/naming-convention": [
+        "error",
+        {
+          "format": [
+            "camelCase",
+            "PascalCase",
+            "UPPER_CASE"
+          ],
+          "selector": "variable"
+        },
+        {
+          "format": [
+            "camelCase",
+            "PascalCase"
+          ],
+          "selector": "function"
+        },
+        {
+          "format": [
+            "PascalCase"
+          ],
+          "selector": "typeLike"
+        }
+      ],
+      "@typescript-eslint/no-array-constructor": "error",
+      "@typescript-eslint/no-confusing-void-expression": "error",
+      "@typescript-eslint/no-duplicate-enum-values": "error",
+      "@typescript-eslint/no-dynamic-delete": "error",
+      "@typescript-eslint/no-empty-object-type": "error",
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/no-extra-non-null-assertion": "error",
+      "@typescript-eslint/no-extra-parens": "off",
+      "@typescript-eslint/no-extra-semi": "off",
+      "@typescript-eslint/no-extraneous-class": "error",
+      "@typescript-eslint/no-floating-promises": [
+        "error",
+        {
+          "ignoreIIFE": true
+        }
+      ],
+      "@typescript-eslint/no-import-type-side-effects": "error",
+      "@typescript-eslint/no-invalid-void-type": "error",
+      "@typescript-eslint/no-loop-func": "error",
+      "@typescript-eslint/no-magic-numbers": "off",
+      "@typescript-eslint/no-meaningless-void-operator": "error",
+      "@typescript-eslint/no-misused-new": "error",
+      "@typescript-eslint/no-misused-promises": [
+        "error",
+        {
+          "checksConditionals": false
+        }
+      ],
+      "@typescript-eslint/no-mixed-enums": "error",
+      "@typescript-eslint/no-namespace": "error",
+      "@typescript-eslint/no-non-null-asserted-nullish-coalescing": "error",
+      "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
+      "@typescript-eslint/no-non-null-assertion": "error",
+      "@typescript-eslint/no-redeclare": "error",
+      "@typescript-eslint/no-require-imports": "error",
+      "@typescript-eslint/no-restricted-imports": [
+        "off",
+        {
+          "paths": [],
+          "patterns": []
+        }
+      ],
+      "@typescript-eslint/no-restricted-types": [
+        "error",
+        {}
+      ],
+      "@typescript-eslint/no-shadow": "error",
+      "@typescript-eslint/no-this-alias": "error",
+      "@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
+      "@typescript-eslint/no-unnecessary-condition": "error",
+      "@typescript-eslint/no-unnecessary-parameter-property-assignment": "error",
+      "@typescript-eslint/no-unnecessary-qualifier": "error",
+      "@typescript-eslint/no-unnecessary-template-expression": "error",
+      "@typescript-eslint/no-unnecessary-type-arguments": "error",
+      "@typescript-eslint/no-unnecessary-type-constraint": "error",
+      "@typescript-eslint/no-unnecessary-type-parameters": "off",
+      "@typescript-eslint/no-unsafe-declaration-merging": "error",
+      "@typescript-eslint/no-unsafe-function-type": "error",
+      "@typescript-eslint/no-unused-expressions": "error",
+      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/no-useless-constructor": "error",
+      "@typescript-eslint/no-useless-empty-export": "error",
+      "@typescript-eslint/no-wrapper-object-types": "error",
+      "@typescript-eslint/object-curly-spacing": "off",
+      "@typescript-eslint/prefer-as-const": "error",
+      "@typescript-eslint/prefer-enum-initializers": "error",
+      "@typescript-eslint/prefer-for-of": "off",
+      "@typescript-eslint/prefer-literal-enum-member": "error",
+      "@typescript-eslint/prefer-namespace-keyword": "error",
+      "@typescript-eslint/prefer-reduce-type-parameter": "error",
+      "@typescript-eslint/prefer-return-this-type": "error",
+      "@typescript-eslint/quotes": 0,
+      "@typescript-eslint/require-array-sort-compare": "error",
+      "@typescript-eslint/return-await": "error",
+      "@typescript-eslint/semi": "off",
+      "@typescript-eslint/space-before-blocks": "off",
+      "@typescript-eslint/space-before-function-paren": "off",
+      "@typescript-eslint/space-infix-ops": "off",
+      "@typescript-eslint/strict-boolean-expressions": "off",
+      "@typescript-eslint/switch-exhaustiveness-check": "error",
+      "@typescript-eslint/triple-slash-reference": "error",
+      "@typescript-eslint/type-annotation-spacing": "off",
+      "@typescript-eslint/unified-signatures": "error",
+      "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
+      "array-bracket-newline": "off",
+      "array-bracket-spacing": "off",
+      "array-callback-return": [
+        "error",
+        {
+          "allowImplicit": true
+        }
+      ],
+      "array-element-newline": "off",
+      "arrow-body-style": "off",
+      "arrow-parens": "off",
+      "arrow-spacing": "off",
+      "babel/object-curly-spacing": "off",
+      "babel/quotes": 0,
+      "babel/semi": "off",
+      "block-scoped-var": "error",
+      "block-spacing": "off",
+      "brace-style": "off",
+      "camelcase": "off",
+      "class-methods-use-this": "off",
+      "comma-dangle": "off",
+      "comma-spacing": "off",
+      "comma-style": "off",
+      "computed-property-spacing": "off",
+      "consistent-return": "error",
+      "constructor-super": "off",
+      "curly": 0,
+      "default-case": [
+        "error",
+        {
+          "commentPattern": "^no default$"
+        }
+      ],
+      "default-case-last": "error",
+      "default-param-last": "off",
+      "dot-location": "off",
+      "eol-last": "off",
+      "eqeqeq": [
+        "error",
+        "always",
+        {
+          "null": "ignore"
+        }
+      ],
+      "flowtype/boolean-style": "off",
+      "flowtype/delimiter-dangle": "off",
+      "flowtype/generic-spacing": "off",
+      "flowtype/object-type-curly-spacing": "off",
+      "flowtype/object-type-delimiter": "off",
+      "flowtype/quotes": "off",
+      "flowtype/semi": "off",
+      "flowtype/space-after-type-colon": "off",
+      "flowtype/space-before-generic-bracket": "off",
+      "flowtype/space-before-type-colon": "off",
+      "flowtype/union-intersection-spacing": "off",
+      "for-direction": "error",
+      "func-call-spacing": "off",
+      "func-names": "warn",
+      "function-call-argument-newline": "off",
+      "function-paren-newline": "off",
+      "generator-star": "off",
+      "generator-star-spacing": "off",
+      "getter-return": "off",
+      "grouped-accessor-pairs": "error",
+      "implicit-arrow-linebreak": "off",
+      "import-x/consistent-type-specifier-style": "off",
+      "import-x/default": "error",
+      "import-x/export": "error",
+      "import-x/extensions": [
+        "error",
+        "ignorePackages",
+        {
+          "cjs": "never",
+          "cts": "never",
+          "js": "never",
+          "jsx": "never",
+          "mjs": "never",
+          "mts": "never",
+          "ts": "never",
+          "tsx": "never"
+        }
+      ],
+      "import-x/named": "off",
+      "import-x/namespace": "error",
+      "import-x/newline-after-import": "error",
+      "import-x/no-absolute-path": "error",
+      "import-x/no-amd": "error",
+      "import-x/no-cycle": [
+        "error",
+        {
+          "ignoreExternal": true
+        }
+      ],
+      "import-x/no-deprecated": "warn",
+      "import-x/no-duplicates": "error",
+      "import-x/no-dynamic-require": "error",
+      "import-x/no-empty-named-blocks": "off",
+      "import-x/no-extraneous-dependencies": [
+        "off",
+        {
+          "devDependencies": [
+            "**/test*/**",
+            "**/mocks/**",
+            "**/mock/**",
+            "test/**",
+            "tests/**",
+            "spec/**",
+            "**/__tests__/**",
+            "**/__mocks__/**",
+            "test.{js,jsx,ts,tsx}",
+            "test-*.{js,jsx,ts,tsx}",
+            "**/*{.,_}{test,spec}.{js,jsx,ts,tsx}",
+            "**/jest.config.{cjs,mjs,js,ts}",
+            "**/jest.setup.{cjs,mjs,js,ts}",
+            "**/vitest.config.{cjs,mjs,js,ts}",
+            "**/vue.config.{cjs,mjs,js,ts}",
+            "**/svelte.config.{cjs,mjs,js,ts}",
+            "**/tsup.config.{cjs,mjs,js,ts}",
+            "**/playwright.config.{cjs,mjs,js,ts}",
+            "**/webpack.config.{cjs,mjs,js,ts}",
+            "**/webpack.mod.{cjs,mjs,js,ts}",
+            "**/rollup.config.{cjs,mjs,js,ts}",
+            "**/rollup.config.*cjs,mjs,.{js,ts}",
+            "**/protractor.conf.{cjs,mjs,js,ts}",
+            "**/protractor.conf.*.{cjs,mjs,js,ts}",
+            "**/.eslintrc.{cjs,mjs,js,ts}",
+            "**/eslint.config.{cjs,mjs,js,ts}",
+            "**/.prettierrc.{cjs,mjs,js,ts}",
+            "**/.prettierrc"
+          ],
+          "optionalDependencies": false
+        }
+      ],
+      "import-x/no-import-module-exports": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "import-x/no-mutable-exports": "error",
+      "import-x/no-named-as-default": "error",
+      "import-x/no-named-as-default-member": "off",
+      "import-x/no-named-default": "error",
+      "import-x/no-nodejs-modules": "off",
+      "import-x/no-relative-packages": "error",
+      "import-x/no-self-import": "error",
+      "import-x/no-unresolved": [
+        "error",
+        {
+          "caseSensitive": true,
+          "commonjs": true
+        }
+      ],
+      "import-x/no-unused-modules": "error",
+      "import-x/no-useless-path-segments": [
+        "error",
+        {
+          "commonjs": true
+        }
+      ],
+      "import-x/no-webpack-loader-syntax": "error",
+      "import-x/prefer-default-export": "off",
+      "indent": "off",
+      "indent-legacy": "off",
+      "jsx-quotes": "off",
+      "key-spacing": "off",
+      "keyword-spacing": "off",
+      "linebreak-style": "off",
+      "lines-around-comment": 0,
+      "max-classes-per-file": [
+        "error",
+        1
+      ],
+      "max-len": 0,
+      "max-statements-per-line": "off",
+      "multiline-ternary": "off",
+      "new-cap": [
+        "error",
+        {
+          "capIsNew": false,
+          "capIsNewExceptions": [
+            "Immutable.Map",
+            "Immutable.Set",
+            "Immutable.List"
+          ],
+          "newIsCap": true,
+          "newIsCapExceptions": []
+        }
+      ],
+      "new-parens": "off",
+      "newline-per-chained-call": "off",
+      "no-alert": "error",
+      "no-array-constructor": "off",
+      "no-arrow-condition": "off",
+      "no-async-promise-executor": "error",
+      "no-await-in-loop": "error",
+      "no-bitwise": "error",
+      "no-caller": "error",
+      "no-case-declarations": "error",
+      "no-class-assign": "off",
+      "no-comma-dangle": "off",
+      "no-compare-neg-zero": "error",
+      "no-cond-assign": [
+        "error",
+        "always"
+      ],
+      "no-confusing-arrow": 0,
+      "no-console": "off",
       "no-const-assign": "off",
       "no-constant-binary-expression": "error",
       "no-constant-condition": "warn",

--- a/packages/eslint-config/test/generated/esm-final-config.js
+++ b/packages/eslint-config/test/generated/esm-final-config.js
@@ -1279,9 +1279,9 @@ export default [
         "parser": {
           "meta": {
             "name": "typescript-eslint/parser",
-            "version": "8.27.0"
+            "version": "8.28.0"
           },
-          "version": "8.27.0"
+          "version": "8.28.0"
         },
         "projectService": true,
         "warnOnUnsupportedTypeScriptVersion": false
@@ -1678,6 +1678,2508 @@ export default [
         "error",
         "ignorePackages",
         {
+          "mts": "never",
+          "ts": "never",
+          "tsx": "never"
+        }
+      ],
+      "import-x/named": "off",
+      "import-x/namespace": "error",
+      "import-x/newline-after-import": "error",
+      "import-x/no-absolute-path": "error",
+      "import-x/no-amd": "error",
+      "import-x/no-cycle": [
+        "error",
+        {
+          "ignoreExternal": true
+        }
+      ],
+      "import-x/no-deprecated": "warn",
+      "import-x/no-duplicates": "error",
+      "import-x/no-dynamic-require": "error",
+      "import-x/no-empty-named-blocks": "off",
+      "import-x/no-extraneous-dependencies": [
+        "off",
+        {
+          "devDependencies": [
+            "**/test*/**",
+            "**/mocks/**",
+            "**/mock/**",
+            "test/**",
+            "tests/**",
+            "spec/**",
+            "**/__tests__/**",
+            "**/__mocks__/**",
+            "test.{js,jsx,ts,tsx}",
+            "test-*.{js,jsx,ts,tsx}",
+            "**/*{.,_}{test,spec}.{js,jsx,ts,tsx}",
+            "**/jest.config.{cjs,mjs,js,ts}",
+            "**/jest.setup.{cjs,mjs,js,ts}",
+            "**/vitest.config.{cjs,mjs,js,ts}",
+            "**/vue.config.{cjs,mjs,js,ts}",
+            "**/svelte.config.{cjs,mjs,js,ts}",
+            "**/tsup.config.{cjs,mjs,js,ts}",
+            "**/playwright.config.{cjs,mjs,js,ts}",
+            "**/webpack.config.{cjs,mjs,js,ts}",
+            "**/webpack.mod.{cjs,mjs,js,ts}",
+            "**/rollup.config.{cjs,mjs,js,ts}",
+            "**/rollup.config.*cjs,mjs,.{js,ts}",
+            "**/protractor.conf.{cjs,mjs,js,ts}",
+            "**/protractor.conf.*.{cjs,mjs,js,ts}",
+            "**/.eslintrc.{cjs,mjs,js,ts}",
+            "**/eslint.config.{cjs,mjs,js,ts}",
+            "**/.prettierrc.{cjs,mjs,js,ts}",
+            "**/.prettierrc"
+          ],
+          "optionalDependencies": false
+        }
+      ],
+      "import-x/no-import-module-exports": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "import-x/no-mutable-exports": "error",
+      "import-x/no-named-as-default": "error",
+      "import-x/no-named-as-default-member": "off",
+      "import-x/no-named-default": "error",
+      "import-x/no-nodejs-modules": "off",
+      "import-x/no-relative-packages": "error",
+      "import-x/no-self-import": "error",
+      "import-x/no-unresolved": [
+        "error",
+        {
+          "caseSensitive": true,
+          "commonjs": true
+        }
+      ],
+      "import-x/no-unused-modules": "error",
+      "import-x/no-useless-path-segments": [
+        "error",
+        {
+          "commonjs": true
+        }
+      ],
+      "import-x/no-webpack-loader-syntax": "error",
+      "import-x/prefer-default-export": "off",
+      "indent": "off",
+      "indent-legacy": "off",
+      "jsx-quotes": "off",
+      "key-spacing": "off",
+      "keyword-spacing": "off",
+      "linebreak-style": "off",
+      "lines-around-comment": 0,
+      "max-classes-per-file": [
+        "error",
+        1
+      ],
+      "max-len": 0,
+      "max-statements-per-line": "off",
+      "multiline-ternary": "off",
+      "new-cap": [
+        "error",
+        {
+          "capIsNew": false,
+          "capIsNewExceptions": [
+            "Immutable.Map",
+            "Immutable.Set",
+            "Immutable.List"
+          ],
+          "newIsCap": true,
+          "newIsCapExceptions": []
+        }
+      ],
+      "new-parens": "off",
+      "newline-per-chained-call": "off",
+      "no-alert": "error",
+      "no-array-constructor": "off",
+      "no-arrow-condition": "off",
+      "no-async-promise-executor": "error",
+      "no-await-in-loop": "error",
+      "no-bitwise": "error",
+      "no-caller": "error",
+      "no-case-declarations": "error",
+      "no-class-assign": "off",
+      "no-comma-dangle": "off",
+      "no-compare-neg-zero": "error",
+      "no-cond-assign": [
+        "error",
+        "always"
+      ],
+      "no-confusing-arrow": 0,
+      "no-console": "off",
+      "no-const-assign": "off",
+      "no-constant-binary-expression": "error",
+      "no-constant-condition": "warn",
+      "no-constructor-return": "error",
+      "no-continue": "error",
+      "no-control-regex": "error",
+      "no-debugger": "error",
+      "no-delete-var": "error",
+      "no-dupe-args": "off",
+      "no-dupe-class-members": "off",
+      "no-dupe-else-if": "error",
+      "no-dupe-keys": "off",
+      "no-duplicate-case": "error",
+      "no-else-return": [
+        "error",
+        {
+          "allowElseIf": false
+        }
+      ],
+      "no-empty": "error",
+      "no-empty-character-class": "error",
+      "no-empty-function": [
+        "error",
+        {
+          "allow": [
+            "arrowFunctions",
+            "functions",
+            "methods"
+          ]
+        }
+      ],
+      "no-empty-pattern": "error",
+      "no-empty-static-block": "error",
+      "no-eval": "error",
+      "no-ex-assign": "error",
+      "no-extend-native": "error",
+      "no-extra-bind": "error",
+      "no-extra-boolean-cast": "error",
+      "no-extra-label": "error",
+      "no-extra-parens": "off",
+      "no-extra-semi": "off",
+      "no-fallthrough": "error",
+      "no-floating-decimal": "off",
+      "no-func-assign": "off",
+      "no-global-assign": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "no-implied-eval": "error",
+      "no-import-assign": "off",
+      "no-inner-declarations": "error",
+      "no-invalid-regexp": "error",
+      "no-irregular-whitespace": "error",
+      "no-iterator": "error",
+      "no-label-var": "error",
+      "no-labels": [
+        "error",
+        {
+          "allowLoop": false,
+          "allowSwitch": false
+        }
+      ],
+      "no-lone-blocks": "error",
+      "no-lonely-if": "error",
+      "no-loop-func": "off",
+      "no-loss-of-precision": "error",
+      "no-magic-numbers": "off",
+      "no-misleading-character-class": "error",
+      "no-mixed-operators": 0,
+      "no-mixed-spaces-and-tabs": "off",
+      "no-multi-assign": [
+        "error"
+      ],
+      "no-multi-spaces": "off",
+      "no-multi-str": "error",
+      "no-multiple-empty-lines": "off",
+      "no-nested-ternary": "error",
+      "no-new": "error",
+      "no-new-func": "error",
+      "no-new-native-nonconstructor": "off",
+      "no-new-symbol": "off",
+      "no-new-wrappers": "error",
+      "no-nonoctal-decimal-escape": "error",
+      "no-obj-calls": "off",
+      "no-object-constructor": "error",
+      "no-octal": "error",
+      "no-octal-escape": "error",
+      "no-param-reassign": [
+        "error",
+        {
+          "ignorePropertyModificationsFor": [
+            "prev",
+            "acc",
+            "accumulator",
+            "e",
+            "ctx",
+            "context",
+            "req",
+            "request",
+            "res",
+            "response",
+            "$scope",
+            "staticContext",
+            "sharedState",
+            "state"
+          ],
+          "props": true
+        }
+      ],
+      "no-promise-executor-return": "error",
+      "no-proto": "error",
+      "no-prototype-builtins": "error",
+      "no-redeclare": "off",
+      "no-regex-spaces": "error",
+      "no-reserved-keys": "off",
+      "no-restricted-exports": [
+        "error",
+        {
+          "restrictedNamedExports": [
+            "default",
+            "then"
+          ]
+        }
+      ],
+      "no-restricted-globals": [
+        "error",
+        {
+          "message": "Use Number.isFinite instead",
+          "name": "isFinite"
+        },
+        {
+          "message": "Use Number.isNaN instead",
+          "name": "isNaN"
+        },
+        {
+          "message": "Use window.addEventListener instead",
+          "name": "addEventListener"
+        },
+        {
+          "message": "Use window.blur instead",
+          "name": "blur"
+        },
+        {
+          "message": "Use window.close instead",
+          "name": "close"
+        },
+        {
+          "message": "Use window.closed instead",
+          "name": "closed"
+        },
+        {
+          "message": "Use window.confirm instead",
+          "name": "confirm"
+        },
+        {
+          "message": "Use window.defaultStatus instead",
+          "name": "defaultStatus"
+        },
+        {
+          "message": "Use window.defaultstatus instead",
+          "name": "defaultstatus"
+        },
+        {
+          "message": "Use window.event instead",
+          "name": "event"
+        },
+        {
+          "message": "Use window.external instead",
+          "name": "external"
+        },
+        {
+          "message": "Use window.find instead",
+          "name": "find"
+        },
+        {
+          "message": "Use window.focus instead",
+          "name": "focus"
+        },
+        {
+          "message": "Use window.frameElement instead",
+          "name": "frameElement"
+        },
+        {
+          "message": "Use window.frames instead",
+          "name": "frames"
+        },
+        {
+          "message": "Use window.history instead",
+          "name": "history"
+        },
+        {
+          "message": "Use window.innerHeight instead",
+          "name": "innerHeight"
+        },
+        {
+          "message": "Use window.innerWidth instead",
+          "name": "innerWidth"
+        },
+        {
+          "message": "Use window.length instead",
+          "name": "length"
+        },
+        {
+          "message": "Use window.location instead",
+          "name": "location"
+        },
+        {
+          "message": "Use window.locationbar instead",
+          "name": "locationbar"
+        },
+        {
+          "message": "Use window.menubar instead",
+          "name": "menubar"
+        },
+        {
+          "message": "Use window.moveBy instead",
+          "name": "moveBy"
+        },
+        {
+          "message": "Use window.moveTo instead",
+          "name": "moveTo"
+        },
+        {
+          "message": "Use window.name instead",
+          "name": "name"
+        },
+        {
+          "message": "Use window.onblur instead",
+          "name": "onblur"
+        },
+        {
+          "message": "Use window.onerror instead",
+          "name": "onerror"
+        },
+        {
+          "message": "Use window.onfocus instead",
+          "name": "onfocus"
+        },
+        {
+          "message": "Use window.onload instead",
+          "name": "onload"
+        },
+        {
+          "message": "Use window.onresize instead",
+          "name": "onresize"
+        },
+        {
+          "message": "Use window.onunload instead",
+          "name": "onunload"
+        },
+        {
+          "message": "Use window.open instead",
+          "name": "open"
+        },
+        {
+          "message": "Use window.opener instead",
+          "name": "opener"
+        },
+        {
+          "message": "Use window.opera instead",
+          "name": "opera"
+        },
+        {
+          "message": "Use window.outerHeight instead",
+          "name": "outerHeight"
+        },
+        {
+          "message": "Use window.outerWidth instead",
+          "name": "outerWidth"
+        },
+        {
+          "message": "Use window.pageXOffset instead",
+          "name": "pageXOffset"
+        },
+        {
+          "message": "Use window.pageYOffset instead",
+          "name": "pageYOffset"
+        },
+        {
+          "message": "Use window.parent instead",
+          "name": "parent"
+        },
+        {
+          "message": "Use window.print instead",
+          "name": "print"
+        },
+        {
+          "message": "Use window.removeEventListener instead",
+          "name": "removeEventListener"
+        },
+        {
+          "message": "Use window.resizeBy instead",
+          "name": "resizeBy"
+        },
+        {
+          "message": "Use window.resizeTo instead",
+          "name": "resizeTo"
+        },
+        {
+          "message": "Use window.screen instead",
+          "name": "screen"
+        },
+        {
+          "message": "Use window.screenLeft instead",
+          "name": "screenLeft"
+        },
+        {
+          "message": "Use window.screenTop instead",
+          "name": "screenTop"
+        },
+        {
+          "message": "Use window.screenX instead",
+          "name": "screenX"
+        },
+        {
+          "message": "Use window.screenY instead",
+          "name": "screenY"
+        },
+        {
+          "message": "Use window.scroll instead",
+          "name": "scroll"
+        },
+        {
+          "message": "Use window.scrollbars instead",
+          "name": "scrollbars"
+        },
+        {
+          "message": "Use window.scrollBy instead",
+          "name": "scrollBy"
+        },
+        {
+          "message": "Use window.scrollTo instead",
+          "name": "scrollTo"
+        },
+        {
+          "message": "Use window.scrollX instead",
+          "name": "scrollX"
+        },
+        {
+          "message": "Use window.scrollY instead",
+          "name": "scrollY"
+        },
+        {
+          "message": "Use window.self instead",
+          "name": "self"
+        },
+        {
+          "message": "Use window.status instead",
+          "name": "status"
+        },
+        {
+          "message": "Use window.statusbar instead",
+          "name": "statusbar"
+        },
+        {
+          "message": "Use window.stop instead",
+          "name": "stop"
+        },
+        {
+          "message": "Use window.toolbar instead",
+          "name": "toolbar"
+        },
+        {
+          "message": "Use window.top instead",
+          "name": "top"
+        }
+      ],
+      "no-restricted-imports": "off",
+      "no-restricted-properties": [
+        "error",
+        {
+          "message": "arguments.callee is deprecated",
+          "object": "arguments",
+          "property": "callee"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "global",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "self",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "window",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "global",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "self",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "window",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineGetter__"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineSetter__"
+        },
+        {
+          "message": "Use the exponentiation operator (**) instead.",
+          "object": "Math",
+          "property": "pow"
+        }
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.",
+          "selector": "LabeledStatement"
+        },
+        {
+          "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
+          "selector": "WithStatement"
+        }
+      ],
+      "no-return-assign": [
+        "error",
+        "always"
+      ],
+      "no-return-await": "off",
+      "no-script-url": "error",
+      "no-self-assign": [
+        "error",
+        {
+          "props": true
+        }
+      ],
+      "no-self-compare": "error",
+      "no-sequences": "error",
+      "no-setter-return": "off",
+      "no-shadow": "off",
+      "no-shadow-restricted-names": "error",
+      "no-space-before-semi": "off",
+      "no-spaced-func": "off",
+      "no-sparse-arrays": "error",
+      "no-tabs": 0,
+      "no-template-curly-in-string": "error",
+      "no-this-before-super": "off",
+      "no-throw-literal": "error",
+      "no-trailing-spaces": "off",
+      "no-undef": "off",
+      "no-undef-init": "error",
+      "no-underscore-dangle": "off",
+      "no-unexpected-multiline": 0,
+      "no-unmodified-loop-condition": "error",
+      "no-unneeded-ternary": [
+        "error",
+        {
+          "defaultAssignment": false
+        }
+      ],
+      "no-unreachable": "off",
+      "no-unreachable-loop": [
+        "error",
+        {
+          "ignore": []
+        }
+      ],
+      "no-unsafe-finally": "error",
+      "no-unsafe-negation": "off",
+      "no-unsafe-optional-chaining": [
+        "error",
+        {
+          "disallowArithmeticOperators": true
+        }
+      ],
+      "no-unused-expressions": "off",
+      "no-unused-labels": "error",
+      "no-unused-private-class-members": "error",
+      "no-unused-vars": "off",
+      "no-useless-backreference": "error",
+      "no-useless-call": "error",
+      "no-useless-catch": "error",
+      "no-useless-computed-key": "error",
+      "no-useless-concat": "error",
+      "no-useless-constructor": "off",
+      "no-useless-escape": "error",
+      "no-useless-rename": [
+        "error",
+        {
+          "ignoreDestructuring": false,
+          "ignoreExport": false,
+          "ignoreImport": false
+        }
+      ],
+      "no-useless-return": "error",
+      "no-var": "error",
+      "no-whitespace-before-property": "off",
+      "no-with": "error",
+      "no-wrap-func": "off",
+      "nonblock-statement-body-position": "off",
+      "object-curly-newline": "off",
+      "object-curly-spacing": "off",
+      "object-property-newline": "off",
+      "object-shorthand": [
+        "error",
+        "always",
+        {
+          "avoidQuotes": true,
+          "ignoreConstructors": false
+        }
+      ],
+      "one-var": [
+        "error",
+        "never"
+      ],
+      "one-var-declaration-per-line": "off",
+      "operator-assignment": [
+        "error",
+        "always"
+      ],
+      "operator-linebreak": "off",
+      "padded-blocks": "off",
+      "prefer-arrow-callback": "off",
+      "prefer-const": "error",
+      "prefer-exponentiation-operator": "error",
+      "prefer-numeric-literals": "error",
+      "prefer-object-has-own": "error",
+      "prefer-object-spread": "error",
+      "prefer-promise-reject-errors": [
+        "error",
+        {
+          "allowEmptyReject": true
+        }
+      ],
+      "prefer-regex-literals": [
+        "error",
+        {
+          "disallowRedundantWrapping": true
+        }
+      ],
+      "prefer-rest-params": "error",
+      "prefer-spread": "error",
+      "prefer-template": "error",
+      "quote-props": "off",
+      "quotes": 0,
+      "radix": "error",
+      "react/jsx-child-element-spacing": "off",
+      "react/jsx-closing-bracket-location": "off",
+      "react/jsx-closing-tag-location": "off",
+      "react/jsx-curly-newline": "off",
+      "react/jsx-curly-spacing": "off",
+      "react/jsx-equals-spacing": "off",
+      "react/jsx-first-prop-new-line": "off",
+      "react/jsx-indent": "off",
+      "react/jsx-indent-props": "off",
+      "react/jsx-max-props-per-line": "off",
+      "react/jsx-newline": "off",
+      "react/jsx-one-expression-per-line": "off",
+      "react/jsx-props-no-multi-spaces": "off",
+      "react/jsx-space-before-closing": "off",
+      "react/jsx-tag-spacing": "off",
+      "react/jsx-wrap-multilines": "off",
+      "require-atomic-updates": "error",
+      "require-yield": "error",
+      "rest-spread-spacing": "off",
+      "semi": "off",
+      "semi-spacing": "off",
+      "semi-style": "off",
+      "space-after-function-name": "off",
+      "space-after-keywords": "off",
+      "space-before-blocks": "off",
+      "space-before-function-paren": "off",
+      "space-before-function-parentheses": "off",
+      "space-before-keywords": "off",
+      "space-in-brackets": "off",
+      "space-in-parens": "off",
+      "space-infix-ops": "off",
+      "space-return-throw-case": "off",
+      "space-unary-ops": "off",
+      "space-unary-word-ops": "off",
+      "standard/array-bracket-even-spacing": "off",
+      "standard/computed-property-even-spacing": "off",
+      "standard/object-curly-even-spacing": "off",
+      "switch-colon-spacing": "off",
+      "symbol-description": "error",
+      "template-curly-spacing": "off",
+      "template-tag-spacing": "off",
+      "unicode-bom": [
+        "error",
+        "never"
+      ],
+      "unicorn/empty-brace-spaces": "off",
+      "unicorn/no-nested-ternary": "off",
+      "unicorn/number-literal-case": "off",
+      "unicorn/template-indent": 0,
+      "use-isnan": "error",
+      "valid-typeof": [
+        "error",
+        {
+          "requireStringLiterals": true
+        }
+      ],
+      "vue/array-bracket-newline": "off",
+      "vue/array-bracket-spacing": "off",
+      "vue/array-element-newline": "off",
+      "vue/arrow-spacing": "off",
+      "vue/block-spacing": "off",
+      "vue/block-tag-newline": "off",
+      "vue/brace-style": "off",
+      "vue/comma-dangle": "off",
+      "vue/comma-spacing": "off",
+      "vue/comma-style": "off",
+      "vue/dot-location": "off",
+      "vue/func-call-spacing": "off",
+      "vue/html-closing-bracket-newline": "off",
+      "vue/html-closing-bracket-spacing": "off",
+      "vue/html-end-tags": "off",
+      "vue/html-indent": "off",
+      "vue/html-quotes": "off",
+      "vue/html-self-closing": 0,
+      "vue/key-spacing": "off",
+      "vue/keyword-spacing": "off",
+      "vue/max-attributes-per-line": "off",
+      "vue/max-len": 0,
+      "vue/multiline-html-element-content-newline": "off",
+      "vue/multiline-ternary": "off",
+      "vue/mustache-interpolation-spacing": "off",
+      "vue/no-extra-parens": "off",
+      "vue/no-multi-spaces": "off",
+      "vue/no-spaces-around-equal-signs-in-attribute": "off",
+      "vue/object-curly-newline": "off",
+      "vue/object-curly-spacing": "off",
+      "vue/object-property-newline": "off",
+      "vue/operator-linebreak": "off",
+      "vue/quote-props": "off",
+      "vue/script-indent": "off",
+      "vue/singleline-html-element-content-newline": "off",
+      "vue/space-in-parens": "off",
+      "vue/space-infix-ops": "off",
+      "vue/space-unary-ops": "off",
+      "vue/template-curly-spacing": "off",
+      "wrap-iife": "off",
+      "wrap-regex": "off",
+      "yield-star-spacing": "off",
+      "yoda": "error"
+    },
+    "settings": {
+      "import-x/extensions": [
+        ".ts",
+        ".tsx",
+        ".cts",
+        ".mts",
+        ".js",
+        ".jsx",
+        ".cjs",
+        ".mjs"
+      ],
+      "import-x/external-module-folders": [
+        "node_modules",
+        "node_modules/@types"
+      ],
+      "import-x/parsers": {
+        "@typescript-eslint/parser": [
+          ".ts",
+          ".tsx",
+          ".cts",
+          ".mts"
+        ]
+      },
+      "import-x/resolver": {
+        "typescript": true
+      }
+    }
+  },
+  {
+    "files": [
+      "**/*.cjs"
+    ],
+    "languageOptions": {
+      "ecmaVersion": "latest",
+      "globals": {
+        "AbortController": false,
+        "AbortSignal": false,
+        "Blob": false,
+        "BroadcastChannel": false,
+        "Buffer": false,
+        "ByteLengthQueuingStrategy": false,
+        "CloseEvent": false,
+        "CompressionStream": false,
+        "CountQueuingStrategy": false,
+        "Crypto": false,
+        "CryptoKey": false,
+        "CustomEvent": false,
+        "DOMException": false,
+        "DecompressionStream": false,
+        "Event": false,
+        "EventTarget": false,
+        "File": false,
+        "FormData": false,
+        "Headers": false,
+        "MessageChannel": false,
+        "MessageEvent": false,
+        "MessagePort": false,
+        "Navigator": false,
+        "Performance": false,
+        "PerformanceEntry": false,
+        "PerformanceMark": false,
+        "PerformanceMeasure": false,
+        "PerformanceObserver": false,
+        "PerformanceObserverEntryList": false,
+        "PerformanceResourceTiming": false,
+        "ReadableByteStreamController": false,
+        "ReadableStream": false,
+        "ReadableStreamBYOBReader": false,
+        "ReadableStreamBYOBRequest": false,
+        "ReadableStreamDefaultController": false,
+        "ReadableStreamDefaultReader": false,
+        "Request": false,
+        "Response": false,
+        "SubtleCrypto": false,
+        "TextDecoder": false,
+        "TextDecoderStream": false,
+        "TextEncoder": false,
+        "TextEncoderStream": false,
+        "TransformStream": false,
+        "TransformStreamDefaultController": false,
+        "URL": false,
+        "URLSearchParams": false,
+        "WebAssembly": false,
+        "WebSocket": false,
+        "WritableStream": false,
+        "WritableStreamDefaultController": false,
+        "WritableStreamDefaultWriter": false,
+        "__dirname": false,
+        "__filename": false,
+        "atob": false,
+        "btoa": false,
+        "clearImmediate": false,
+        "clearInterval": false,
+        "clearTimeout": false,
+        "console": false,
+        "crypto": false,
+        "exports": true,
+        "fetch": false,
+        "global": false,
+        "module": false,
+        "navigator": false,
+        "performance": false,
+        "process": false,
+        "queueMicrotask": false,
+        "require": false,
+        "setImmediate": false,
+        "setInterval": false,
+        "setTimeout": false,
+        "structuredClone": false
+      },
+      "parser": "@qlik/eslint-config/node-esm-cjs-parser",
+      "parserOptions": {
+        "warnOnUnsupportedTypeScriptVersion": false
+      },
+      "sourceType": "commonjs"
+    },
+    "name": "@qlik/eslint-config/node-esm-cjs",
+    "plugins": {
+      "@typescript-eslint": "@typescript-eslint-plugin",
+      "import-x": "import-x-plugin"
+    },
+    "rules": {
+      "@babel/object-curly-spacing": "off",
+      "@babel/semi": "off",
+      "@stylistic/array-bracket-newline": "off",
+      "@stylistic/array-bracket-spacing": "off",
+      "@stylistic/array-element-newline": "off",
+      "@stylistic/arrow-parens": "off",
+      "@stylistic/arrow-spacing": "off",
+      "@stylistic/block-spacing": "off",
+      "@stylistic/brace-style": "off",
+      "@stylistic/comma-dangle": "off",
+      "@stylistic/comma-spacing": "off",
+      "@stylistic/comma-style": "off",
+      "@stylistic/computed-property-spacing": "off",
+      "@stylistic/dot-location": "off",
+      "@stylistic/eol-last": "off",
+      "@stylistic/func-call-spacing": "off",
+      "@stylistic/function-call-argument-newline": "off",
+      "@stylistic/function-call-spacing": "off",
+      "@stylistic/function-paren-newline": "off",
+      "@stylistic/generator-star-spacing": "off",
+      "@stylistic/implicit-arrow-linebreak": "off",
+      "@stylistic/indent": "off",
+      "@stylistic/indent-binary-ops": "off",
+      "@stylistic/js/array-bracket-newline": "off",
+      "@stylistic/js/array-bracket-spacing": "off",
+      "@stylistic/js/array-element-newline": "off",
+      "@stylistic/js/arrow-parens": "off",
+      "@stylistic/js/arrow-spacing": "off",
+      "@stylistic/js/block-spacing": "off",
+      "@stylistic/js/brace-style": "off",
+      "@stylistic/js/comma-dangle": "off",
+      "@stylistic/js/comma-spacing": "off",
+      "@stylistic/js/comma-style": "off",
+      "@stylistic/js/computed-property-spacing": "off",
+      "@stylistic/js/dot-location": "off",
+      "@stylistic/js/eol-last": "off",
+      "@stylistic/js/func-call-spacing": "off",
+      "@stylistic/js/function-call-argument-newline": "off",
+      "@stylistic/js/function-call-spacing": "off",
+      "@stylistic/js/function-paren-newline": "off",
+      "@stylistic/js/generator-star-spacing": "off",
+      "@stylistic/js/implicit-arrow-linebreak": "off",
+      "@stylistic/js/indent": "off",
+      "@stylistic/js/jsx-quotes": "off",
+      "@stylistic/js/key-spacing": "off",
+      "@stylistic/js/keyword-spacing": "off",
+      "@stylistic/js/linebreak-style": "off",
+      "@stylistic/js/lines-around-comment": 0,
+      "@stylistic/js/max-len": 0,
+      "@stylistic/js/max-statements-per-line": "off",
+      "@stylistic/js/multiline-ternary": "off",
+      "@stylistic/js/new-parens": "off",
+      "@stylistic/js/newline-per-chained-call": "off",
+      "@stylistic/js/no-confusing-arrow": 0,
+      "@stylistic/js/no-extra-parens": "off",
+      "@stylistic/js/no-extra-semi": "off",
+      "@stylistic/js/no-floating-decimal": "off",
+      "@stylistic/js/no-mixed-operators": 0,
+      "@stylistic/js/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/js/no-multi-spaces": "off",
+      "@stylistic/js/no-multiple-empty-lines": "off",
+      "@stylistic/js/no-tabs": 0,
+      "@stylistic/js/no-trailing-spaces": "off",
+      "@stylistic/js/no-whitespace-before-property": "off",
+      "@stylistic/js/nonblock-statement-body-position": "off",
+      "@stylistic/js/object-curly-newline": "off",
+      "@stylistic/js/object-curly-spacing": "off",
+      "@stylistic/js/object-property-newline": "off",
+      "@stylistic/js/one-var-declaration-per-line": "off",
+      "@stylistic/js/operator-linebreak": "off",
+      "@stylistic/js/padded-blocks": "off",
+      "@stylistic/js/quote-props": "off",
+      "@stylistic/js/quotes": 0,
+      "@stylistic/js/rest-spread-spacing": "off",
+      "@stylistic/js/semi": "off",
+      "@stylistic/js/semi-spacing": "off",
+      "@stylistic/js/semi-style": "off",
+      "@stylistic/js/space-before-blocks": "off",
+      "@stylistic/js/space-before-function-paren": "off",
+      "@stylistic/js/space-in-parens": "off",
+      "@stylistic/js/space-infix-ops": "off",
+      "@stylistic/js/space-unary-ops": "off",
+      "@stylistic/js/switch-colon-spacing": "off",
+      "@stylistic/js/template-curly-spacing": "off",
+      "@stylistic/js/template-tag-spacing": "off",
+      "@stylistic/js/wrap-iife": "off",
+      "@stylistic/js/wrap-regex": "off",
+      "@stylistic/js/yield-star-spacing": "off",
+      "@stylistic/jsx-child-element-spacing": "off",
+      "@stylistic/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx-closing-tag-location": "off",
+      "@stylistic/jsx-curly-newline": "off",
+      "@stylistic/jsx-curly-spacing": "off",
+      "@stylistic/jsx-equals-spacing": "off",
+      "@stylistic/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx-indent": "off",
+      "@stylistic/jsx-indent-props": "off",
+      "@stylistic/jsx-max-props-per-line": "off",
+      "@stylistic/jsx-newline": "off",
+      "@stylistic/jsx-one-expression-per-line": "off",
+      "@stylistic/jsx-props-no-multi-spaces": "off",
+      "@stylistic/jsx-quotes": "off",
+      "@stylistic/jsx-tag-spacing": "off",
+      "@stylistic/jsx-wrap-multilines": "off",
+      "@stylistic/jsx/jsx-child-element-spacing": "off",
+      "@stylistic/jsx/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx/jsx-closing-tag-location": "off",
+      "@stylistic/jsx/jsx-curly-newline": "off",
+      "@stylistic/jsx/jsx-curly-spacing": "off",
+      "@stylistic/jsx/jsx-equals-spacing": "off",
+      "@stylistic/jsx/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx/jsx-indent": "off",
+      "@stylistic/jsx/jsx-indent-props": "off",
+      "@stylistic/jsx/jsx-max-props-per-line": "off",
+      "@stylistic/key-spacing": "off",
+      "@stylistic/keyword-spacing": "off",
+      "@stylistic/linebreak-style": "off",
+      "@stylistic/lines-around-comment": 0,
+      "@stylistic/max-len": 0,
+      "@stylistic/max-statements-per-line": "off",
+      "@stylistic/member-delimiter-style": "off",
+      "@stylistic/multiline-ternary": "off",
+      "@stylistic/new-parens": "off",
+      "@stylistic/newline-per-chained-call": "off",
+      "@stylistic/no-confusing-arrow": 0,
+      "@stylistic/no-extra-parens": "off",
+      "@stylistic/no-extra-semi": "off",
+      "@stylistic/no-floating-decimal": "off",
+      "@stylistic/no-mixed-operators": 0,
+      "@stylistic/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/no-multi-spaces": "off",
+      "@stylistic/no-multiple-empty-lines": "off",
+      "@stylistic/no-tabs": 0,
+      "@stylistic/no-trailing-spaces": "off",
+      "@stylistic/no-whitespace-before-property": "off",
+      "@stylistic/nonblock-statement-body-position": "off",
+      "@stylistic/object-curly-newline": "off",
+      "@stylistic/object-curly-spacing": "off",
+      "@stylistic/object-property-newline": "off",
+      "@stylistic/one-var-declaration-per-line": "off",
+      "@stylistic/operator-linebreak": "off",
+      "@stylistic/padded-blocks": "off",
+      "@stylistic/quote-props": "off",
+      "@stylistic/quotes": 0,
+      "@stylistic/rest-spread-spacing": "off",
+      "@stylistic/semi": "off",
+      "@stylistic/semi-spacing": "off",
+      "@stylistic/semi-style": "off",
+      "@stylistic/space-before-blocks": "off",
+      "@stylistic/space-before-function-paren": "off",
+      "@stylistic/space-in-parens": "off",
+      "@stylistic/space-infix-ops": "off",
+      "@stylistic/space-unary-ops": "off",
+      "@stylistic/switch-colon-spacing": "off",
+      "@stylistic/template-curly-spacing": "off",
+      "@stylistic/template-tag-spacing": "off",
+      "@stylistic/ts/block-spacing": "off",
+      "@stylistic/ts/brace-style": "off",
+      "@stylistic/ts/comma-dangle": "off",
+      "@stylistic/ts/comma-spacing": "off",
+      "@stylistic/ts/func-call-spacing": "off",
+      "@stylistic/ts/function-call-spacing": "off",
+      "@stylistic/ts/indent": "off",
+      "@stylistic/ts/key-spacing": "off",
+      "@stylistic/ts/keyword-spacing": "off",
+      "@stylistic/ts/lines-around-comment": 0,
+      "@stylistic/ts/member-delimiter-style": "off",
+      "@stylistic/ts/no-extra-parens": "off",
+      "@stylistic/ts/no-extra-semi": "off",
+      "@stylistic/ts/object-curly-spacing": "off",
+      "@stylistic/ts/quotes": 0,
+      "@stylistic/ts/semi": "off",
+      "@stylistic/ts/space-before-blocks": "off",
+      "@stylistic/ts/space-before-function-paren": "off",
+      "@stylistic/ts/space-infix-ops": "off",
+      "@stylistic/ts/type-annotation-spacing": "off",
+      "@stylistic/type-annotation-spacing": "off",
+      "@stylistic/type-generic-spacing": "off",
+      "@stylistic/type-named-tuple-spacing": "off",
+      "@stylistic/wrap-iife": "off",
+      "@stylistic/wrap-regex": "off",
+      "@stylistic/yield-star-spacing": "off",
+      "@typescript-eslint/block-spacing": "off",
+      "@typescript-eslint/brace-style": "off",
+      "@typescript-eslint/comma-dangle": "off",
+      "@typescript-eslint/comma-spacing": "off",
+      "@typescript-eslint/func-call-spacing": "off",
+      "@typescript-eslint/indent": "off",
+      "@typescript-eslint/key-spacing": "off",
+      "@typescript-eslint/keyword-spacing": "off",
+      "@typescript-eslint/lines-around-comment": 0,
+      "@typescript-eslint/member-delimiter-style": "off",
+      "@typescript-eslint/no-extra-parens": "off",
+      "@typescript-eslint/no-extra-semi": "off",
+      "@typescript-eslint/object-curly-spacing": "off",
+      "@typescript-eslint/quotes": 0,
+      "@typescript-eslint/semi": "off",
+      "@typescript-eslint/space-before-blocks": "off",
+      "@typescript-eslint/space-before-function-paren": "off",
+      "@typescript-eslint/space-infix-ops": "off",
+      "@typescript-eslint/type-annotation-spacing": "off",
+      "array-bracket-newline": "off",
+      "array-bracket-spacing": "off",
+      "array-callback-return": [
+        "error",
+        {
+          "allowImplicit": true
+        }
+      ],
+      "array-element-newline": "off",
+      "arrow-body-style": "off",
+      "arrow-parens": "off",
+      "arrow-spacing": "off",
+      "babel/object-curly-spacing": "off",
+      "babel/quotes": 0,
+      "babel/semi": "off",
+      "block-scoped-var": "error",
+      "block-spacing": "off",
+      "brace-style": "off",
+      "camelcase": [
+        "error",
+        {
+          "ignoreDestructuring": false,
+          "properties": "never"
+        }
+      ],
+      "class-methods-use-this": [
+        "warn",
+        {
+          "exceptMethods": []
+        }
+      ],
+      "comma-dangle": "off",
+      "comma-spacing": "off",
+      "comma-style": "off",
+      "computed-property-spacing": "off",
+      "consistent-return": "error",
+      "constructor-super": "error",
+      "curly": 0,
+      "default-case": [
+        "error",
+        {
+          "commentPattern": "^no default$"
+        }
+      ],
+      "default-case-last": "error",
+      "default-param-last": "error",
+      "dot-location": "off",
+      "eol-last": "off",
+      "eqeqeq": [
+        "error",
+        "always",
+        {
+          "null": "ignore"
+        }
+      ],
+      "flowtype/boolean-style": "off",
+      "flowtype/delimiter-dangle": "off",
+      "flowtype/generic-spacing": "off",
+      "flowtype/object-type-curly-spacing": "off",
+      "flowtype/object-type-delimiter": "off",
+      "flowtype/quotes": "off",
+      "flowtype/semi": "off",
+      "flowtype/space-after-type-colon": "off",
+      "flowtype/space-before-generic-bracket": "off",
+      "flowtype/space-before-type-colon": "off",
+      "flowtype/union-intersection-spacing": "off",
+      "for-direction": "error",
+      "func-call-spacing": "off",
+      "func-names": "warn",
+      "function-call-argument-newline": "off",
+      "function-paren-newline": "off",
+      "generator-star": "off",
+      "generator-star-spacing": "off",
+      "getter-return": [
+        "error",
+        {
+          "allowImplicit": true
+        }
+      ],
+      "grouped-accessor-pairs": "error",
+      "implicit-arrow-linebreak": "off",
+      "import-x/consistent-type-specifier-style": "off",
+      "import-x/default": "error",
+      "import-x/export": "error",
+      "import-x/extensions": [
+        "error",
+        "ignorePackages",
+        {
+          "cjs": "never",
+          "cts": "never",
+          "js": "never",
+          "jsx": "never",
+          "mjs": "never",
+          "mts": "never",
+          "ts": "never",
+          "tsx": "never"
+        }
+      ],
+      "import-x/named": "error",
+      "import-x/namespace": "error",
+      "import-x/newline-after-import": "error",
+      "import-x/no-absolute-path": "error",
+      "import-x/no-amd": "error",
+      "import-x/no-cycle": [
+        "error",
+        {
+          "ignoreExternal": true
+        }
+      ],
+      "import-x/no-deprecated": "warn",
+      "import-x/no-duplicates": "error",
+      "import-x/no-dynamic-require": "error",
+      "import-x/no-empty-named-blocks": "off",
+      "import-x/no-extraneous-dependencies": [
+        "off",
+        {
+          "devDependencies": [
+            "**/test*/**",
+            "**/mocks/**",
+            "**/mock/**",
+            "test/**",
+            "tests/**",
+            "spec/**",
+            "**/__tests__/**",
+            "**/__mocks__/**",
+            "test.{js,jsx,ts,tsx}",
+            "test-*.{js,jsx,ts,tsx}",
+            "**/*{.,_}{test,spec}.{js,jsx,ts,tsx}",
+            "**/jest.config.{cjs,mjs,js,ts}",
+            "**/jest.setup.{cjs,mjs,js,ts}",
+            "**/vitest.config.{cjs,mjs,js,ts}",
+            "**/vue.config.{cjs,mjs,js,ts}",
+            "**/svelte.config.{cjs,mjs,js,ts}",
+            "**/tsup.config.{cjs,mjs,js,ts}",
+            "**/playwright.config.{cjs,mjs,js,ts}",
+            "**/webpack.config.{cjs,mjs,js,ts}",
+            "**/webpack.mod.{cjs,mjs,js,ts}",
+            "**/rollup.config.{cjs,mjs,js,ts}",
+            "**/rollup.config.*cjs,mjs,.{js,ts}",
+            "**/protractor.conf.{cjs,mjs,js,ts}",
+            "**/protractor.conf.*.{cjs,mjs,js,ts}",
+            "**/.eslintrc.{cjs,mjs,js,ts}",
+            "**/eslint.config.{cjs,mjs,js,ts}",
+            "**/.prettierrc.{cjs,mjs,js,ts}",
+            "**/.prettierrc"
+          ],
+          "optionalDependencies": false
+        }
+      ],
+      "import-x/no-import-module-exports": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "import-x/no-mutable-exports": "error",
+      "import-x/no-named-as-default": "error",
+      "import-x/no-named-as-default-member": "off",
+      "import-x/no-named-default": "error",
+      "import-x/no-nodejs-modules": "off",
+      "import-x/no-relative-packages": "error",
+      "import-x/no-self-import": "error",
+      "import-x/no-unresolved": [
+        "error",
+        {
+          "caseSensitive": true,
+          "commonjs": true
+        }
+      ],
+      "import-x/no-unused-modules": "error",
+      "import-x/no-useless-path-segments": [
+        "error",
+        {
+          "commonjs": true
+        }
+      ],
+      "import-x/no-webpack-loader-syntax": "error",
+      "import-x/prefer-default-export": "off",
+      "indent": "off",
+      "indent-legacy": "off",
+      "jsx-quotes": "off",
+      "key-spacing": "off",
+      "keyword-spacing": "off",
+      "linebreak-style": "off",
+      "lines-around-comment": 0,
+      "max-classes-per-file": [
+        "error",
+        1
+      ],
+      "max-len": 0,
+      "max-statements-per-line": "off",
+      "multiline-ternary": "off",
+      "new-cap": [
+        "error",
+        {
+          "capIsNew": false,
+          "capIsNewExceptions": [
+            "Immutable.Map",
+            "Immutable.Set",
+            "Immutable.List"
+          ],
+          "newIsCap": true,
+          "newIsCapExceptions": []
+        }
+      ],
+      "new-parens": "off",
+      "newline-per-chained-call": "off",
+      "no-alert": "error",
+      "no-array-constructor": "error",
+      "no-arrow-condition": "off",
+      "no-async-promise-executor": "error",
+      "no-await-in-loop": "error",
+      "no-bitwise": "error",
+      "no-caller": "error",
+      "no-case-declarations": "error",
+      "no-class-assign": "error",
+      "no-comma-dangle": "off",
+      "no-compare-neg-zero": "error",
+      "no-cond-assign": [
+        "error",
+        "always"
+      ],
+      "no-confusing-arrow": 0,
+      "no-console": "off",
+      "no-const-assign": "error",
+      "no-constant-binary-expression": "error",
+      "no-constant-condition": "warn",
+      "no-constructor-return": "error",
+      "no-continue": "error",
+      "no-control-regex": "error",
+      "no-debugger": "error",
+      "no-delete-var": "error",
+      "no-dupe-args": "error",
+      "no-dupe-class-members": "error",
+      "no-dupe-else-if": "error",
+      "no-dupe-keys": "error",
+      "no-duplicate-case": "error",
+      "no-else-return": [
+        "error",
+        {
+          "allowElseIf": false
+        }
+      ],
+      "no-empty": "error",
+      "no-empty-character-class": "error",
+      "no-empty-function": [
+        "error",
+        {
+          "allow": [
+            "arrowFunctions",
+            "functions",
+            "methods"
+          ]
+        }
+      ],
+      "no-empty-pattern": "error",
+      "no-empty-static-block": "error",
+      "no-eval": "error",
+      "no-ex-assign": "error",
+      "no-extend-native": "error",
+      "no-extra-bind": "error",
+      "no-extra-boolean-cast": "error",
+      "no-extra-label": "error",
+      "no-extra-parens": "off",
+      "no-extra-semi": "off",
+      "no-fallthrough": "error",
+      "no-floating-decimal": "off",
+      "no-func-assign": "error",
+      "no-global-assign": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "no-implied-eval": "error",
+      "no-import-assign": "error",
+      "no-inner-declarations": "error",
+      "no-invalid-regexp": "error",
+      "no-irregular-whitespace": "error",
+      "no-iterator": "error",
+      "no-label-var": "error",
+      "no-labels": [
+        "error",
+        {
+          "allowLoop": false,
+          "allowSwitch": false
+        }
+      ],
+      "no-lone-blocks": "error",
+      "no-lonely-if": "error",
+      "no-loop-func": "error",
+      "no-loss-of-precision": "error",
+      "no-magic-numbers": "off",
+      "no-misleading-character-class": "error",
+      "no-mixed-operators": 0,
+      "no-mixed-spaces-and-tabs": "off",
+      "no-multi-assign": [
+        "error"
+      ],
+      "no-multi-spaces": "off",
+      "no-multi-str": "error",
+      "no-multiple-empty-lines": "off",
+      "no-nested-ternary": "error",
+      "no-new": "error",
+      "no-new-func": "error",
+      "no-new-native-nonconstructor": "error",
+      "no-new-wrappers": "error",
+      "no-nonoctal-decimal-escape": "error",
+      "no-obj-calls": "error",
+      "no-object-constructor": "error",
+      "no-octal": "error",
+      "no-octal-escape": "error",
+      "no-param-reassign": [
+        "error",
+        {
+          "ignorePropertyModificationsFor": [
+            "prev",
+            "acc",
+            "accumulator",
+            "e",
+            "ctx",
+            "context",
+            "req",
+            "request",
+            "res",
+            "response",
+            "$scope",
+            "staticContext",
+            "sharedState",
+            "state"
+          ],
+          "props": true
+        }
+      ],
+      "no-promise-executor-return": "error",
+      "no-proto": "error",
+      "no-prototype-builtins": "error",
+      "no-redeclare": "error",
+      "no-regex-spaces": "error",
+      "no-reserved-keys": "off",
+      "no-restricted-exports": [
+        "error",
+        {
+          "restrictedNamedExports": [
+            "default",
+            "then"
+          ]
+        }
+      ],
+      "no-restricted-globals": [
+        "error",
+        {
+          "message": "Use Number.isFinite instead",
+          "name": "isFinite"
+        },
+        {
+          "message": "Use Number.isNaN instead",
+          "name": "isNaN"
+        },
+        {
+          "message": "Use window.addEventListener instead",
+          "name": "addEventListener"
+        },
+        {
+          "message": "Use window.blur instead",
+          "name": "blur"
+        },
+        {
+          "message": "Use window.close instead",
+          "name": "close"
+        },
+        {
+          "message": "Use window.closed instead",
+          "name": "closed"
+        },
+        {
+          "message": "Use window.confirm instead",
+          "name": "confirm"
+        },
+        {
+          "message": "Use window.defaultStatus instead",
+          "name": "defaultStatus"
+        },
+        {
+          "message": "Use window.defaultstatus instead",
+          "name": "defaultstatus"
+        },
+        {
+          "message": "Use window.event instead",
+          "name": "event"
+        },
+        {
+          "message": "Use window.external instead",
+          "name": "external"
+        },
+        {
+          "message": "Use window.find instead",
+          "name": "find"
+        },
+        {
+          "message": "Use window.focus instead",
+          "name": "focus"
+        },
+        {
+          "message": "Use window.frameElement instead",
+          "name": "frameElement"
+        },
+        {
+          "message": "Use window.frames instead",
+          "name": "frames"
+        },
+        {
+          "message": "Use window.history instead",
+          "name": "history"
+        },
+        {
+          "message": "Use window.innerHeight instead",
+          "name": "innerHeight"
+        },
+        {
+          "message": "Use window.innerWidth instead",
+          "name": "innerWidth"
+        },
+        {
+          "message": "Use window.length instead",
+          "name": "length"
+        },
+        {
+          "message": "Use window.location instead",
+          "name": "location"
+        },
+        {
+          "message": "Use window.locationbar instead",
+          "name": "locationbar"
+        },
+        {
+          "message": "Use window.menubar instead",
+          "name": "menubar"
+        },
+        {
+          "message": "Use window.moveBy instead",
+          "name": "moveBy"
+        },
+        {
+          "message": "Use window.moveTo instead",
+          "name": "moveTo"
+        },
+        {
+          "message": "Use window.name instead",
+          "name": "name"
+        },
+        {
+          "message": "Use window.onblur instead",
+          "name": "onblur"
+        },
+        {
+          "message": "Use window.onerror instead",
+          "name": "onerror"
+        },
+        {
+          "message": "Use window.onfocus instead",
+          "name": "onfocus"
+        },
+        {
+          "message": "Use window.onload instead",
+          "name": "onload"
+        },
+        {
+          "message": "Use window.onresize instead",
+          "name": "onresize"
+        },
+        {
+          "message": "Use window.onunload instead",
+          "name": "onunload"
+        },
+        {
+          "message": "Use window.open instead",
+          "name": "open"
+        },
+        {
+          "message": "Use window.opener instead",
+          "name": "opener"
+        },
+        {
+          "message": "Use window.opera instead",
+          "name": "opera"
+        },
+        {
+          "message": "Use window.outerHeight instead",
+          "name": "outerHeight"
+        },
+        {
+          "message": "Use window.outerWidth instead",
+          "name": "outerWidth"
+        },
+        {
+          "message": "Use window.pageXOffset instead",
+          "name": "pageXOffset"
+        },
+        {
+          "message": "Use window.pageYOffset instead",
+          "name": "pageYOffset"
+        },
+        {
+          "message": "Use window.parent instead",
+          "name": "parent"
+        },
+        {
+          "message": "Use window.print instead",
+          "name": "print"
+        },
+        {
+          "message": "Use window.removeEventListener instead",
+          "name": "removeEventListener"
+        },
+        {
+          "message": "Use window.resizeBy instead",
+          "name": "resizeBy"
+        },
+        {
+          "message": "Use window.resizeTo instead",
+          "name": "resizeTo"
+        },
+        {
+          "message": "Use window.screen instead",
+          "name": "screen"
+        },
+        {
+          "message": "Use window.screenLeft instead",
+          "name": "screenLeft"
+        },
+        {
+          "message": "Use window.screenTop instead",
+          "name": "screenTop"
+        },
+        {
+          "message": "Use window.screenX instead",
+          "name": "screenX"
+        },
+        {
+          "message": "Use window.screenY instead",
+          "name": "screenY"
+        },
+        {
+          "message": "Use window.scroll instead",
+          "name": "scroll"
+        },
+        {
+          "message": "Use window.scrollbars instead",
+          "name": "scrollbars"
+        },
+        {
+          "message": "Use window.scrollBy instead",
+          "name": "scrollBy"
+        },
+        {
+          "message": "Use window.scrollTo instead",
+          "name": "scrollTo"
+        },
+        {
+          "message": "Use window.scrollX instead",
+          "name": "scrollX"
+        },
+        {
+          "message": "Use window.scrollY instead",
+          "name": "scrollY"
+        },
+        {
+          "message": "Use window.self instead",
+          "name": "self"
+        },
+        {
+          "message": "Use window.status instead",
+          "name": "status"
+        },
+        {
+          "message": "Use window.statusbar instead",
+          "name": "statusbar"
+        },
+        {
+          "message": "Use window.stop instead",
+          "name": "stop"
+        },
+        {
+          "message": "Use window.toolbar instead",
+          "name": "toolbar"
+        },
+        {
+          "message": "Use window.top instead",
+          "name": "top"
+        }
+      ],
+      "no-restricted-imports": [
+        "off",
+        {
+          "paths": [],
+          "patterns": []
+        }
+      ],
+      "no-restricted-properties": [
+        "error",
+        {
+          "message": "arguments.callee is deprecated",
+          "object": "arguments",
+          "property": "callee"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "global",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "self",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "window",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "global",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "self",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "window",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineGetter__"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineSetter__"
+        },
+        {
+          "message": "Use the exponentiation operator (**) instead.",
+          "object": "Math",
+          "property": "pow"
+        }
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.",
+          "selector": "LabeledStatement"
+        },
+        {
+          "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
+          "selector": "WithStatement"
+        }
+      ],
+      "no-return-assign": [
+        "error",
+        "always"
+      ],
+      "no-script-url": "error",
+      "no-self-assign": [
+        "error",
+        {
+          "props": true
+        }
+      ],
+      "no-self-compare": "error",
+      "no-sequences": "error",
+      "no-setter-return": "error",
+      "no-shadow": "error",
+      "no-shadow-restricted-names": "error",
+      "no-space-before-semi": "off",
+      "no-spaced-func": "off",
+      "no-sparse-arrays": "error",
+      "no-tabs": 0,
+      "no-template-curly-in-string": "error",
+      "no-this-before-super": "error",
+      "no-throw-literal": "error",
+      "no-trailing-spaces": "off",
+      "no-undef": "error",
+      "no-undef-init": "error",
+      "no-underscore-dangle": "off",
+      "no-unexpected-multiline": 0,
+      "no-unmodified-loop-condition": "error",
+      "no-unneeded-ternary": [
+        "error",
+        {
+          "defaultAssignment": false
+        }
+      ],
+      "no-unreachable": "error",
+      "no-unreachable-loop": [
+        "error",
+        {
+          "ignore": []
+        }
+      ],
+      "no-unsafe-finally": "error",
+      "no-unsafe-negation": "error",
+      "no-unsafe-optional-chaining": [
+        "error",
+        {
+          "disallowArithmeticOperators": true
+        }
+      ],
+      "no-unused-expressions": [
+        "error",
+        {
+          "allowShortCircuit": false,
+          "allowTaggedTemplates": false,
+          "allowTernary": false
+        }
+      ],
+      "no-unused-labels": "error",
+      "no-unused-private-class-members": "error",
+      "no-unused-vars": [
+        "error",
+        {
+          "args": "after-used",
+          "ignoreRestSiblings": true,
+          "vars": "all"
+        }
+      ],
+      "no-useless-backreference": "error",
+      "no-useless-call": "error",
+      "no-useless-catch": "error",
+      "no-useless-computed-key": "error",
+      "no-useless-concat": "error",
+      "no-useless-constructor": "error",
+      "no-useless-escape": "error",
+      "no-useless-rename": [
+        "error",
+        {
+          "ignoreDestructuring": false,
+          "ignoreExport": false,
+          "ignoreImport": false
+        }
+      ],
+      "no-useless-return": "error",
+      "no-var": "error",
+      "no-whitespace-before-property": "off",
+      "no-with": "error",
+      "no-wrap-func": "off",
+      "nonblock-statement-body-position": "off",
+      "object-curly-newline": "off",
+      "object-curly-spacing": "off",
+      "object-property-newline": "off",
+      "object-shorthand": [
+        "error",
+        "always",
+        {
+          "avoidQuotes": true,
+          "ignoreConstructors": false
+        }
+      ],
+      "one-var": [
+        "error",
+        "never"
+      ],
+      "one-var-declaration-per-line": "off",
+      "operator-assignment": [
+        "error",
+        "always"
+      ],
+      "operator-linebreak": "off",
+      "padded-blocks": "off",
+      "prefer-arrow-callback": "off",
+      "prefer-const": [
+        "error",
+        {
+          "destructuring": "any",
+          "ignoreReadBeforeAssign": true
+        }
+      ],
+      "prefer-exponentiation-operator": "error",
+      "prefer-numeric-literals": "error",
+      "prefer-object-has-own": "error",
+      "prefer-object-spread": "error",
+      "prefer-promise-reject-errors": [
+        "error",
+        {
+          "allowEmptyReject": true
+        }
+      ],
+      "prefer-regex-literals": [
+        "error",
+        {
+          "disallowRedundantWrapping": true
+        }
+      ],
+      "prefer-rest-params": "error",
+      "prefer-spread": "error",
+      "prefer-template": "error",
+      "quote-props": "off",
+      "quotes": 0,
+      "radix": "error",
+      "react/jsx-child-element-spacing": "off",
+      "react/jsx-closing-bracket-location": "off",
+      "react/jsx-closing-tag-location": "off",
+      "react/jsx-curly-newline": "off",
+      "react/jsx-curly-spacing": "off",
+      "react/jsx-equals-spacing": "off",
+      "react/jsx-first-prop-new-line": "off",
+      "react/jsx-indent": "off",
+      "react/jsx-indent-props": "off",
+      "react/jsx-max-props-per-line": "off",
+      "react/jsx-newline": "off",
+      "react/jsx-one-expression-per-line": "off",
+      "react/jsx-props-no-multi-spaces": "off",
+      "react/jsx-space-before-closing": "off",
+      "react/jsx-tag-spacing": "off",
+      "react/jsx-wrap-multilines": "off",
+      "require-atomic-updates": "error",
+      "require-yield": "error",
+      "rest-spread-spacing": "off",
+      "semi": "off",
+      "semi-spacing": "off",
+      "semi-style": "off",
+      "space-after-function-name": "off",
+      "space-after-keywords": "off",
+      "space-before-blocks": "off",
+      "space-before-function-paren": "off",
+      "space-before-function-parentheses": "off",
+      "space-before-keywords": "off",
+      "space-in-brackets": "off",
+      "space-in-parens": "off",
+      "space-infix-ops": "off",
+      "space-return-throw-case": "off",
+      "space-unary-ops": "off",
+      "space-unary-word-ops": "off",
+      "standard/array-bracket-even-spacing": "off",
+      "standard/computed-property-even-spacing": "off",
+      "standard/object-curly-even-spacing": "off",
+      "switch-colon-spacing": "off",
+      "symbol-description": "error",
+      "template-curly-spacing": "off",
+      "template-tag-spacing": "off",
+      "unicode-bom": [
+        "error",
+        "never"
+      ],
+      "unicorn/empty-brace-spaces": "off",
+      "unicorn/no-nested-ternary": "off",
+      "unicorn/number-literal-case": "off",
+      "unicorn/template-indent": 0,
+      "use-isnan": "error",
+      "valid-typeof": [
+        "error",
+        {
+          "requireStringLiterals": true
+        }
+      ],
+      "vue/array-bracket-newline": "off",
+      "vue/array-bracket-spacing": "off",
+      "vue/array-element-newline": "off",
+      "vue/arrow-spacing": "off",
+      "vue/block-spacing": "off",
+      "vue/block-tag-newline": "off",
+      "vue/brace-style": "off",
+      "vue/comma-dangle": "off",
+      "vue/comma-spacing": "off",
+      "vue/comma-style": "off",
+      "vue/dot-location": "off",
+      "vue/func-call-spacing": "off",
+      "vue/html-closing-bracket-newline": "off",
+      "vue/html-closing-bracket-spacing": "off",
+      "vue/html-end-tags": "off",
+      "vue/html-indent": "off",
+      "vue/html-quotes": "off",
+      "vue/html-self-closing": 0,
+      "vue/key-spacing": "off",
+      "vue/keyword-spacing": "off",
+      "vue/max-attributes-per-line": "off",
+      "vue/max-len": 0,
+      "vue/multiline-html-element-content-newline": "off",
+      "vue/multiline-ternary": "off",
+      "vue/mustache-interpolation-spacing": "off",
+      "vue/no-extra-parens": "off",
+      "vue/no-multi-spaces": "off",
+      "vue/no-spaces-around-equal-signs-in-attribute": "off",
+      "vue/object-curly-newline": "off",
+      "vue/object-curly-spacing": "off",
+      "vue/object-property-newline": "off",
+      "vue/operator-linebreak": "off",
+      "vue/quote-props": "off",
+      "vue/script-indent": "off",
+      "vue/singleline-html-element-content-newline": "off",
+      "vue/space-in-parens": "off",
+      "vue/space-infix-ops": "off",
+      "vue/space-unary-ops": "off",
+      "vue/template-curly-spacing": "off",
+      "wrap-iife": "off",
+      "wrap-regex": "off",
+      "yield-star-spacing": "off",
+      "yoda": "error"
+    }
+  },
+  {
+    "files": [
+      "**/*.cts"
+    ],
+    "languageOptions": {
+      "ecmaVersion": "latest",
+      "globals": {
+        "AbortController": false,
+        "AbortSignal": false,
+        "Blob": false,
+        "BroadcastChannel": false,
+        "Buffer": false,
+        "ByteLengthQueuingStrategy": false,
+        "CloseEvent": false,
+        "CompressionStream": false,
+        "CountQueuingStrategy": false,
+        "Crypto": false,
+        "CryptoKey": false,
+        "CustomEvent": false,
+        "DOMException": false,
+        "DecompressionStream": false,
+        "Event": false,
+        "EventTarget": false,
+        "File": false,
+        "FormData": false,
+        "Headers": false,
+        "MessageChannel": false,
+        "MessageEvent": false,
+        "MessagePort": false,
+        "Navigator": false,
+        "Performance": false,
+        "PerformanceEntry": false,
+        "PerformanceMark": false,
+        "PerformanceMeasure": false,
+        "PerformanceObserver": false,
+        "PerformanceObserverEntryList": false,
+        "PerformanceResourceTiming": false,
+        "ReadableByteStreamController": false,
+        "ReadableStream": false,
+        "ReadableStreamBYOBReader": false,
+        "ReadableStreamBYOBRequest": false,
+        "ReadableStreamDefaultController": false,
+        "ReadableStreamDefaultReader": false,
+        "Request": false,
+        "Response": false,
+        "SubtleCrypto": false,
+        "TextDecoder": false,
+        "TextDecoderStream": false,
+        "TextEncoder": false,
+        "TextEncoderStream": false,
+        "TransformStream": false,
+        "TransformStreamDefaultController": false,
+        "URL": false,
+        "URLSearchParams": false,
+        "WebAssembly": false,
+        "WebSocket": false,
+        "WritableStream": false,
+        "WritableStreamDefaultController": false,
+        "WritableStreamDefaultWriter": false,
+        "__dirname": false,
+        "__filename": false,
+        "atob": false,
+        "btoa": false,
+        "clearImmediate": false,
+        "clearInterval": false,
+        "clearTimeout": false,
+        "console": false,
+        "crypto": false,
+        "exports": true,
+        "fetch": false,
+        "global": false,
+        "module": false,
+        "navigator": false,
+        "performance": false,
+        "process": false,
+        "queueMicrotask": false,
+        "require": false,
+        "setImmediate": false,
+        "setInterval": false,
+        "setTimeout": false,
+        "structuredClone": false
+      },
+      "parser": "@qlik/eslint-config/node-esm-cts-parser",
+      "parserOptions": {
+        "parser": {
+          "meta": {
+            "name": "typescript-eslint/parser",
+            "version": "8.28.0"
+          },
+          "version": "8.28.0"
+        },
+        "projectService": true,
+        "warnOnUnsupportedTypeScriptVersion": false
+      },
+      "sourceType": "commonjs"
+    },
+    "name": "@qlik/eslint-config/node-esm-cts",
+    "plugins": {
+      "@typescript-eslint": "@typescript-eslint-plugin",
+      "import-x": "import-x-plugin"
+    },
+    "rules": {
+      "@babel/object-curly-spacing": "off",
+      "@babel/semi": "off",
+      "@stylistic/array-bracket-newline": "off",
+      "@stylistic/array-bracket-spacing": "off",
+      "@stylistic/array-element-newline": "off",
+      "@stylistic/arrow-parens": "off",
+      "@stylistic/arrow-spacing": "off",
+      "@stylistic/block-spacing": "off",
+      "@stylistic/brace-style": "off",
+      "@stylistic/comma-dangle": "off",
+      "@stylistic/comma-spacing": "off",
+      "@stylistic/comma-style": "off",
+      "@stylistic/computed-property-spacing": "off",
+      "@stylistic/dot-location": "off",
+      "@stylistic/eol-last": "off",
+      "@stylistic/func-call-spacing": "off",
+      "@stylistic/function-call-argument-newline": "off",
+      "@stylistic/function-call-spacing": "off",
+      "@stylistic/function-paren-newline": "off",
+      "@stylistic/generator-star-spacing": "off",
+      "@stylistic/implicit-arrow-linebreak": "off",
+      "@stylistic/indent": "off",
+      "@stylistic/indent-binary-ops": "off",
+      "@stylistic/js/array-bracket-newline": "off",
+      "@stylistic/js/array-bracket-spacing": "off",
+      "@stylistic/js/array-element-newline": "off",
+      "@stylistic/js/arrow-parens": "off",
+      "@stylistic/js/arrow-spacing": "off",
+      "@stylistic/js/block-spacing": "off",
+      "@stylistic/js/brace-style": "off",
+      "@stylistic/js/comma-dangle": "off",
+      "@stylistic/js/comma-spacing": "off",
+      "@stylistic/js/comma-style": "off",
+      "@stylistic/js/computed-property-spacing": "off",
+      "@stylistic/js/dot-location": "off",
+      "@stylistic/js/eol-last": "off",
+      "@stylistic/js/func-call-spacing": "off",
+      "@stylistic/js/function-call-argument-newline": "off",
+      "@stylistic/js/function-call-spacing": "off",
+      "@stylistic/js/function-paren-newline": "off",
+      "@stylistic/js/generator-star-spacing": "off",
+      "@stylistic/js/implicit-arrow-linebreak": "off",
+      "@stylistic/js/indent": "off",
+      "@stylistic/js/jsx-quotes": "off",
+      "@stylistic/js/key-spacing": "off",
+      "@stylistic/js/keyword-spacing": "off",
+      "@stylistic/js/linebreak-style": "off",
+      "@stylistic/js/lines-around-comment": 0,
+      "@stylistic/js/max-len": 0,
+      "@stylistic/js/max-statements-per-line": "off",
+      "@stylistic/js/multiline-ternary": "off",
+      "@stylistic/js/new-parens": "off",
+      "@stylistic/js/newline-per-chained-call": "off",
+      "@stylistic/js/no-confusing-arrow": 0,
+      "@stylistic/js/no-extra-parens": "off",
+      "@stylistic/js/no-extra-semi": "off",
+      "@stylistic/js/no-floating-decimal": "off",
+      "@stylistic/js/no-mixed-operators": 0,
+      "@stylistic/js/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/js/no-multi-spaces": "off",
+      "@stylistic/js/no-multiple-empty-lines": "off",
+      "@stylistic/js/no-tabs": 0,
+      "@stylistic/js/no-trailing-spaces": "off",
+      "@stylistic/js/no-whitespace-before-property": "off",
+      "@stylistic/js/nonblock-statement-body-position": "off",
+      "@stylistic/js/object-curly-newline": "off",
+      "@stylistic/js/object-curly-spacing": "off",
+      "@stylistic/js/object-property-newline": "off",
+      "@stylistic/js/one-var-declaration-per-line": "off",
+      "@stylistic/js/operator-linebreak": "off",
+      "@stylistic/js/padded-blocks": "off",
+      "@stylistic/js/quote-props": "off",
+      "@stylistic/js/quotes": 0,
+      "@stylistic/js/rest-spread-spacing": "off",
+      "@stylistic/js/semi": "off",
+      "@stylistic/js/semi-spacing": "off",
+      "@stylistic/js/semi-style": "off",
+      "@stylistic/js/space-before-blocks": "off",
+      "@stylistic/js/space-before-function-paren": "off",
+      "@stylistic/js/space-in-parens": "off",
+      "@stylistic/js/space-infix-ops": "off",
+      "@stylistic/js/space-unary-ops": "off",
+      "@stylistic/js/switch-colon-spacing": "off",
+      "@stylistic/js/template-curly-spacing": "off",
+      "@stylistic/js/template-tag-spacing": "off",
+      "@stylistic/js/wrap-iife": "off",
+      "@stylistic/js/wrap-regex": "off",
+      "@stylistic/js/yield-star-spacing": "off",
+      "@stylistic/jsx-child-element-spacing": "off",
+      "@stylistic/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx-closing-tag-location": "off",
+      "@stylistic/jsx-curly-newline": "off",
+      "@stylistic/jsx-curly-spacing": "off",
+      "@stylistic/jsx-equals-spacing": "off",
+      "@stylistic/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx-indent": "off",
+      "@stylistic/jsx-indent-props": "off",
+      "@stylistic/jsx-max-props-per-line": "off",
+      "@stylistic/jsx-newline": "off",
+      "@stylistic/jsx-one-expression-per-line": "off",
+      "@stylistic/jsx-props-no-multi-spaces": "off",
+      "@stylistic/jsx-quotes": "off",
+      "@stylistic/jsx-tag-spacing": "off",
+      "@stylistic/jsx-wrap-multilines": "off",
+      "@stylistic/jsx/jsx-child-element-spacing": "off",
+      "@stylistic/jsx/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx/jsx-closing-tag-location": "off",
+      "@stylistic/jsx/jsx-curly-newline": "off",
+      "@stylistic/jsx/jsx-curly-spacing": "off",
+      "@stylistic/jsx/jsx-equals-spacing": "off",
+      "@stylistic/jsx/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx/jsx-indent": "off",
+      "@stylistic/jsx/jsx-indent-props": "off",
+      "@stylistic/jsx/jsx-max-props-per-line": "off",
+      "@stylistic/key-spacing": "off",
+      "@stylistic/keyword-spacing": "off",
+      "@stylistic/linebreak-style": "off",
+      "@stylistic/lines-around-comment": 0,
+      "@stylistic/max-len": 0,
+      "@stylistic/max-statements-per-line": "off",
+      "@stylistic/member-delimiter-style": "off",
+      "@stylistic/multiline-ternary": "off",
+      "@stylistic/new-parens": "off",
+      "@stylistic/newline-per-chained-call": "off",
+      "@stylistic/no-confusing-arrow": 0,
+      "@stylistic/no-extra-parens": "off",
+      "@stylistic/no-extra-semi": "off",
+      "@stylistic/no-floating-decimal": "off",
+      "@stylistic/no-mixed-operators": 0,
+      "@stylistic/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/no-multi-spaces": "off",
+      "@stylistic/no-multiple-empty-lines": "off",
+      "@stylistic/no-tabs": 0,
+      "@stylistic/no-trailing-spaces": "off",
+      "@stylistic/no-whitespace-before-property": "off",
+      "@stylistic/nonblock-statement-body-position": "off",
+      "@stylistic/object-curly-newline": "off",
+      "@stylistic/object-curly-spacing": "off",
+      "@stylistic/object-property-newline": "off",
+      "@stylistic/one-var-declaration-per-line": "off",
+      "@stylistic/operator-linebreak": "off",
+      "@stylistic/padded-blocks": "off",
+      "@stylistic/quote-props": "off",
+      "@stylistic/quotes": 0,
+      "@stylistic/rest-spread-spacing": "off",
+      "@stylistic/semi": "off",
+      "@stylistic/semi-spacing": "off",
+      "@stylistic/semi-style": "off",
+      "@stylistic/space-before-blocks": "off",
+      "@stylistic/space-before-function-paren": "off",
+      "@stylistic/space-in-parens": "off",
+      "@stylistic/space-infix-ops": "off",
+      "@stylistic/space-unary-ops": "off",
+      "@stylistic/switch-colon-spacing": "off",
+      "@stylistic/template-curly-spacing": "off",
+      "@stylistic/template-tag-spacing": "off",
+      "@stylistic/ts/block-spacing": "off",
+      "@stylistic/ts/brace-style": "off",
+      "@stylistic/ts/comma-dangle": "off",
+      "@stylistic/ts/comma-spacing": "off",
+      "@stylistic/ts/func-call-spacing": "off",
+      "@stylistic/ts/function-call-spacing": "off",
+      "@stylistic/ts/indent": "off",
+      "@stylistic/ts/key-spacing": "off",
+      "@stylistic/ts/keyword-spacing": "off",
+      "@stylistic/ts/lines-around-comment": 0,
+      "@stylistic/ts/member-delimiter-style": "off",
+      "@stylistic/ts/no-extra-parens": "off",
+      "@stylistic/ts/no-extra-semi": "off",
+      "@stylistic/ts/object-curly-spacing": "off",
+      "@stylistic/ts/quotes": 0,
+      "@stylistic/ts/semi": "off",
+      "@stylistic/ts/space-before-blocks": "off",
+      "@stylistic/ts/space-before-function-paren": "off",
+      "@stylistic/ts/space-infix-ops": "off",
+      "@stylistic/ts/type-annotation-spacing": "off",
+      "@stylistic/type-annotation-spacing": "off",
+      "@stylistic/type-generic-spacing": "off",
+      "@stylistic/type-named-tuple-spacing": "off",
+      "@stylistic/wrap-iife": "off",
+      "@stylistic/wrap-regex": "off",
+      "@stylistic/yield-star-spacing": "off",
+      "@typescript-eslint/ban-ts-comment": "error",
+      "@typescript-eslint/block-spacing": "off",
+      "@typescript-eslint/brace-style": "off",
+      "@typescript-eslint/class-methods-use-this": [
+        "warn",
+        {
+          "exceptMethods": []
+        }
+      ],
+      "@typescript-eslint/comma-dangle": "off",
+      "@typescript-eslint/comma-spacing": "off",
+      "@typescript-eslint/consistent-type-exports": "error",
+      "@typescript-eslint/consistent-type-imports": "error",
+      "@typescript-eslint/default-param-last": "error",
+      "@typescript-eslint/explicit-module-boundary-types": "off",
+      "@typescript-eslint/func-call-spacing": "off",
+      "@typescript-eslint/indent": "off",
+      "@typescript-eslint/key-spacing": "off",
+      "@typescript-eslint/keyword-spacing": "off",
+      "@typescript-eslint/lines-around-comment": 0,
+      "@typescript-eslint/member-delimiter-style": "off",
+      "@typescript-eslint/method-signature-style": "error",
+      "@typescript-eslint/naming-convention": [
+        "error",
+        {
+          "format": [
+            "camelCase",
+            "PascalCase",
+            "UPPER_CASE"
+          ],
+          "selector": "variable"
+        },
+        {
+          "format": [
+            "camelCase",
+            "PascalCase"
+          ],
+          "selector": "function"
+        },
+        {
+          "format": [
+            "PascalCase"
+          ],
+          "selector": "typeLike"
+        }
+      ],
+      "@typescript-eslint/no-array-constructor": "error",
+      "@typescript-eslint/no-confusing-void-expression": "error",
+      "@typescript-eslint/no-duplicate-enum-values": "error",
+      "@typescript-eslint/no-dynamic-delete": "error",
+      "@typescript-eslint/no-empty-object-type": "error",
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/no-extra-non-null-assertion": "error",
+      "@typescript-eslint/no-extra-parens": "off",
+      "@typescript-eslint/no-extra-semi": "off",
+      "@typescript-eslint/no-extraneous-class": "error",
+      "@typescript-eslint/no-floating-promises": [
+        "error",
+        {
+          "ignoreIIFE": true
+        }
+      ],
+      "@typescript-eslint/no-import-type-side-effects": "error",
+      "@typescript-eslint/no-invalid-void-type": "error",
+      "@typescript-eslint/no-loop-func": "error",
+      "@typescript-eslint/no-magic-numbers": "off",
+      "@typescript-eslint/no-meaningless-void-operator": "error",
+      "@typescript-eslint/no-misused-new": "error",
+      "@typescript-eslint/no-misused-promises": [
+        "error",
+        {
+          "checksConditionals": false
+        }
+      ],
+      "@typescript-eslint/no-mixed-enums": "error",
+      "@typescript-eslint/no-namespace": "error",
+      "@typescript-eslint/no-non-null-asserted-nullish-coalescing": "error",
+      "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
+      "@typescript-eslint/no-non-null-assertion": "error",
+      "@typescript-eslint/no-redeclare": "error",
+      "@typescript-eslint/no-require-imports": "error",
+      "@typescript-eslint/no-restricted-imports": [
+        "off",
+        {
+          "paths": [],
+          "patterns": []
+        }
+      ],
+      "@typescript-eslint/no-restricted-types": [
+        "error",
+        {}
+      ],
+      "@typescript-eslint/no-shadow": "error",
+      "@typescript-eslint/no-this-alias": "error",
+      "@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
+      "@typescript-eslint/no-unnecessary-condition": "error",
+      "@typescript-eslint/no-unnecessary-parameter-property-assignment": "error",
+      "@typescript-eslint/no-unnecessary-qualifier": "error",
+      "@typescript-eslint/no-unnecessary-template-expression": "error",
+      "@typescript-eslint/no-unnecessary-type-arguments": "error",
+      "@typescript-eslint/no-unnecessary-type-constraint": "error",
+      "@typescript-eslint/no-unnecessary-type-parameters": "off",
+      "@typescript-eslint/no-unsafe-declaration-merging": "error",
+      "@typescript-eslint/no-unsafe-function-type": "error",
+      "@typescript-eslint/no-unused-expressions": "error",
+      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/no-useless-constructor": "error",
+      "@typescript-eslint/no-useless-empty-export": "error",
+      "@typescript-eslint/no-wrapper-object-types": "error",
+      "@typescript-eslint/object-curly-spacing": "off",
+      "@typescript-eslint/prefer-as-const": "error",
+      "@typescript-eslint/prefer-enum-initializers": "error",
+      "@typescript-eslint/prefer-for-of": "off",
+      "@typescript-eslint/prefer-literal-enum-member": "error",
+      "@typescript-eslint/prefer-namespace-keyword": "error",
+      "@typescript-eslint/prefer-reduce-type-parameter": "error",
+      "@typescript-eslint/prefer-return-this-type": "error",
+      "@typescript-eslint/quotes": 0,
+      "@typescript-eslint/require-array-sort-compare": "error",
+      "@typescript-eslint/return-await": "error",
+      "@typescript-eslint/semi": "off",
+      "@typescript-eslint/space-before-blocks": "off",
+      "@typescript-eslint/space-before-function-paren": "off",
+      "@typescript-eslint/space-infix-ops": "off",
+      "@typescript-eslint/strict-boolean-expressions": "off",
+      "@typescript-eslint/switch-exhaustiveness-check": "error",
+      "@typescript-eslint/triple-slash-reference": "error",
+      "@typescript-eslint/type-annotation-spacing": "off",
+      "@typescript-eslint/unified-signatures": "error",
+      "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
+      "array-bracket-newline": "off",
+      "array-bracket-spacing": "off",
+      "array-callback-return": [
+        "error",
+        {
+          "allowImplicit": true
+        }
+      ],
+      "array-element-newline": "off",
+      "arrow-body-style": "off",
+      "arrow-parens": "off",
+      "arrow-spacing": "off",
+      "babel/object-curly-spacing": "off",
+      "babel/quotes": 0,
+      "babel/semi": "off",
+      "block-scoped-var": "error",
+      "block-spacing": "off",
+      "brace-style": "off",
+      "camelcase": "off",
+      "class-methods-use-this": "off",
+      "comma-dangle": "off",
+      "comma-spacing": "off",
+      "comma-style": "off",
+      "computed-property-spacing": "off",
+      "consistent-return": "error",
+      "constructor-super": "off",
+      "curly": 0,
+      "default-case": [
+        "error",
+        {
+          "commentPattern": "^no default$"
+        }
+      ],
+      "default-case-last": "error",
+      "default-param-last": "off",
+      "dot-location": "off",
+      "eol-last": "off",
+      "eqeqeq": [
+        "error",
+        "always",
+        {
+          "null": "ignore"
+        }
+      ],
+      "flowtype/boolean-style": "off",
+      "flowtype/delimiter-dangle": "off",
+      "flowtype/generic-spacing": "off",
+      "flowtype/object-type-curly-spacing": "off",
+      "flowtype/object-type-delimiter": "off",
+      "flowtype/quotes": "off",
+      "flowtype/semi": "off",
+      "flowtype/space-after-type-colon": "off",
+      "flowtype/space-before-generic-bracket": "off",
+      "flowtype/space-before-type-colon": "off",
+      "flowtype/union-intersection-spacing": "off",
+      "for-direction": "error",
+      "func-call-spacing": "off",
+      "func-names": "warn",
+      "function-call-argument-newline": "off",
+      "function-paren-newline": "off",
+      "generator-star": "off",
+      "generator-star-spacing": "off",
+      "getter-return": "off",
+      "grouped-accessor-pairs": "error",
+      "implicit-arrow-linebreak": "off",
+      "import-x/consistent-type-specifier-style": "off",
+      "import-x/default": "error",
+      "import-x/export": "error",
+      "import-x/extensions": [
+        "error",
+        "ignorePackages",
+        {
+          "cjs": "never",
+          "cts": "never",
+          "js": "never",
+          "jsx": "never",
+          "mjs": "never",
           "mts": "never",
           "ts": "never",
           "tsx": "never"

--- a/packages/eslint-config/test/generated/react-final-config.js
+++ b/packages/eslint-config/test/generated/react-final-config.js
@@ -1180,6 +1180,9 @@ export default [
       "@eslint-react/dom/no-void-elements-with-children": "error",
       "@eslint-react/hooks-extra/no-direct-set-state-in-use-effect": "warn",
       "@eslint-react/hooks-extra/no-unnecessary-use-prefix": "warn",
+      "@eslint-react/hooks-extra/prefer-use-state-lazy-initialization": "warn",
+      "@eslint-react/jsx-no-duplicate-props": "warn",
+      "@eslint-react/jsx-uses-vars": "warn",
       "@eslint-react/no-access-state-in-setstate": "error",
       "@eslint-react/no-array-index-key": "warn",
       "@eslint-react/no-children-count": "warn",
@@ -1196,7 +1199,6 @@ export default [
       "@eslint-react/no-create-ref": "error",
       "@eslint-react/no-default-props": "error",
       "@eslint-react/no-direct-mutation-state": "error",
-      "@eslint-react/no-duplicate-jsx-props": "warn",
       "@eslint-react/no-duplicate-key": "warn",
       "@eslint-react/no-forward-ref": "warn",
       "@eslint-react/no-implicit-key": "warn",
@@ -1218,7 +1220,6 @@ export default [
       "@eslint-react/no-use-context": "warn",
       "@eslint-react/no-useless-forward-ref": "warn",
       "@eslint-react/no-useless-fragment": "warn",
-      "@eslint-react/use-jsx-vars": "warn",
       "@eslint-react/web-api/no-leaked-event-listener": "warn",
       "@eslint-react/web-api/no-leaked-interval": "warn",
       "@eslint-react/web-api/no-leaked-resize-observer": "warn",
@@ -3975,9 +3976,9 @@ export default [
         "parser": {
           "meta": {
             "name": "typescript-eslint/parser",
-            "version": "8.27.0"
+            "version": "8.28.0"
           },
-          "version": "8.27.0"
+          "version": "8.28.0"
         },
         "projectService": true,
         "warnOnUnsupportedTypeScriptVersion": false
@@ -4018,6 +4019,9 @@ export default [
       "@eslint-react/dom/no-void-elements-with-children": "error",
       "@eslint-react/hooks-extra/no-direct-set-state-in-use-effect": "warn",
       "@eslint-react/hooks-extra/no-unnecessary-use-prefix": "warn",
+      "@eslint-react/hooks-extra/prefer-use-state-lazy-initialization": "warn",
+      "@eslint-react/jsx-no-duplicate-props": "warn",
+      "@eslint-react/jsx-uses-vars": "warn",
       "@eslint-react/no-access-state-in-setstate": "error",
       "@eslint-react/no-array-index-key": "warn",
       "@eslint-react/no-children-count": "warn",
@@ -4034,7 +4038,6 @@ export default [
       "@eslint-react/no-create-ref": "error",
       "@eslint-react/no-default-props": "error",
       "@eslint-react/no-direct-mutation-state": "error",
-      "@eslint-react/no-duplicate-jsx-props": "warn",
       "@eslint-react/no-duplicate-key": "warn",
       "@eslint-react/no-forward-ref": "warn",
       "@eslint-react/no-implicit-key": "warn",
@@ -4056,7 +4059,6 @@ export default [
       "@eslint-react/no-use-context": "warn",
       "@eslint-react/no-useless-forward-ref": "warn",
       "@eslint-react/no-useless-fragment": "warn",
-      "@eslint-react/use-jsx-vars": "warn",
       "@eslint-react/web-api/no-leaked-event-listener": "warn",
       "@eslint-react/web-api/no-leaked-interval": "warn",
       "@eslint-react/web-api/no-leaked-resize-observer": "warn",
@@ -5762,6 +5764,2508 @@ export default [
         "skipImportCheck": true,
         "strict": false,
         "version": "detect"
+      }
+    }
+  },
+  {
+    "files": [
+      "**/*.cjs"
+    ],
+    "languageOptions": {
+      "ecmaVersion": "latest",
+      "globals": {
+        "AbortController": false,
+        "AbortSignal": false,
+        "Blob": false,
+        "BroadcastChannel": false,
+        "Buffer": false,
+        "ByteLengthQueuingStrategy": false,
+        "CloseEvent": false,
+        "CompressionStream": false,
+        "CountQueuingStrategy": false,
+        "Crypto": false,
+        "CryptoKey": false,
+        "CustomEvent": false,
+        "DOMException": false,
+        "DecompressionStream": false,
+        "Event": false,
+        "EventTarget": false,
+        "File": false,
+        "FormData": false,
+        "Headers": false,
+        "MessageChannel": false,
+        "MessageEvent": false,
+        "MessagePort": false,
+        "Navigator": false,
+        "Performance": false,
+        "PerformanceEntry": false,
+        "PerformanceMark": false,
+        "PerformanceMeasure": false,
+        "PerformanceObserver": false,
+        "PerformanceObserverEntryList": false,
+        "PerformanceResourceTiming": false,
+        "ReadableByteStreamController": false,
+        "ReadableStream": false,
+        "ReadableStreamBYOBReader": false,
+        "ReadableStreamBYOBRequest": false,
+        "ReadableStreamDefaultController": false,
+        "ReadableStreamDefaultReader": false,
+        "Request": false,
+        "Response": false,
+        "SubtleCrypto": false,
+        "TextDecoder": false,
+        "TextDecoderStream": false,
+        "TextEncoder": false,
+        "TextEncoderStream": false,
+        "TransformStream": false,
+        "TransformStreamDefaultController": false,
+        "URL": false,
+        "URLSearchParams": false,
+        "WebAssembly": false,
+        "WebSocket": false,
+        "WritableStream": false,
+        "WritableStreamDefaultController": false,
+        "WritableStreamDefaultWriter": false,
+        "__dirname": false,
+        "__filename": false,
+        "atob": false,
+        "btoa": false,
+        "clearImmediate": false,
+        "clearInterval": false,
+        "clearTimeout": false,
+        "console": false,
+        "crypto": false,
+        "exports": true,
+        "fetch": false,
+        "global": false,
+        "module": false,
+        "navigator": false,
+        "performance": false,
+        "process": false,
+        "queueMicrotask": false,
+        "require": false,
+        "setImmediate": false,
+        "setInterval": false,
+        "setTimeout": false,
+        "structuredClone": false
+      },
+      "parser": "@qlik/eslint-config/react-cjs-parser",
+      "parserOptions": {
+        "warnOnUnsupportedTypeScriptVersion": false
+      },
+      "sourceType": "commonjs"
+    },
+    "name": "@qlik/eslint-config/react-cjs",
+    "plugins": {
+      "@typescript-eslint": "@typescript-eslint-plugin",
+      "import-x": "import-x-plugin"
+    },
+    "rules": {
+      "@babel/object-curly-spacing": "off",
+      "@babel/semi": "off",
+      "@stylistic/array-bracket-newline": "off",
+      "@stylistic/array-bracket-spacing": "off",
+      "@stylistic/array-element-newline": "off",
+      "@stylistic/arrow-parens": "off",
+      "@stylistic/arrow-spacing": "off",
+      "@stylistic/block-spacing": "off",
+      "@stylistic/brace-style": "off",
+      "@stylistic/comma-dangle": "off",
+      "@stylistic/comma-spacing": "off",
+      "@stylistic/comma-style": "off",
+      "@stylistic/computed-property-spacing": "off",
+      "@stylistic/dot-location": "off",
+      "@stylistic/eol-last": "off",
+      "@stylistic/func-call-spacing": "off",
+      "@stylistic/function-call-argument-newline": "off",
+      "@stylistic/function-call-spacing": "off",
+      "@stylistic/function-paren-newline": "off",
+      "@stylistic/generator-star-spacing": "off",
+      "@stylistic/implicit-arrow-linebreak": "off",
+      "@stylistic/indent": "off",
+      "@stylistic/indent-binary-ops": "off",
+      "@stylistic/js/array-bracket-newline": "off",
+      "@stylistic/js/array-bracket-spacing": "off",
+      "@stylistic/js/array-element-newline": "off",
+      "@stylistic/js/arrow-parens": "off",
+      "@stylistic/js/arrow-spacing": "off",
+      "@stylistic/js/block-spacing": "off",
+      "@stylistic/js/brace-style": "off",
+      "@stylistic/js/comma-dangle": "off",
+      "@stylistic/js/comma-spacing": "off",
+      "@stylistic/js/comma-style": "off",
+      "@stylistic/js/computed-property-spacing": "off",
+      "@stylistic/js/dot-location": "off",
+      "@stylistic/js/eol-last": "off",
+      "@stylistic/js/func-call-spacing": "off",
+      "@stylistic/js/function-call-argument-newline": "off",
+      "@stylistic/js/function-call-spacing": "off",
+      "@stylistic/js/function-paren-newline": "off",
+      "@stylistic/js/generator-star-spacing": "off",
+      "@stylistic/js/implicit-arrow-linebreak": "off",
+      "@stylistic/js/indent": "off",
+      "@stylistic/js/jsx-quotes": "off",
+      "@stylistic/js/key-spacing": "off",
+      "@stylistic/js/keyword-spacing": "off",
+      "@stylistic/js/linebreak-style": "off",
+      "@stylistic/js/lines-around-comment": 0,
+      "@stylistic/js/max-len": 0,
+      "@stylistic/js/max-statements-per-line": "off",
+      "@stylistic/js/multiline-ternary": "off",
+      "@stylistic/js/new-parens": "off",
+      "@stylistic/js/newline-per-chained-call": "off",
+      "@stylistic/js/no-confusing-arrow": 0,
+      "@stylistic/js/no-extra-parens": "off",
+      "@stylistic/js/no-extra-semi": "off",
+      "@stylistic/js/no-floating-decimal": "off",
+      "@stylistic/js/no-mixed-operators": 0,
+      "@stylistic/js/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/js/no-multi-spaces": "off",
+      "@stylistic/js/no-multiple-empty-lines": "off",
+      "@stylistic/js/no-tabs": 0,
+      "@stylistic/js/no-trailing-spaces": "off",
+      "@stylistic/js/no-whitespace-before-property": "off",
+      "@stylistic/js/nonblock-statement-body-position": "off",
+      "@stylistic/js/object-curly-newline": "off",
+      "@stylistic/js/object-curly-spacing": "off",
+      "@stylistic/js/object-property-newline": "off",
+      "@stylistic/js/one-var-declaration-per-line": "off",
+      "@stylistic/js/operator-linebreak": "off",
+      "@stylistic/js/padded-blocks": "off",
+      "@stylistic/js/quote-props": "off",
+      "@stylistic/js/quotes": 0,
+      "@stylistic/js/rest-spread-spacing": "off",
+      "@stylistic/js/semi": "off",
+      "@stylistic/js/semi-spacing": "off",
+      "@stylistic/js/semi-style": "off",
+      "@stylistic/js/space-before-blocks": "off",
+      "@stylistic/js/space-before-function-paren": "off",
+      "@stylistic/js/space-in-parens": "off",
+      "@stylistic/js/space-infix-ops": "off",
+      "@stylistic/js/space-unary-ops": "off",
+      "@stylistic/js/switch-colon-spacing": "off",
+      "@stylistic/js/template-curly-spacing": "off",
+      "@stylistic/js/template-tag-spacing": "off",
+      "@stylistic/js/wrap-iife": "off",
+      "@stylistic/js/wrap-regex": "off",
+      "@stylistic/js/yield-star-spacing": "off",
+      "@stylistic/jsx-child-element-spacing": "off",
+      "@stylistic/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx-closing-tag-location": "off",
+      "@stylistic/jsx-curly-newline": "off",
+      "@stylistic/jsx-curly-spacing": "off",
+      "@stylistic/jsx-equals-spacing": "off",
+      "@stylistic/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx-indent": "off",
+      "@stylistic/jsx-indent-props": "off",
+      "@stylistic/jsx-max-props-per-line": "off",
+      "@stylistic/jsx-newline": "off",
+      "@stylistic/jsx-one-expression-per-line": "off",
+      "@stylistic/jsx-props-no-multi-spaces": "off",
+      "@stylistic/jsx-quotes": "off",
+      "@stylistic/jsx-tag-spacing": "off",
+      "@stylistic/jsx-wrap-multilines": "off",
+      "@stylistic/jsx/jsx-child-element-spacing": "off",
+      "@stylistic/jsx/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx/jsx-closing-tag-location": "off",
+      "@stylistic/jsx/jsx-curly-newline": "off",
+      "@stylistic/jsx/jsx-curly-spacing": "off",
+      "@stylistic/jsx/jsx-equals-spacing": "off",
+      "@stylistic/jsx/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx/jsx-indent": "off",
+      "@stylistic/jsx/jsx-indent-props": "off",
+      "@stylistic/jsx/jsx-max-props-per-line": "off",
+      "@stylistic/key-spacing": "off",
+      "@stylistic/keyword-spacing": "off",
+      "@stylistic/linebreak-style": "off",
+      "@stylistic/lines-around-comment": 0,
+      "@stylistic/max-len": 0,
+      "@stylistic/max-statements-per-line": "off",
+      "@stylistic/member-delimiter-style": "off",
+      "@stylistic/multiline-ternary": "off",
+      "@stylistic/new-parens": "off",
+      "@stylistic/newline-per-chained-call": "off",
+      "@stylistic/no-confusing-arrow": 0,
+      "@stylistic/no-extra-parens": "off",
+      "@stylistic/no-extra-semi": "off",
+      "@stylistic/no-floating-decimal": "off",
+      "@stylistic/no-mixed-operators": 0,
+      "@stylistic/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/no-multi-spaces": "off",
+      "@stylistic/no-multiple-empty-lines": "off",
+      "@stylistic/no-tabs": 0,
+      "@stylistic/no-trailing-spaces": "off",
+      "@stylistic/no-whitespace-before-property": "off",
+      "@stylistic/nonblock-statement-body-position": "off",
+      "@stylistic/object-curly-newline": "off",
+      "@stylistic/object-curly-spacing": "off",
+      "@stylistic/object-property-newline": "off",
+      "@stylistic/one-var-declaration-per-line": "off",
+      "@stylistic/operator-linebreak": "off",
+      "@stylistic/padded-blocks": "off",
+      "@stylistic/quote-props": "off",
+      "@stylistic/quotes": 0,
+      "@stylistic/rest-spread-spacing": "off",
+      "@stylistic/semi": "off",
+      "@stylistic/semi-spacing": "off",
+      "@stylistic/semi-style": "off",
+      "@stylistic/space-before-blocks": "off",
+      "@stylistic/space-before-function-paren": "off",
+      "@stylistic/space-in-parens": "off",
+      "@stylistic/space-infix-ops": "off",
+      "@stylistic/space-unary-ops": "off",
+      "@stylistic/switch-colon-spacing": "off",
+      "@stylistic/template-curly-spacing": "off",
+      "@stylistic/template-tag-spacing": "off",
+      "@stylistic/ts/block-spacing": "off",
+      "@stylistic/ts/brace-style": "off",
+      "@stylistic/ts/comma-dangle": "off",
+      "@stylistic/ts/comma-spacing": "off",
+      "@stylistic/ts/func-call-spacing": "off",
+      "@stylistic/ts/function-call-spacing": "off",
+      "@stylistic/ts/indent": "off",
+      "@stylistic/ts/key-spacing": "off",
+      "@stylistic/ts/keyword-spacing": "off",
+      "@stylistic/ts/lines-around-comment": 0,
+      "@stylistic/ts/member-delimiter-style": "off",
+      "@stylistic/ts/no-extra-parens": "off",
+      "@stylistic/ts/no-extra-semi": "off",
+      "@stylistic/ts/object-curly-spacing": "off",
+      "@stylistic/ts/quotes": 0,
+      "@stylistic/ts/semi": "off",
+      "@stylistic/ts/space-before-blocks": "off",
+      "@stylistic/ts/space-before-function-paren": "off",
+      "@stylistic/ts/space-infix-ops": "off",
+      "@stylistic/ts/type-annotation-spacing": "off",
+      "@stylistic/type-annotation-spacing": "off",
+      "@stylistic/type-generic-spacing": "off",
+      "@stylistic/type-named-tuple-spacing": "off",
+      "@stylistic/wrap-iife": "off",
+      "@stylistic/wrap-regex": "off",
+      "@stylistic/yield-star-spacing": "off",
+      "@typescript-eslint/block-spacing": "off",
+      "@typescript-eslint/brace-style": "off",
+      "@typescript-eslint/comma-dangle": "off",
+      "@typescript-eslint/comma-spacing": "off",
+      "@typescript-eslint/func-call-spacing": "off",
+      "@typescript-eslint/indent": "off",
+      "@typescript-eslint/key-spacing": "off",
+      "@typescript-eslint/keyword-spacing": "off",
+      "@typescript-eslint/lines-around-comment": 0,
+      "@typescript-eslint/member-delimiter-style": "off",
+      "@typescript-eslint/no-extra-parens": "off",
+      "@typescript-eslint/no-extra-semi": "off",
+      "@typescript-eslint/object-curly-spacing": "off",
+      "@typescript-eslint/quotes": 0,
+      "@typescript-eslint/semi": "off",
+      "@typescript-eslint/space-before-blocks": "off",
+      "@typescript-eslint/space-before-function-paren": "off",
+      "@typescript-eslint/space-infix-ops": "off",
+      "@typescript-eslint/type-annotation-spacing": "off",
+      "array-bracket-newline": "off",
+      "array-bracket-spacing": "off",
+      "array-callback-return": [
+        "error",
+        {
+          "allowImplicit": true
+        }
+      ],
+      "array-element-newline": "off",
+      "arrow-body-style": "off",
+      "arrow-parens": "off",
+      "arrow-spacing": "off",
+      "babel/object-curly-spacing": "off",
+      "babel/quotes": 0,
+      "babel/semi": "off",
+      "block-scoped-var": "error",
+      "block-spacing": "off",
+      "brace-style": "off",
+      "camelcase": [
+        "error",
+        {
+          "ignoreDestructuring": false,
+          "properties": "never"
+        }
+      ],
+      "class-methods-use-this": [
+        "warn",
+        {
+          "exceptMethods": []
+        }
+      ],
+      "comma-dangle": "off",
+      "comma-spacing": "off",
+      "comma-style": "off",
+      "computed-property-spacing": "off",
+      "consistent-return": "error",
+      "constructor-super": "error",
+      "curly": 0,
+      "default-case": [
+        "error",
+        {
+          "commentPattern": "^no default$"
+        }
+      ],
+      "default-case-last": "error",
+      "default-param-last": "error",
+      "dot-location": "off",
+      "eol-last": "off",
+      "eqeqeq": [
+        "error",
+        "always",
+        {
+          "null": "ignore"
+        }
+      ],
+      "flowtype/boolean-style": "off",
+      "flowtype/delimiter-dangle": "off",
+      "flowtype/generic-spacing": "off",
+      "flowtype/object-type-curly-spacing": "off",
+      "flowtype/object-type-delimiter": "off",
+      "flowtype/quotes": "off",
+      "flowtype/semi": "off",
+      "flowtype/space-after-type-colon": "off",
+      "flowtype/space-before-generic-bracket": "off",
+      "flowtype/space-before-type-colon": "off",
+      "flowtype/union-intersection-spacing": "off",
+      "for-direction": "error",
+      "func-call-spacing": "off",
+      "func-names": "warn",
+      "function-call-argument-newline": "off",
+      "function-paren-newline": "off",
+      "generator-star": "off",
+      "generator-star-spacing": "off",
+      "getter-return": [
+        "error",
+        {
+          "allowImplicit": true
+        }
+      ],
+      "grouped-accessor-pairs": "error",
+      "implicit-arrow-linebreak": "off",
+      "import-x/consistent-type-specifier-style": "off",
+      "import-x/default": "error",
+      "import-x/export": "error",
+      "import-x/extensions": [
+        "error",
+        "ignorePackages",
+        {
+          "cjs": "never",
+          "cts": "never",
+          "js": "never",
+          "jsx": "never",
+          "mjs": "never",
+          "mts": "never",
+          "ts": "never",
+          "tsx": "never"
+        }
+      ],
+      "import-x/named": "error",
+      "import-x/namespace": "error",
+      "import-x/newline-after-import": "error",
+      "import-x/no-absolute-path": "error",
+      "import-x/no-amd": "error",
+      "import-x/no-cycle": [
+        "error",
+        {
+          "ignoreExternal": true
+        }
+      ],
+      "import-x/no-deprecated": "warn",
+      "import-x/no-duplicates": "error",
+      "import-x/no-dynamic-require": "error",
+      "import-x/no-empty-named-blocks": "off",
+      "import-x/no-extraneous-dependencies": [
+        "off",
+        {
+          "devDependencies": [
+            "**/test*/**",
+            "**/mocks/**",
+            "**/mock/**",
+            "test/**",
+            "tests/**",
+            "spec/**",
+            "**/__tests__/**",
+            "**/__mocks__/**",
+            "test.{js,jsx,ts,tsx}",
+            "test-*.{js,jsx,ts,tsx}",
+            "**/*{.,_}{test,spec}.{js,jsx,ts,tsx}",
+            "**/jest.config.{cjs,mjs,js,ts}",
+            "**/jest.setup.{cjs,mjs,js,ts}",
+            "**/vitest.config.{cjs,mjs,js,ts}",
+            "**/vue.config.{cjs,mjs,js,ts}",
+            "**/svelte.config.{cjs,mjs,js,ts}",
+            "**/tsup.config.{cjs,mjs,js,ts}",
+            "**/playwright.config.{cjs,mjs,js,ts}",
+            "**/webpack.config.{cjs,mjs,js,ts}",
+            "**/webpack.mod.{cjs,mjs,js,ts}",
+            "**/rollup.config.{cjs,mjs,js,ts}",
+            "**/rollup.config.*cjs,mjs,.{js,ts}",
+            "**/protractor.conf.{cjs,mjs,js,ts}",
+            "**/protractor.conf.*.{cjs,mjs,js,ts}",
+            "**/.eslintrc.{cjs,mjs,js,ts}",
+            "**/eslint.config.{cjs,mjs,js,ts}",
+            "**/.prettierrc.{cjs,mjs,js,ts}",
+            "**/.prettierrc"
+          ],
+          "optionalDependencies": false
+        }
+      ],
+      "import-x/no-import-module-exports": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "import-x/no-mutable-exports": "error",
+      "import-x/no-named-as-default": "error",
+      "import-x/no-named-as-default-member": "off",
+      "import-x/no-named-default": "error",
+      "import-x/no-nodejs-modules": "off",
+      "import-x/no-relative-packages": "error",
+      "import-x/no-self-import": "error",
+      "import-x/no-unresolved": [
+        "error",
+        {
+          "caseSensitive": true,
+          "commonjs": true
+        }
+      ],
+      "import-x/no-unused-modules": "error",
+      "import-x/no-useless-path-segments": [
+        "error",
+        {
+          "commonjs": true
+        }
+      ],
+      "import-x/no-webpack-loader-syntax": "error",
+      "import-x/prefer-default-export": "off",
+      "indent": "off",
+      "indent-legacy": "off",
+      "jsx-quotes": "off",
+      "key-spacing": "off",
+      "keyword-spacing": "off",
+      "linebreak-style": "off",
+      "lines-around-comment": 0,
+      "max-classes-per-file": [
+        "error",
+        1
+      ],
+      "max-len": 0,
+      "max-statements-per-line": "off",
+      "multiline-ternary": "off",
+      "new-cap": [
+        "error",
+        {
+          "capIsNew": false,
+          "capIsNewExceptions": [
+            "Immutable.Map",
+            "Immutable.Set",
+            "Immutable.List"
+          ],
+          "newIsCap": true,
+          "newIsCapExceptions": []
+        }
+      ],
+      "new-parens": "off",
+      "newline-per-chained-call": "off",
+      "no-alert": "error",
+      "no-array-constructor": "error",
+      "no-arrow-condition": "off",
+      "no-async-promise-executor": "error",
+      "no-await-in-loop": "error",
+      "no-bitwise": "error",
+      "no-caller": "error",
+      "no-case-declarations": "error",
+      "no-class-assign": "error",
+      "no-comma-dangle": "off",
+      "no-compare-neg-zero": "error",
+      "no-cond-assign": [
+        "error",
+        "always"
+      ],
+      "no-confusing-arrow": 0,
+      "no-console": "off",
+      "no-const-assign": "error",
+      "no-constant-binary-expression": "error",
+      "no-constant-condition": "warn",
+      "no-constructor-return": "error",
+      "no-continue": "error",
+      "no-control-regex": "error",
+      "no-debugger": "error",
+      "no-delete-var": "error",
+      "no-dupe-args": "error",
+      "no-dupe-class-members": "error",
+      "no-dupe-else-if": "error",
+      "no-dupe-keys": "error",
+      "no-duplicate-case": "error",
+      "no-else-return": [
+        "error",
+        {
+          "allowElseIf": false
+        }
+      ],
+      "no-empty": "error",
+      "no-empty-character-class": "error",
+      "no-empty-function": [
+        "error",
+        {
+          "allow": [
+            "arrowFunctions",
+            "functions",
+            "methods"
+          ]
+        }
+      ],
+      "no-empty-pattern": "error",
+      "no-empty-static-block": "error",
+      "no-eval": "error",
+      "no-ex-assign": "error",
+      "no-extend-native": "error",
+      "no-extra-bind": "error",
+      "no-extra-boolean-cast": "error",
+      "no-extra-label": "error",
+      "no-extra-parens": "off",
+      "no-extra-semi": "off",
+      "no-fallthrough": "error",
+      "no-floating-decimal": "off",
+      "no-func-assign": "error",
+      "no-global-assign": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "no-implied-eval": "error",
+      "no-import-assign": "error",
+      "no-inner-declarations": "error",
+      "no-invalid-regexp": "error",
+      "no-irregular-whitespace": "error",
+      "no-iterator": "error",
+      "no-label-var": "error",
+      "no-labels": [
+        "error",
+        {
+          "allowLoop": false,
+          "allowSwitch": false
+        }
+      ],
+      "no-lone-blocks": "error",
+      "no-lonely-if": "error",
+      "no-loop-func": "error",
+      "no-loss-of-precision": "error",
+      "no-magic-numbers": "off",
+      "no-misleading-character-class": "error",
+      "no-mixed-operators": 0,
+      "no-mixed-spaces-and-tabs": "off",
+      "no-multi-assign": [
+        "error"
+      ],
+      "no-multi-spaces": "off",
+      "no-multi-str": "error",
+      "no-multiple-empty-lines": "off",
+      "no-nested-ternary": "error",
+      "no-new": "error",
+      "no-new-func": "error",
+      "no-new-native-nonconstructor": "error",
+      "no-new-wrappers": "error",
+      "no-nonoctal-decimal-escape": "error",
+      "no-obj-calls": "error",
+      "no-object-constructor": "error",
+      "no-octal": "error",
+      "no-octal-escape": "error",
+      "no-param-reassign": [
+        "error",
+        {
+          "ignorePropertyModificationsFor": [
+            "prev",
+            "acc",
+            "accumulator",
+            "e",
+            "ctx",
+            "context",
+            "req",
+            "request",
+            "res",
+            "response",
+            "$scope",
+            "staticContext",
+            "sharedState",
+            "state"
+          ],
+          "props": true
+        }
+      ],
+      "no-promise-executor-return": "error",
+      "no-proto": "error",
+      "no-prototype-builtins": "error",
+      "no-redeclare": "error",
+      "no-regex-spaces": "error",
+      "no-reserved-keys": "off",
+      "no-restricted-exports": [
+        "error",
+        {
+          "restrictedNamedExports": [
+            "default",
+            "then"
+          ]
+        }
+      ],
+      "no-restricted-globals": [
+        "error",
+        {
+          "message": "Use Number.isFinite instead",
+          "name": "isFinite"
+        },
+        {
+          "message": "Use Number.isNaN instead",
+          "name": "isNaN"
+        },
+        {
+          "message": "Use window.addEventListener instead",
+          "name": "addEventListener"
+        },
+        {
+          "message": "Use window.blur instead",
+          "name": "blur"
+        },
+        {
+          "message": "Use window.close instead",
+          "name": "close"
+        },
+        {
+          "message": "Use window.closed instead",
+          "name": "closed"
+        },
+        {
+          "message": "Use window.confirm instead",
+          "name": "confirm"
+        },
+        {
+          "message": "Use window.defaultStatus instead",
+          "name": "defaultStatus"
+        },
+        {
+          "message": "Use window.defaultstatus instead",
+          "name": "defaultstatus"
+        },
+        {
+          "message": "Use window.event instead",
+          "name": "event"
+        },
+        {
+          "message": "Use window.external instead",
+          "name": "external"
+        },
+        {
+          "message": "Use window.find instead",
+          "name": "find"
+        },
+        {
+          "message": "Use window.focus instead",
+          "name": "focus"
+        },
+        {
+          "message": "Use window.frameElement instead",
+          "name": "frameElement"
+        },
+        {
+          "message": "Use window.frames instead",
+          "name": "frames"
+        },
+        {
+          "message": "Use window.history instead",
+          "name": "history"
+        },
+        {
+          "message": "Use window.innerHeight instead",
+          "name": "innerHeight"
+        },
+        {
+          "message": "Use window.innerWidth instead",
+          "name": "innerWidth"
+        },
+        {
+          "message": "Use window.length instead",
+          "name": "length"
+        },
+        {
+          "message": "Use window.location instead",
+          "name": "location"
+        },
+        {
+          "message": "Use window.locationbar instead",
+          "name": "locationbar"
+        },
+        {
+          "message": "Use window.menubar instead",
+          "name": "menubar"
+        },
+        {
+          "message": "Use window.moveBy instead",
+          "name": "moveBy"
+        },
+        {
+          "message": "Use window.moveTo instead",
+          "name": "moveTo"
+        },
+        {
+          "message": "Use window.name instead",
+          "name": "name"
+        },
+        {
+          "message": "Use window.onblur instead",
+          "name": "onblur"
+        },
+        {
+          "message": "Use window.onerror instead",
+          "name": "onerror"
+        },
+        {
+          "message": "Use window.onfocus instead",
+          "name": "onfocus"
+        },
+        {
+          "message": "Use window.onload instead",
+          "name": "onload"
+        },
+        {
+          "message": "Use window.onresize instead",
+          "name": "onresize"
+        },
+        {
+          "message": "Use window.onunload instead",
+          "name": "onunload"
+        },
+        {
+          "message": "Use window.open instead",
+          "name": "open"
+        },
+        {
+          "message": "Use window.opener instead",
+          "name": "opener"
+        },
+        {
+          "message": "Use window.opera instead",
+          "name": "opera"
+        },
+        {
+          "message": "Use window.outerHeight instead",
+          "name": "outerHeight"
+        },
+        {
+          "message": "Use window.outerWidth instead",
+          "name": "outerWidth"
+        },
+        {
+          "message": "Use window.pageXOffset instead",
+          "name": "pageXOffset"
+        },
+        {
+          "message": "Use window.pageYOffset instead",
+          "name": "pageYOffset"
+        },
+        {
+          "message": "Use window.parent instead",
+          "name": "parent"
+        },
+        {
+          "message": "Use window.print instead",
+          "name": "print"
+        },
+        {
+          "message": "Use window.removeEventListener instead",
+          "name": "removeEventListener"
+        },
+        {
+          "message": "Use window.resizeBy instead",
+          "name": "resizeBy"
+        },
+        {
+          "message": "Use window.resizeTo instead",
+          "name": "resizeTo"
+        },
+        {
+          "message": "Use window.screen instead",
+          "name": "screen"
+        },
+        {
+          "message": "Use window.screenLeft instead",
+          "name": "screenLeft"
+        },
+        {
+          "message": "Use window.screenTop instead",
+          "name": "screenTop"
+        },
+        {
+          "message": "Use window.screenX instead",
+          "name": "screenX"
+        },
+        {
+          "message": "Use window.screenY instead",
+          "name": "screenY"
+        },
+        {
+          "message": "Use window.scroll instead",
+          "name": "scroll"
+        },
+        {
+          "message": "Use window.scrollbars instead",
+          "name": "scrollbars"
+        },
+        {
+          "message": "Use window.scrollBy instead",
+          "name": "scrollBy"
+        },
+        {
+          "message": "Use window.scrollTo instead",
+          "name": "scrollTo"
+        },
+        {
+          "message": "Use window.scrollX instead",
+          "name": "scrollX"
+        },
+        {
+          "message": "Use window.scrollY instead",
+          "name": "scrollY"
+        },
+        {
+          "message": "Use window.self instead",
+          "name": "self"
+        },
+        {
+          "message": "Use window.status instead",
+          "name": "status"
+        },
+        {
+          "message": "Use window.statusbar instead",
+          "name": "statusbar"
+        },
+        {
+          "message": "Use window.stop instead",
+          "name": "stop"
+        },
+        {
+          "message": "Use window.toolbar instead",
+          "name": "toolbar"
+        },
+        {
+          "message": "Use window.top instead",
+          "name": "top"
+        }
+      ],
+      "no-restricted-imports": [
+        "off",
+        {
+          "paths": [],
+          "patterns": []
+        }
+      ],
+      "no-restricted-properties": [
+        "error",
+        {
+          "message": "arguments.callee is deprecated",
+          "object": "arguments",
+          "property": "callee"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "global",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "self",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "window",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "global",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "self",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "window",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineGetter__"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineSetter__"
+        },
+        {
+          "message": "Use the exponentiation operator (**) instead.",
+          "object": "Math",
+          "property": "pow"
+        }
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.",
+          "selector": "LabeledStatement"
+        },
+        {
+          "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
+          "selector": "WithStatement"
+        }
+      ],
+      "no-return-assign": [
+        "error",
+        "always"
+      ],
+      "no-script-url": "error",
+      "no-self-assign": [
+        "error",
+        {
+          "props": true
+        }
+      ],
+      "no-self-compare": "error",
+      "no-sequences": "error",
+      "no-setter-return": "error",
+      "no-shadow": "error",
+      "no-shadow-restricted-names": "error",
+      "no-space-before-semi": "off",
+      "no-spaced-func": "off",
+      "no-sparse-arrays": "error",
+      "no-tabs": 0,
+      "no-template-curly-in-string": "error",
+      "no-this-before-super": "error",
+      "no-throw-literal": "error",
+      "no-trailing-spaces": "off",
+      "no-undef": "error",
+      "no-undef-init": "error",
+      "no-underscore-dangle": "off",
+      "no-unexpected-multiline": 0,
+      "no-unmodified-loop-condition": "error",
+      "no-unneeded-ternary": [
+        "error",
+        {
+          "defaultAssignment": false
+        }
+      ],
+      "no-unreachable": "error",
+      "no-unreachable-loop": [
+        "error",
+        {
+          "ignore": []
+        }
+      ],
+      "no-unsafe-finally": "error",
+      "no-unsafe-negation": "error",
+      "no-unsafe-optional-chaining": [
+        "error",
+        {
+          "disallowArithmeticOperators": true
+        }
+      ],
+      "no-unused-expressions": [
+        "error",
+        {
+          "allowShortCircuit": false,
+          "allowTaggedTemplates": false,
+          "allowTernary": false
+        }
+      ],
+      "no-unused-labels": "error",
+      "no-unused-private-class-members": "error",
+      "no-unused-vars": [
+        "error",
+        {
+          "args": "after-used",
+          "ignoreRestSiblings": true,
+          "vars": "all"
+        }
+      ],
+      "no-useless-backreference": "error",
+      "no-useless-call": "error",
+      "no-useless-catch": "error",
+      "no-useless-computed-key": "error",
+      "no-useless-concat": "error",
+      "no-useless-constructor": "error",
+      "no-useless-escape": "error",
+      "no-useless-rename": [
+        "error",
+        {
+          "ignoreDestructuring": false,
+          "ignoreExport": false,
+          "ignoreImport": false
+        }
+      ],
+      "no-useless-return": "error",
+      "no-var": "error",
+      "no-whitespace-before-property": "off",
+      "no-with": "error",
+      "no-wrap-func": "off",
+      "nonblock-statement-body-position": "off",
+      "object-curly-newline": "off",
+      "object-curly-spacing": "off",
+      "object-property-newline": "off",
+      "object-shorthand": [
+        "error",
+        "always",
+        {
+          "avoidQuotes": true,
+          "ignoreConstructors": false
+        }
+      ],
+      "one-var": [
+        "error",
+        "never"
+      ],
+      "one-var-declaration-per-line": "off",
+      "operator-assignment": [
+        "error",
+        "always"
+      ],
+      "operator-linebreak": "off",
+      "padded-blocks": "off",
+      "prefer-arrow-callback": "off",
+      "prefer-const": [
+        "error",
+        {
+          "destructuring": "any",
+          "ignoreReadBeforeAssign": true
+        }
+      ],
+      "prefer-exponentiation-operator": "error",
+      "prefer-numeric-literals": "error",
+      "prefer-object-has-own": "error",
+      "prefer-object-spread": "error",
+      "prefer-promise-reject-errors": [
+        "error",
+        {
+          "allowEmptyReject": true
+        }
+      ],
+      "prefer-regex-literals": [
+        "error",
+        {
+          "disallowRedundantWrapping": true
+        }
+      ],
+      "prefer-rest-params": "error",
+      "prefer-spread": "error",
+      "prefer-template": "error",
+      "quote-props": "off",
+      "quotes": 0,
+      "radix": "error",
+      "react/jsx-child-element-spacing": "off",
+      "react/jsx-closing-bracket-location": "off",
+      "react/jsx-closing-tag-location": "off",
+      "react/jsx-curly-newline": "off",
+      "react/jsx-curly-spacing": "off",
+      "react/jsx-equals-spacing": "off",
+      "react/jsx-first-prop-new-line": "off",
+      "react/jsx-indent": "off",
+      "react/jsx-indent-props": "off",
+      "react/jsx-max-props-per-line": "off",
+      "react/jsx-newline": "off",
+      "react/jsx-one-expression-per-line": "off",
+      "react/jsx-props-no-multi-spaces": "off",
+      "react/jsx-space-before-closing": "off",
+      "react/jsx-tag-spacing": "off",
+      "react/jsx-wrap-multilines": "off",
+      "require-atomic-updates": "error",
+      "require-yield": "error",
+      "rest-spread-spacing": "off",
+      "semi": "off",
+      "semi-spacing": "off",
+      "semi-style": "off",
+      "space-after-function-name": "off",
+      "space-after-keywords": "off",
+      "space-before-blocks": "off",
+      "space-before-function-paren": "off",
+      "space-before-function-parentheses": "off",
+      "space-before-keywords": "off",
+      "space-in-brackets": "off",
+      "space-in-parens": "off",
+      "space-infix-ops": "off",
+      "space-return-throw-case": "off",
+      "space-unary-ops": "off",
+      "space-unary-word-ops": "off",
+      "standard/array-bracket-even-spacing": "off",
+      "standard/computed-property-even-spacing": "off",
+      "standard/object-curly-even-spacing": "off",
+      "switch-colon-spacing": "off",
+      "symbol-description": "error",
+      "template-curly-spacing": "off",
+      "template-tag-spacing": "off",
+      "unicode-bom": [
+        "error",
+        "never"
+      ],
+      "unicorn/empty-brace-spaces": "off",
+      "unicorn/no-nested-ternary": "off",
+      "unicorn/number-literal-case": "off",
+      "unicorn/template-indent": 0,
+      "use-isnan": "error",
+      "valid-typeof": [
+        "error",
+        {
+          "requireStringLiterals": true
+        }
+      ],
+      "vue/array-bracket-newline": "off",
+      "vue/array-bracket-spacing": "off",
+      "vue/array-element-newline": "off",
+      "vue/arrow-spacing": "off",
+      "vue/block-spacing": "off",
+      "vue/block-tag-newline": "off",
+      "vue/brace-style": "off",
+      "vue/comma-dangle": "off",
+      "vue/comma-spacing": "off",
+      "vue/comma-style": "off",
+      "vue/dot-location": "off",
+      "vue/func-call-spacing": "off",
+      "vue/html-closing-bracket-newline": "off",
+      "vue/html-closing-bracket-spacing": "off",
+      "vue/html-end-tags": "off",
+      "vue/html-indent": "off",
+      "vue/html-quotes": "off",
+      "vue/html-self-closing": 0,
+      "vue/key-spacing": "off",
+      "vue/keyword-spacing": "off",
+      "vue/max-attributes-per-line": "off",
+      "vue/max-len": 0,
+      "vue/multiline-html-element-content-newline": "off",
+      "vue/multiline-ternary": "off",
+      "vue/mustache-interpolation-spacing": "off",
+      "vue/no-extra-parens": "off",
+      "vue/no-multi-spaces": "off",
+      "vue/no-spaces-around-equal-signs-in-attribute": "off",
+      "vue/object-curly-newline": "off",
+      "vue/object-curly-spacing": "off",
+      "vue/object-property-newline": "off",
+      "vue/operator-linebreak": "off",
+      "vue/quote-props": "off",
+      "vue/script-indent": "off",
+      "vue/singleline-html-element-content-newline": "off",
+      "vue/space-in-parens": "off",
+      "vue/space-infix-ops": "off",
+      "vue/space-unary-ops": "off",
+      "vue/template-curly-spacing": "off",
+      "wrap-iife": "off",
+      "wrap-regex": "off",
+      "yield-star-spacing": "off",
+      "yoda": "error"
+    }
+  },
+  {
+    "files": [
+      "**/*.cts"
+    ],
+    "languageOptions": {
+      "ecmaVersion": "latest",
+      "globals": {
+        "AbortController": false,
+        "AbortSignal": false,
+        "Blob": false,
+        "BroadcastChannel": false,
+        "Buffer": false,
+        "ByteLengthQueuingStrategy": false,
+        "CloseEvent": false,
+        "CompressionStream": false,
+        "CountQueuingStrategy": false,
+        "Crypto": false,
+        "CryptoKey": false,
+        "CustomEvent": false,
+        "DOMException": false,
+        "DecompressionStream": false,
+        "Event": false,
+        "EventTarget": false,
+        "File": false,
+        "FormData": false,
+        "Headers": false,
+        "MessageChannel": false,
+        "MessageEvent": false,
+        "MessagePort": false,
+        "Navigator": false,
+        "Performance": false,
+        "PerformanceEntry": false,
+        "PerformanceMark": false,
+        "PerformanceMeasure": false,
+        "PerformanceObserver": false,
+        "PerformanceObserverEntryList": false,
+        "PerformanceResourceTiming": false,
+        "ReadableByteStreamController": false,
+        "ReadableStream": false,
+        "ReadableStreamBYOBReader": false,
+        "ReadableStreamBYOBRequest": false,
+        "ReadableStreamDefaultController": false,
+        "ReadableStreamDefaultReader": false,
+        "Request": false,
+        "Response": false,
+        "SubtleCrypto": false,
+        "TextDecoder": false,
+        "TextDecoderStream": false,
+        "TextEncoder": false,
+        "TextEncoderStream": false,
+        "TransformStream": false,
+        "TransformStreamDefaultController": false,
+        "URL": false,
+        "URLSearchParams": false,
+        "WebAssembly": false,
+        "WebSocket": false,
+        "WritableStream": false,
+        "WritableStreamDefaultController": false,
+        "WritableStreamDefaultWriter": false,
+        "__dirname": false,
+        "__filename": false,
+        "atob": false,
+        "btoa": false,
+        "clearImmediate": false,
+        "clearInterval": false,
+        "clearTimeout": false,
+        "console": false,
+        "crypto": false,
+        "exports": true,
+        "fetch": false,
+        "global": false,
+        "module": false,
+        "navigator": false,
+        "performance": false,
+        "process": false,
+        "queueMicrotask": false,
+        "require": false,
+        "setImmediate": false,
+        "setInterval": false,
+        "setTimeout": false,
+        "structuredClone": false
+      },
+      "parser": "@qlik/eslint-config/react-cts-parser",
+      "parserOptions": {
+        "parser": {
+          "meta": {
+            "name": "typescript-eslint/parser",
+            "version": "8.28.0"
+          },
+          "version": "8.28.0"
+        },
+        "projectService": true,
+        "warnOnUnsupportedTypeScriptVersion": false
+      },
+      "sourceType": "commonjs"
+    },
+    "name": "@qlik/eslint-config/react-cts",
+    "plugins": {
+      "@typescript-eslint": "@typescript-eslint-plugin",
+      "import-x": "import-x-plugin"
+    },
+    "rules": {
+      "@babel/object-curly-spacing": "off",
+      "@babel/semi": "off",
+      "@stylistic/array-bracket-newline": "off",
+      "@stylistic/array-bracket-spacing": "off",
+      "@stylistic/array-element-newline": "off",
+      "@stylistic/arrow-parens": "off",
+      "@stylistic/arrow-spacing": "off",
+      "@stylistic/block-spacing": "off",
+      "@stylistic/brace-style": "off",
+      "@stylistic/comma-dangle": "off",
+      "@stylistic/comma-spacing": "off",
+      "@stylistic/comma-style": "off",
+      "@stylistic/computed-property-spacing": "off",
+      "@stylistic/dot-location": "off",
+      "@stylistic/eol-last": "off",
+      "@stylistic/func-call-spacing": "off",
+      "@stylistic/function-call-argument-newline": "off",
+      "@stylistic/function-call-spacing": "off",
+      "@stylistic/function-paren-newline": "off",
+      "@stylistic/generator-star-spacing": "off",
+      "@stylistic/implicit-arrow-linebreak": "off",
+      "@stylistic/indent": "off",
+      "@stylistic/indent-binary-ops": "off",
+      "@stylistic/js/array-bracket-newline": "off",
+      "@stylistic/js/array-bracket-spacing": "off",
+      "@stylistic/js/array-element-newline": "off",
+      "@stylistic/js/arrow-parens": "off",
+      "@stylistic/js/arrow-spacing": "off",
+      "@stylistic/js/block-spacing": "off",
+      "@stylistic/js/brace-style": "off",
+      "@stylistic/js/comma-dangle": "off",
+      "@stylistic/js/comma-spacing": "off",
+      "@stylistic/js/comma-style": "off",
+      "@stylistic/js/computed-property-spacing": "off",
+      "@stylistic/js/dot-location": "off",
+      "@stylistic/js/eol-last": "off",
+      "@stylistic/js/func-call-spacing": "off",
+      "@stylistic/js/function-call-argument-newline": "off",
+      "@stylistic/js/function-call-spacing": "off",
+      "@stylistic/js/function-paren-newline": "off",
+      "@stylistic/js/generator-star-spacing": "off",
+      "@stylistic/js/implicit-arrow-linebreak": "off",
+      "@stylistic/js/indent": "off",
+      "@stylistic/js/jsx-quotes": "off",
+      "@stylistic/js/key-spacing": "off",
+      "@stylistic/js/keyword-spacing": "off",
+      "@stylistic/js/linebreak-style": "off",
+      "@stylistic/js/lines-around-comment": 0,
+      "@stylistic/js/max-len": 0,
+      "@stylistic/js/max-statements-per-line": "off",
+      "@stylistic/js/multiline-ternary": "off",
+      "@stylistic/js/new-parens": "off",
+      "@stylistic/js/newline-per-chained-call": "off",
+      "@stylistic/js/no-confusing-arrow": 0,
+      "@stylistic/js/no-extra-parens": "off",
+      "@stylistic/js/no-extra-semi": "off",
+      "@stylistic/js/no-floating-decimal": "off",
+      "@stylistic/js/no-mixed-operators": 0,
+      "@stylistic/js/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/js/no-multi-spaces": "off",
+      "@stylistic/js/no-multiple-empty-lines": "off",
+      "@stylistic/js/no-tabs": 0,
+      "@stylistic/js/no-trailing-spaces": "off",
+      "@stylistic/js/no-whitespace-before-property": "off",
+      "@stylistic/js/nonblock-statement-body-position": "off",
+      "@stylistic/js/object-curly-newline": "off",
+      "@stylistic/js/object-curly-spacing": "off",
+      "@stylistic/js/object-property-newline": "off",
+      "@stylistic/js/one-var-declaration-per-line": "off",
+      "@stylistic/js/operator-linebreak": "off",
+      "@stylistic/js/padded-blocks": "off",
+      "@stylistic/js/quote-props": "off",
+      "@stylistic/js/quotes": 0,
+      "@stylistic/js/rest-spread-spacing": "off",
+      "@stylistic/js/semi": "off",
+      "@stylistic/js/semi-spacing": "off",
+      "@stylistic/js/semi-style": "off",
+      "@stylistic/js/space-before-blocks": "off",
+      "@stylistic/js/space-before-function-paren": "off",
+      "@stylistic/js/space-in-parens": "off",
+      "@stylistic/js/space-infix-ops": "off",
+      "@stylistic/js/space-unary-ops": "off",
+      "@stylistic/js/switch-colon-spacing": "off",
+      "@stylistic/js/template-curly-spacing": "off",
+      "@stylistic/js/template-tag-spacing": "off",
+      "@stylistic/js/wrap-iife": "off",
+      "@stylistic/js/wrap-regex": "off",
+      "@stylistic/js/yield-star-spacing": "off",
+      "@stylistic/jsx-child-element-spacing": "off",
+      "@stylistic/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx-closing-tag-location": "off",
+      "@stylistic/jsx-curly-newline": "off",
+      "@stylistic/jsx-curly-spacing": "off",
+      "@stylistic/jsx-equals-spacing": "off",
+      "@stylistic/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx-indent": "off",
+      "@stylistic/jsx-indent-props": "off",
+      "@stylistic/jsx-max-props-per-line": "off",
+      "@stylistic/jsx-newline": "off",
+      "@stylistic/jsx-one-expression-per-line": "off",
+      "@stylistic/jsx-props-no-multi-spaces": "off",
+      "@stylistic/jsx-quotes": "off",
+      "@stylistic/jsx-tag-spacing": "off",
+      "@stylistic/jsx-wrap-multilines": "off",
+      "@stylistic/jsx/jsx-child-element-spacing": "off",
+      "@stylistic/jsx/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx/jsx-closing-tag-location": "off",
+      "@stylistic/jsx/jsx-curly-newline": "off",
+      "@stylistic/jsx/jsx-curly-spacing": "off",
+      "@stylistic/jsx/jsx-equals-spacing": "off",
+      "@stylistic/jsx/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx/jsx-indent": "off",
+      "@stylistic/jsx/jsx-indent-props": "off",
+      "@stylistic/jsx/jsx-max-props-per-line": "off",
+      "@stylistic/key-spacing": "off",
+      "@stylistic/keyword-spacing": "off",
+      "@stylistic/linebreak-style": "off",
+      "@stylistic/lines-around-comment": 0,
+      "@stylistic/max-len": 0,
+      "@stylistic/max-statements-per-line": "off",
+      "@stylistic/member-delimiter-style": "off",
+      "@stylistic/multiline-ternary": "off",
+      "@stylistic/new-parens": "off",
+      "@stylistic/newline-per-chained-call": "off",
+      "@stylistic/no-confusing-arrow": 0,
+      "@stylistic/no-extra-parens": "off",
+      "@stylistic/no-extra-semi": "off",
+      "@stylistic/no-floating-decimal": "off",
+      "@stylistic/no-mixed-operators": 0,
+      "@stylistic/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/no-multi-spaces": "off",
+      "@stylistic/no-multiple-empty-lines": "off",
+      "@stylistic/no-tabs": 0,
+      "@stylistic/no-trailing-spaces": "off",
+      "@stylistic/no-whitespace-before-property": "off",
+      "@stylistic/nonblock-statement-body-position": "off",
+      "@stylistic/object-curly-newline": "off",
+      "@stylistic/object-curly-spacing": "off",
+      "@stylistic/object-property-newline": "off",
+      "@stylistic/one-var-declaration-per-line": "off",
+      "@stylistic/operator-linebreak": "off",
+      "@stylistic/padded-blocks": "off",
+      "@stylistic/quote-props": "off",
+      "@stylistic/quotes": 0,
+      "@stylistic/rest-spread-spacing": "off",
+      "@stylistic/semi": "off",
+      "@stylistic/semi-spacing": "off",
+      "@stylistic/semi-style": "off",
+      "@stylistic/space-before-blocks": "off",
+      "@stylistic/space-before-function-paren": "off",
+      "@stylistic/space-in-parens": "off",
+      "@stylistic/space-infix-ops": "off",
+      "@stylistic/space-unary-ops": "off",
+      "@stylistic/switch-colon-spacing": "off",
+      "@stylistic/template-curly-spacing": "off",
+      "@stylistic/template-tag-spacing": "off",
+      "@stylistic/ts/block-spacing": "off",
+      "@stylistic/ts/brace-style": "off",
+      "@stylistic/ts/comma-dangle": "off",
+      "@stylistic/ts/comma-spacing": "off",
+      "@stylistic/ts/func-call-spacing": "off",
+      "@stylistic/ts/function-call-spacing": "off",
+      "@stylistic/ts/indent": "off",
+      "@stylistic/ts/key-spacing": "off",
+      "@stylistic/ts/keyword-spacing": "off",
+      "@stylistic/ts/lines-around-comment": 0,
+      "@stylistic/ts/member-delimiter-style": "off",
+      "@stylistic/ts/no-extra-parens": "off",
+      "@stylistic/ts/no-extra-semi": "off",
+      "@stylistic/ts/object-curly-spacing": "off",
+      "@stylistic/ts/quotes": 0,
+      "@stylistic/ts/semi": "off",
+      "@stylistic/ts/space-before-blocks": "off",
+      "@stylistic/ts/space-before-function-paren": "off",
+      "@stylistic/ts/space-infix-ops": "off",
+      "@stylistic/ts/type-annotation-spacing": "off",
+      "@stylistic/type-annotation-spacing": "off",
+      "@stylistic/type-generic-spacing": "off",
+      "@stylistic/type-named-tuple-spacing": "off",
+      "@stylistic/wrap-iife": "off",
+      "@stylistic/wrap-regex": "off",
+      "@stylistic/yield-star-spacing": "off",
+      "@typescript-eslint/ban-ts-comment": "error",
+      "@typescript-eslint/block-spacing": "off",
+      "@typescript-eslint/brace-style": "off",
+      "@typescript-eslint/class-methods-use-this": [
+        "warn",
+        {
+          "exceptMethods": []
+        }
+      ],
+      "@typescript-eslint/comma-dangle": "off",
+      "@typescript-eslint/comma-spacing": "off",
+      "@typescript-eslint/consistent-type-exports": "error",
+      "@typescript-eslint/consistent-type-imports": "error",
+      "@typescript-eslint/default-param-last": "error",
+      "@typescript-eslint/explicit-module-boundary-types": "off",
+      "@typescript-eslint/func-call-spacing": "off",
+      "@typescript-eslint/indent": "off",
+      "@typescript-eslint/key-spacing": "off",
+      "@typescript-eslint/keyword-spacing": "off",
+      "@typescript-eslint/lines-around-comment": 0,
+      "@typescript-eslint/member-delimiter-style": "off",
+      "@typescript-eslint/method-signature-style": "error",
+      "@typescript-eslint/naming-convention": [
+        "error",
+        {
+          "format": [
+            "camelCase",
+            "PascalCase",
+            "UPPER_CASE"
+          ],
+          "selector": "variable"
+        },
+        {
+          "format": [
+            "camelCase",
+            "PascalCase"
+          ],
+          "selector": "function"
+        },
+        {
+          "format": [
+            "PascalCase"
+          ],
+          "selector": "typeLike"
+        }
+      ],
+      "@typescript-eslint/no-array-constructor": "error",
+      "@typescript-eslint/no-confusing-void-expression": "error",
+      "@typescript-eslint/no-duplicate-enum-values": "error",
+      "@typescript-eslint/no-dynamic-delete": "error",
+      "@typescript-eslint/no-empty-object-type": "error",
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/no-extra-non-null-assertion": "error",
+      "@typescript-eslint/no-extra-parens": "off",
+      "@typescript-eslint/no-extra-semi": "off",
+      "@typescript-eslint/no-extraneous-class": "error",
+      "@typescript-eslint/no-floating-promises": [
+        "error",
+        {
+          "ignoreIIFE": true
+        }
+      ],
+      "@typescript-eslint/no-import-type-side-effects": "error",
+      "@typescript-eslint/no-invalid-void-type": "error",
+      "@typescript-eslint/no-loop-func": "error",
+      "@typescript-eslint/no-magic-numbers": "off",
+      "@typescript-eslint/no-meaningless-void-operator": "error",
+      "@typescript-eslint/no-misused-new": "error",
+      "@typescript-eslint/no-misused-promises": [
+        "error",
+        {
+          "checksConditionals": false
+        }
+      ],
+      "@typescript-eslint/no-mixed-enums": "error",
+      "@typescript-eslint/no-namespace": "error",
+      "@typescript-eslint/no-non-null-asserted-nullish-coalescing": "error",
+      "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
+      "@typescript-eslint/no-non-null-assertion": "error",
+      "@typescript-eslint/no-redeclare": "error",
+      "@typescript-eslint/no-require-imports": "error",
+      "@typescript-eslint/no-restricted-imports": [
+        "off",
+        {
+          "paths": [],
+          "patterns": []
+        }
+      ],
+      "@typescript-eslint/no-restricted-types": [
+        "error",
+        {}
+      ],
+      "@typescript-eslint/no-shadow": "error",
+      "@typescript-eslint/no-this-alias": "error",
+      "@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
+      "@typescript-eslint/no-unnecessary-condition": "error",
+      "@typescript-eslint/no-unnecessary-parameter-property-assignment": "error",
+      "@typescript-eslint/no-unnecessary-qualifier": "error",
+      "@typescript-eslint/no-unnecessary-template-expression": "error",
+      "@typescript-eslint/no-unnecessary-type-arguments": "error",
+      "@typescript-eslint/no-unnecessary-type-constraint": "error",
+      "@typescript-eslint/no-unnecessary-type-parameters": "off",
+      "@typescript-eslint/no-unsafe-declaration-merging": "error",
+      "@typescript-eslint/no-unsafe-function-type": "error",
+      "@typescript-eslint/no-unused-expressions": "error",
+      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/no-useless-constructor": "error",
+      "@typescript-eslint/no-useless-empty-export": "error",
+      "@typescript-eslint/no-wrapper-object-types": "error",
+      "@typescript-eslint/object-curly-spacing": "off",
+      "@typescript-eslint/prefer-as-const": "error",
+      "@typescript-eslint/prefer-enum-initializers": "error",
+      "@typescript-eslint/prefer-for-of": "off",
+      "@typescript-eslint/prefer-literal-enum-member": "error",
+      "@typescript-eslint/prefer-namespace-keyword": "error",
+      "@typescript-eslint/prefer-reduce-type-parameter": "error",
+      "@typescript-eslint/prefer-return-this-type": "error",
+      "@typescript-eslint/quotes": 0,
+      "@typescript-eslint/require-array-sort-compare": "error",
+      "@typescript-eslint/return-await": "error",
+      "@typescript-eslint/semi": "off",
+      "@typescript-eslint/space-before-blocks": "off",
+      "@typescript-eslint/space-before-function-paren": "off",
+      "@typescript-eslint/space-infix-ops": "off",
+      "@typescript-eslint/strict-boolean-expressions": "off",
+      "@typescript-eslint/switch-exhaustiveness-check": "error",
+      "@typescript-eslint/triple-slash-reference": "error",
+      "@typescript-eslint/type-annotation-spacing": "off",
+      "@typescript-eslint/unified-signatures": "error",
+      "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
+      "array-bracket-newline": "off",
+      "array-bracket-spacing": "off",
+      "array-callback-return": [
+        "error",
+        {
+          "allowImplicit": true
+        }
+      ],
+      "array-element-newline": "off",
+      "arrow-body-style": "off",
+      "arrow-parens": "off",
+      "arrow-spacing": "off",
+      "babel/object-curly-spacing": "off",
+      "babel/quotes": 0,
+      "babel/semi": "off",
+      "block-scoped-var": "error",
+      "block-spacing": "off",
+      "brace-style": "off",
+      "camelcase": "off",
+      "class-methods-use-this": "off",
+      "comma-dangle": "off",
+      "comma-spacing": "off",
+      "comma-style": "off",
+      "computed-property-spacing": "off",
+      "consistent-return": "error",
+      "constructor-super": "off",
+      "curly": 0,
+      "default-case": [
+        "error",
+        {
+          "commentPattern": "^no default$"
+        }
+      ],
+      "default-case-last": "error",
+      "default-param-last": "off",
+      "dot-location": "off",
+      "eol-last": "off",
+      "eqeqeq": [
+        "error",
+        "always",
+        {
+          "null": "ignore"
+        }
+      ],
+      "flowtype/boolean-style": "off",
+      "flowtype/delimiter-dangle": "off",
+      "flowtype/generic-spacing": "off",
+      "flowtype/object-type-curly-spacing": "off",
+      "flowtype/object-type-delimiter": "off",
+      "flowtype/quotes": "off",
+      "flowtype/semi": "off",
+      "flowtype/space-after-type-colon": "off",
+      "flowtype/space-before-generic-bracket": "off",
+      "flowtype/space-before-type-colon": "off",
+      "flowtype/union-intersection-spacing": "off",
+      "for-direction": "error",
+      "func-call-spacing": "off",
+      "func-names": "warn",
+      "function-call-argument-newline": "off",
+      "function-paren-newline": "off",
+      "generator-star": "off",
+      "generator-star-spacing": "off",
+      "getter-return": "off",
+      "grouped-accessor-pairs": "error",
+      "implicit-arrow-linebreak": "off",
+      "import-x/consistent-type-specifier-style": "off",
+      "import-x/default": "error",
+      "import-x/export": "error",
+      "import-x/extensions": [
+        "error",
+        "ignorePackages",
+        {
+          "cjs": "never",
+          "cts": "never",
+          "js": "never",
+          "jsx": "never",
+          "mjs": "never",
+          "mts": "never",
+          "ts": "never",
+          "tsx": "never"
+        }
+      ],
+      "import-x/named": "off",
+      "import-x/namespace": "error",
+      "import-x/newline-after-import": "error",
+      "import-x/no-absolute-path": "error",
+      "import-x/no-amd": "error",
+      "import-x/no-cycle": [
+        "error",
+        {
+          "ignoreExternal": true
+        }
+      ],
+      "import-x/no-deprecated": "warn",
+      "import-x/no-duplicates": "error",
+      "import-x/no-dynamic-require": "error",
+      "import-x/no-empty-named-blocks": "off",
+      "import-x/no-extraneous-dependencies": [
+        "off",
+        {
+          "devDependencies": [
+            "**/test*/**",
+            "**/mocks/**",
+            "**/mock/**",
+            "test/**",
+            "tests/**",
+            "spec/**",
+            "**/__tests__/**",
+            "**/__mocks__/**",
+            "test.{js,jsx,ts,tsx}",
+            "test-*.{js,jsx,ts,tsx}",
+            "**/*{.,_}{test,spec}.{js,jsx,ts,tsx}",
+            "**/jest.config.{cjs,mjs,js,ts}",
+            "**/jest.setup.{cjs,mjs,js,ts}",
+            "**/vitest.config.{cjs,mjs,js,ts}",
+            "**/vue.config.{cjs,mjs,js,ts}",
+            "**/svelte.config.{cjs,mjs,js,ts}",
+            "**/tsup.config.{cjs,mjs,js,ts}",
+            "**/playwright.config.{cjs,mjs,js,ts}",
+            "**/webpack.config.{cjs,mjs,js,ts}",
+            "**/webpack.mod.{cjs,mjs,js,ts}",
+            "**/rollup.config.{cjs,mjs,js,ts}",
+            "**/rollup.config.*cjs,mjs,.{js,ts}",
+            "**/protractor.conf.{cjs,mjs,js,ts}",
+            "**/protractor.conf.*.{cjs,mjs,js,ts}",
+            "**/.eslintrc.{cjs,mjs,js,ts}",
+            "**/eslint.config.{cjs,mjs,js,ts}",
+            "**/.prettierrc.{cjs,mjs,js,ts}",
+            "**/.prettierrc"
+          ],
+          "optionalDependencies": false
+        }
+      ],
+      "import-x/no-import-module-exports": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "import-x/no-mutable-exports": "error",
+      "import-x/no-named-as-default": "error",
+      "import-x/no-named-as-default-member": "off",
+      "import-x/no-named-default": "error",
+      "import-x/no-nodejs-modules": "off",
+      "import-x/no-relative-packages": "error",
+      "import-x/no-self-import": "error",
+      "import-x/no-unresolved": [
+        "error",
+        {
+          "caseSensitive": true,
+          "commonjs": true
+        }
+      ],
+      "import-x/no-unused-modules": "error",
+      "import-x/no-useless-path-segments": [
+        "error",
+        {
+          "commonjs": true
+        }
+      ],
+      "import-x/no-webpack-loader-syntax": "error",
+      "import-x/prefer-default-export": "off",
+      "indent": "off",
+      "indent-legacy": "off",
+      "jsx-quotes": "off",
+      "key-spacing": "off",
+      "keyword-spacing": "off",
+      "linebreak-style": "off",
+      "lines-around-comment": 0,
+      "max-classes-per-file": [
+        "error",
+        1
+      ],
+      "max-len": 0,
+      "max-statements-per-line": "off",
+      "multiline-ternary": "off",
+      "new-cap": [
+        "error",
+        {
+          "capIsNew": false,
+          "capIsNewExceptions": [
+            "Immutable.Map",
+            "Immutable.Set",
+            "Immutable.List"
+          ],
+          "newIsCap": true,
+          "newIsCapExceptions": []
+        }
+      ],
+      "new-parens": "off",
+      "newline-per-chained-call": "off",
+      "no-alert": "error",
+      "no-array-constructor": "off",
+      "no-arrow-condition": "off",
+      "no-async-promise-executor": "error",
+      "no-await-in-loop": "error",
+      "no-bitwise": "error",
+      "no-caller": "error",
+      "no-case-declarations": "error",
+      "no-class-assign": "off",
+      "no-comma-dangle": "off",
+      "no-compare-neg-zero": "error",
+      "no-cond-assign": [
+        "error",
+        "always"
+      ],
+      "no-confusing-arrow": 0,
+      "no-console": "off",
+      "no-const-assign": "off",
+      "no-constant-binary-expression": "error",
+      "no-constant-condition": "warn",
+      "no-constructor-return": "error",
+      "no-continue": "error",
+      "no-control-regex": "error",
+      "no-debugger": "error",
+      "no-delete-var": "error",
+      "no-dupe-args": "off",
+      "no-dupe-class-members": "off",
+      "no-dupe-else-if": "error",
+      "no-dupe-keys": "off",
+      "no-duplicate-case": "error",
+      "no-else-return": [
+        "error",
+        {
+          "allowElseIf": false
+        }
+      ],
+      "no-empty": "error",
+      "no-empty-character-class": "error",
+      "no-empty-function": [
+        "error",
+        {
+          "allow": [
+            "arrowFunctions",
+            "functions",
+            "methods"
+          ]
+        }
+      ],
+      "no-empty-pattern": "error",
+      "no-empty-static-block": "error",
+      "no-eval": "error",
+      "no-ex-assign": "error",
+      "no-extend-native": "error",
+      "no-extra-bind": "error",
+      "no-extra-boolean-cast": "error",
+      "no-extra-label": "error",
+      "no-extra-parens": "off",
+      "no-extra-semi": "off",
+      "no-fallthrough": "error",
+      "no-floating-decimal": "off",
+      "no-func-assign": "off",
+      "no-global-assign": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "no-implied-eval": "error",
+      "no-import-assign": "off",
+      "no-inner-declarations": "error",
+      "no-invalid-regexp": "error",
+      "no-irregular-whitespace": "error",
+      "no-iterator": "error",
+      "no-label-var": "error",
+      "no-labels": [
+        "error",
+        {
+          "allowLoop": false,
+          "allowSwitch": false
+        }
+      ],
+      "no-lone-blocks": "error",
+      "no-lonely-if": "error",
+      "no-loop-func": "off",
+      "no-loss-of-precision": "error",
+      "no-magic-numbers": "off",
+      "no-misleading-character-class": "error",
+      "no-mixed-operators": 0,
+      "no-mixed-spaces-and-tabs": "off",
+      "no-multi-assign": [
+        "error"
+      ],
+      "no-multi-spaces": "off",
+      "no-multi-str": "error",
+      "no-multiple-empty-lines": "off",
+      "no-nested-ternary": "error",
+      "no-new": "error",
+      "no-new-func": "error",
+      "no-new-native-nonconstructor": "off",
+      "no-new-symbol": "off",
+      "no-new-wrappers": "error",
+      "no-nonoctal-decimal-escape": "error",
+      "no-obj-calls": "off",
+      "no-object-constructor": "error",
+      "no-octal": "error",
+      "no-octal-escape": "error",
+      "no-param-reassign": [
+        "error",
+        {
+          "ignorePropertyModificationsFor": [
+            "prev",
+            "acc",
+            "accumulator",
+            "e",
+            "ctx",
+            "context",
+            "req",
+            "request",
+            "res",
+            "response",
+            "$scope",
+            "staticContext",
+            "sharedState",
+            "state"
+          ],
+          "props": true
+        }
+      ],
+      "no-promise-executor-return": "error",
+      "no-proto": "error",
+      "no-prototype-builtins": "error",
+      "no-redeclare": "off",
+      "no-regex-spaces": "error",
+      "no-reserved-keys": "off",
+      "no-restricted-exports": [
+        "error",
+        {
+          "restrictedNamedExports": [
+            "default",
+            "then"
+          ]
+        }
+      ],
+      "no-restricted-globals": [
+        "error",
+        {
+          "message": "Use Number.isFinite instead",
+          "name": "isFinite"
+        },
+        {
+          "message": "Use Number.isNaN instead",
+          "name": "isNaN"
+        },
+        {
+          "message": "Use window.addEventListener instead",
+          "name": "addEventListener"
+        },
+        {
+          "message": "Use window.blur instead",
+          "name": "blur"
+        },
+        {
+          "message": "Use window.close instead",
+          "name": "close"
+        },
+        {
+          "message": "Use window.closed instead",
+          "name": "closed"
+        },
+        {
+          "message": "Use window.confirm instead",
+          "name": "confirm"
+        },
+        {
+          "message": "Use window.defaultStatus instead",
+          "name": "defaultStatus"
+        },
+        {
+          "message": "Use window.defaultstatus instead",
+          "name": "defaultstatus"
+        },
+        {
+          "message": "Use window.event instead",
+          "name": "event"
+        },
+        {
+          "message": "Use window.external instead",
+          "name": "external"
+        },
+        {
+          "message": "Use window.find instead",
+          "name": "find"
+        },
+        {
+          "message": "Use window.focus instead",
+          "name": "focus"
+        },
+        {
+          "message": "Use window.frameElement instead",
+          "name": "frameElement"
+        },
+        {
+          "message": "Use window.frames instead",
+          "name": "frames"
+        },
+        {
+          "message": "Use window.history instead",
+          "name": "history"
+        },
+        {
+          "message": "Use window.innerHeight instead",
+          "name": "innerHeight"
+        },
+        {
+          "message": "Use window.innerWidth instead",
+          "name": "innerWidth"
+        },
+        {
+          "message": "Use window.length instead",
+          "name": "length"
+        },
+        {
+          "message": "Use window.location instead",
+          "name": "location"
+        },
+        {
+          "message": "Use window.locationbar instead",
+          "name": "locationbar"
+        },
+        {
+          "message": "Use window.menubar instead",
+          "name": "menubar"
+        },
+        {
+          "message": "Use window.moveBy instead",
+          "name": "moveBy"
+        },
+        {
+          "message": "Use window.moveTo instead",
+          "name": "moveTo"
+        },
+        {
+          "message": "Use window.name instead",
+          "name": "name"
+        },
+        {
+          "message": "Use window.onblur instead",
+          "name": "onblur"
+        },
+        {
+          "message": "Use window.onerror instead",
+          "name": "onerror"
+        },
+        {
+          "message": "Use window.onfocus instead",
+          "name": "onfocus"
+        },
+        {
+          "message": "Use window.onload instead",
+          "name": "onload"
+        },
+        {
+          "message": "Use window.onresize instead",
+          "name": "onresize"
+        },
+        {
+          "message": "Use window.onunload instead",
+          "name": "onunload"
+        },
+        {
+          "message": "Use window.open instead",
+          "name": "open"
+        },
+        {
+          "message": "Use window.opener instead",
+          "name": "opener"
+        },
+        {
+          "message": "Use window.opera instead",
+          "name": "opera"
+        },
+        {
+          "message": "Use window.outerHeight instead",
+          "name": "outerHeight"
+        },
+        {
+          "message": "Use window.outerWidth instead",
+          "name": "outerWidth"
+        },
+        {
+          "message": "Use window.pageXOffset instead",
+          "name": "pageXOffset"
+        },
+        {
+          "message": "Use window.pageYOffset instead",
+          "name": "pageYOffset"
+        },
+        {
+          "message": "Use window.parent instead",
+          "name": "parent"
+        },
+        {
+          "message": "Use window.print instead",
+          "name": "print"
+        },
+        {
+          "message": "Use window.removeEventListener instead",
+          "name": "removeEventListener"
+        },
+        {
+          "message": "Use window.resizeBy instead",
+          "name": "resizeBy"
+        },
+        {
+          "message": "Use window.resizeTo instead",
+          "name": "resizeTo"
+        },
+        {
+          "message": "Use window.screen instead",
+          "name": "screen"
+        },
+        {
+          "message": "Use window.screenLeft instead",
+          "name": "screenLeft"
+        },
+        {
+          "message": "Use window.screenTop instead",
+          "name": "screenTop"
+        },
+        {
+          "message": "Use window.screenX instead",
+          "name": "screenX"
+        },
+        {
+          "message": "Use window.screenY instead",
+          "name": "screenY"
+        },
+        {
+          "message": "Use window.scroll instead",
+          "name": "scroll"
+        },
+        {
+          "message": "Use window.scrollbars instead",
+          "name": "scrollbars"
+        },
+        {
+          "message": "Use window.scrollBy instead",
+          "name": "scrollBy"
+        },
+        {
+          "message": "Use window.scrollTo instead",
+          "name": "scrollTo"
+        },
+        {
+          "message": "Use window.scrollX instead",
+          "name": "scrollX"
+        },
+        {
+          "message": "Use window.scrollY instead",
+          "name": "scrollY"
+        },
+        {
+          "message": "Use window.self instead",
+          "name": "self"
+        },
+        {
+          "message": "Use window.status instead",
+          "name": "status"
+        },
+        {
+          "message": "Use window.statusbar instead",
+          "name": "statusbar"
+        },
+        {
+          "message": "Use window.stop instead",
+          "name": "stop"
+        },
+        {
+          "message": "Use window.toolbar instead",
+          "name": "toolbar"
+        },
+        {
+          "message": "Use window.top instead",
+          "name": "top"
+        }
+      ],
+      "no-restricted-imports": "off",
+      "no-restricted-properties": [
+        "error",
+        {
+          "message": "arguments.callee is deprecated",
+          "object": "arguments",
+          "property": "callee"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "global",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "self",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "window",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "global",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "self",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "window",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineGetter__"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineSetter__"
+        },
+        {
+          "message": "Use the exponentiation operator (**) instead.",
+          "object": "Math",
+          "property": "pow"
+        }
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.",
+          "selector": "LabeledStatement"
+        },
+        {
+          "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
+          "selector": "WithStatement"
+        }
+      ],
+      "no-return-assign": [
+        "error",
+        "always"
+      ],
+      "no-return-await": "off",
+      "no-script-url": "error",
+      "no-self-assign": [
+        "error",
+        {
+          "props": true
+        }
+      ],
+      "no-self-compare": "error",
+      "no-sequences": "error",
+      "no-setter-return": "off",
+      "no-shadow": "off",
+      "no-shadow-restricted-names": "error",
+      "no-space-before-semi": "off",
+      "no-spaced-func": "off",
+      "no-sparse-arrays": "error",
+      "no-tabs": 0,
+      "no-template-curly-in-string": "error",
+      "no-this-before-super": "off",
+      "no-throw-literal": "error",
+      "no-trailing-spaces": "off",
+      "no-undef": "off",
+      "no-undef-init": "error",
+      "no-underscore-dangle": "off",
+      "no-unexpected-multiline": 0,
+      "no-unmodified-loop-condition": "error",
+      "no-unneeded-ternary": [
+        "error",
+        {
+          "defaultAssignment": false
+        }
+      ],
+      "no-unreachable": "off",
+      "no-unreachable-loop": [
+        "error",
+        {
+          "ignore": []
+        }
+      ],
+      "no-unsafe-finally": "error",
+      "no-unsafe-negation": "off",
+      "no-unsafe-optional-chaining": [
+        "error",
+        {
+          "disallowArithmeticOperators": true
+        }
+      ],
+      "no-unused-expressions": "off",
+      "no-unused-labels": "error",
+      "no-unused-private-class-members": "error",
+      "no-unused-vars": "off",
+      "no-useless-backreference": "error",
+      "no-useless-call": "error",
+      "no-useless-catch": "error",
+      "no-useless-computed-key": "error",
+      "no-useless-concat": "error",
+      "no-useless-constructor": "off",
+      "no-useless-escape": "error",
+      "no-useless-rename": [
+        "error",
+        {
+          "ignoreDestructuring": false,
+          "ignoreExport": false,
+          "ignoreImport": false
+        }
+      ],
+      "no-useless-return": "error",
+      "no-var": "error",
+      "no-whitespace-before-property": "off",
+      "no-with": "error",
+      "no-wrap-func": "off",
+      "nonblock-statement-body-position": "off",
+      "object-curly-newline": "off",
+      "object-curly-spacing": "off",
+      "object-property-newline": "off",
+      "object-shorthand": [
+        "error",
+        "always",
+        {
+          "avoidQuotes": true,
+          "ignoreConstructors": false
+        }
+      ],
+      "one-var": [
+        "error",
+        "never"
+      ],
+      "one-var-declaration-per-line": "off",
+      "operator-assignment": [
+        "error",
+        "always"
+      ],
+      "operator-linebreak": "off",
+      "padded-blocks": "off",
+      "prefer-arrow-callback": "off",
+      "prefer-const": "error",
+      "prefer-exponentiation-operator": "error",
+      "prefer-numeric-literals": "error",
+      "prefer-object-has-own": "error",
+      "prefer-object-spread": "error",
+      "prefer-promise-reject-errors": [
+        "error",
+        {
+          "allowEmptyReject": true
+        }
+      ],
+      "prefer-regex-literals": [
+        "error",
+        {
+          "disallowRedundantWrapping": true
+        }
+      ],
+      "prefer-rest-params": "error",
+      "prefer-spread": "error",
+      "prefer-template": "error",
+      "quote-props": "off",
+      "quotes": 0,
+      "radix": "error",
+      "react/jsx-child-element-spacing": "off",
+      "react/jsx-closing-bracket-location": "off",
+      "react/jsx-closing-tag-location": "off",
+      "react/jsx-curly-newline": "off",
+      "react/jsx-curly-spacing": "off",
+      "react/jsx-equals-spacing": "off",
+      "react/jsx-first-prop-new-line": "off",
+      "react/jsx-indent": "off",
+      "react/jsx-indent-props": "off",
+      "react/jsx-max-props-per-line": "off",
+      "react/jsx-newline": "off",
+      "react/jsx-one-expression-per-line": "off",
+      "react/jsx-props-no-multi-spaces": "off",
+      "react/jsx-space-before-closing": "off",
+      "react/jsx-tag-spacing": "off",
+      "react/jsx-wrap-multilines": "off",
+      "require-atomic-updates": "error",
+      "require-yield": "error",
+      "rest-spread-spacing": "off",
+      "semi": "off",
+      "semi-spacing": "off",
+      "semi-style": "off",
+      "space-after-function-name": "off",
+      "space-after-keywords": "off",
+      "space-before-blocks": "off",
+      "space-before-function-paren": "off",
+      "space-before-function-parentheses": "off",
+      "space-before-keywords": "off",
+      "space-in-brackets": "off",
+      "space-in-parens": "off",
+      "space-infix-ops": "off",
+      "space-return-throw-case": "off",
+      "space-unary-ops": "off",
+      "space-unary-word-ops": "off",
+      "standard/array-bracket-even-spacing": "off",
+      "standard/computed-property-even-spacing": "off",
+      "standard/object-curly-even-spacing": "off",
+      "switch-colon-spacing": "off",
+      "symbol-description": "error",
+      "template-curly-spacing": "off",
+      "template-tag-spacing": "off",
+      "unicode-bom": [
+        "error",
+        "never"
+      ],
+      "unicorn/empty-brace-spaces": "off",
+      "unicorn/no-nested-ternary": "off",
+      "unicorn/number-literal-case": "off",
+      "unicorn/template-indent": 0,
+      "use-isnan": "error",
+      "valid-typeof": [
+        "error",
+        {
+          "requireStringLiterals": true
+        }
+      ],
+      "vue/array-bracket-newline": "off",
+      "vue/array-bracket-spacing": "off",
+      "vue/array-element-newline": "off",
+      "vue/arrow-spacing": "off",
+      "vue/block-spacing": "off",
+      "vue/block-tag-newline": "off",
+      "vue/brace-style": "off",
+      "vue/comma-dangle": "off",
+      "vue/comma-spacing": "off",
+      "vue/comma-style": "off",
+      "vue/dot-location": "off",
+      "vue/func-call-spacing": "off",
+      "vue/html-closing-bracket-newline": "off",
+      "vue/html-closing-bracket-spacing": "off",
+      "vue/html-end-tags": "off",
+      "vue/html-indent": "off",
+      "vue/html-quotes": "off",
+      "vue/html-self-closing": 0,
+      "vue/key-spacing": "off",
+      "vue/keyword-spacing": "off",
+      "vue/max-attributes-per-line": "off",
+      "vue/max-len": 0,
+      "vue/multiline-html-element-content-newline": "off",
+      "vue/multiline-ternary": "off",
+      "vue/mustache-interpolation-spacing": "off",
+      "vue/no-extra-parens": "off",
+      "vue/no-multi-spaces": "off",
+      "vue/no-spaces-around-equal-signs-in-attribute": "off",
+      "vue/object-curly-newline": "off",
+      "vue/object-curly-spacing": "off",
+      "vue/object-property-newline": "off",
+      "vue/operator-linebreak": "off",
+      "vue/quote-props": "off",
+      "vue/script-indent": "off",
+      "vue/singleline-html-element-content-newline": "off",
+      "vue/space-in-parens": "off",
+      "vue/space-infix-ops": "off",
+      "vue/space-unary-ops": "off",
+      "vue/template-curly-spacing": "off",
+      "wrap-iife": "off",
+      "wrap-regex": "off",
+      "yield-star-spacing": "off",
+      "yoda": "error"
+    },
+    "settings": {
+      "import-x/extensions": [
+        ".ts",
+        ".tsx",
+        ".cts",
+        ".mts",
+        ".js",
+        ".jsx",
+        ".cjs",
+        ".mjs"
+      ],
+      "import-x/external-module-folders": [
+        "node_modules",
+        "node_modules/@types"
+      ],
+      "import-x/parsers": {
+        "@typescript-eslint/parser": [
+          ".ts",
+          ".tsx",
+          ".cts",
+          ".mts"
+        ]
+      },
+      "import-x/resolver": {
+        "typescript": true
       }
     }
   }

--- a/packages/eslint-config/test/generated/recommended-final-config.js
+++ b/packages/eslint-config/test/generated/recommended-final-config.js
@@ -2,8 +2,7 @@ export default [
   {
     "files": [
       "**/*.js",
-      "**/*.mjs",
-      "**/*.cjs"
+      "**/*.mjs"
     ],
     "languageOptions": {
       "ecmaVersion": "latest",
@@ -2256,9 +2255,7 @@ export default [
   {
     "files": [
       "**/*.ts",
-      "**/*.tsx",
       "**/*.mts",
-      "**/*.cts",
       "**/*.d.ts"
     ],
     "languageOptions": {
@@ -3398,9 +3395,9 @@ export default [
         "parser": {
           "meta": {
             "name": "typescript-eslint/parser",
-            "version": "8.27.0"
+            "version": "8.28.0"
           },
-          "version": "8.27.0"
+          "version": "8.28.0"
         },
         "projectService": true,
         "warnOnUnsupportedTypeScriptVersion": false
@@ -3933,6 +3930,2508 @@ export default [
       ],
       "no-confusing-arrow": 0,
       "no-console": "warn",
+      "no-const-assign": "off",
+      "no-constant-binary-expression": "error",
+      "no-constant-condition": "warn",
+      "no-constructor-return": "error",
+      "no-continue": "error",
+      "no-control-regex": "error",
+      "no-debugger": "error",
+      "no-delete-var": "error",
+      "no-dupe-args": "off",
+      "no-dupe-class-members": "off",
+      "no-dupe-else-if": "error",
+      "no-dupe-keys": "off",
+      "no-duplicate-case": "error",
+      "no-else-return": [
+        "error",
+        {
+          "allowElseIf": false
+        }
+      ],
+      "no-empty": "error",
+      "no-empty-character-class": "error",
+      "no-empty-function": [
+        "error",
+        {
+          "allow": [
+            "arrowFunctions",
+            "functions",
+            "methods"
+          ]
+        }
+      ],
+      "no-empty-pattern": "error",
+      "no-empty-static-block": "error",
+      "no-eval": "error",
+      "no-ex-assign": "error",
+      "no-extend-native": "error",
+      "no-extra-bind": "error",
+      "no-extra-boolean-cast": "error",
+      "no-extra-label": "error",
+      "no-extra-parens": "off",
+      "no-extra-semi": "off",
+      "no-fallthrough": "error",
+      "no-floating-decimal": "off",
+      "no-func-assign": "off",
+      "no-global-assign": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "no-implied-eval": "error",
+      "no-import-assign": "off",
+      "no-inner-declarations": "error",
+      "no-invalid-regexp": "error",
+      "no-irregular-whitespace": "error",
+      "no-iterator": "error",
+      "no-label-var": "error",
+      "no-labels": [
+        "error",
+        {
+          "allowLoop": false,
+          "allowSwitch": false
+        }
+      ],
+      "no-lone-blocks": "error",
+      "no-lonely-if": "error",
+      "no-loop-func": "off",
+      "no-loss-of-precision": "error",
+      "no-magic-numbers": "off",
+      "no-misleading-character-class": "error",
+      "no-mixed-operators": 0,
+      "no-mixed-spaces-and-tabs": "off",
+      "no-multi-assign": [
+        "error"
+      ],
+      "no-multi-spaces": "off",
+      "no-multi-str": "error",
+      "no-multiple-empty-lines": "off",
+      "no-nested-ternary": "error",
+      "no-new": "error",
+      "no-new-func": "error",
+      "no-new-native-nonconstructor": "off",
+      "no-new-symbol": "off",
+      "no-new-wrappers": "error",
+      "no-nonoctal-decimal-escape": "error",
+      "no-obj-calls": "off",
+      "no-object-constructor": "error",
+      "no-octal": "error",
+      "no-octal-escape": "error",
+      "no-param-reassign": [
+        "error",
+        {
+          "ignorePropertyModificationsFor": [
+            "prev",
+            "acc",
+            "accumulator",
+            "e",
+            "ctx",
+            "context",
+            "req",
+            "request",
+            "res",
+            "response",
+            "$scope",
+            "staticContext",
+            "sharedState",
+            "state"
+          ],
+          "props": true
+        }
+      ],
+      "no-promise-executor-return": "error",
+      "no-proto": "error",
+      "no-prototype-builtins": "error",
+      "no-redeclare": "off",
+      "no-regex-spaces": "error",
+      "no-reserved-keys": "off",
+      "no-restricted-exports": [
+        "error",
+        {
+          "restrictedNamedExports": [
+            "default",
+            "then"
+          ]
+        }
+      ],
+      "no-restricted-globals": [
+        "error",
+        {
+          "message": "Use Number.isFinite instead",
+          "name": "isFinite"
+        },
+        {
+          "message": "Use Number.isNaN instead",
+          "name": "isNaN"
+        },
+        {
+          "message": "Use window.addEventListener instead",
+          "name": "addEventListener"
+        },
+        {
+          "message": "Use window.blur instead",
+          "name": "blur"
+        },
+        {
+          "message": "Use window.close instead",
+          "name": "close"
+        },
+        {
+          "message": "Use window.closed instead",
+          "name": "closed"
+        },
+        {
+          "message": "Use window.confirm instead",
+          "name": "confirm"
+        },
+        {
+          "message": "Use window.defaultStatus instead",
+          "name": "defaultStatus"
+        },
+        {
+          "message": "Use window.defaultstatus instead",
+          "name": "defaultstatus"
+        },
+        {
+          "message": "Use window.event instead",
+          "name": "event"
+        },
+        {
+          "message": "Use window.external instead",
+          "name": "external"
+        },
+        {
+          "message": "Use window.find instead",
+          "name": "find"
+        },
+        {
+          "message": "Use window.focus instead",
+          "name": "focus"
+        },
+        {
+          "message": "Use window.frameElement instead",
+          "name": "frameElement"
+        },
+        {
+          "message": "Use window.frames instead",
+          "name": "frames"
+        },
+        {
+          "message": "Use window.history instead",
+          "name": "history"
+        },
+        {
+          "message": "Use window.innerHeight instead",
+          "name": "innerHeight"
+        },
+        {
+          "message": "Use window.innerWidth instead",
+          "name": "innerWidth"
+        },
+        {
+          "message": "Use window.length instead",
+          "name": "length"
+        },
+        {
+          "message": "Use window.location instead",
+          "name": "location"
+        },
+        {
+          "message": "Use window.locationbar instead",
+          "name": "locationbar"
+        },
+        {
+          "message": "Use window.menubar instead",
+          "name": "menubar"
+        },
+        {
+          "message": "Use window.moveBy instead",
+          "name": "moveBy"
+        },
+        {
+          "message": "Use window.moveTo instead",
+          "name": "moveTo"
+        },
+        {
+          "message": "Use window.name instead",
+          "name": "name"
+        },
+        {
+          "message": "Use window.onblur instead",
+          "name": "onblur"
+        },
+        {
+          "message": "Use window.onerror instead",
+          "name": "onerror"
+        },
+        {
+          "message": "Use window.onfocus instead",
+          "name": "onfocus"
+        },
+        {
+          "message": "Use window.onload instead",
+          "name": "onload"
+        },
+        {
+          "message": "Use window.onresize instead",
+          "name": "onresize"
+        },
+        {
+          "message": "Use window.onunload instead",
+          "name": "onunload"
+        },
+        {
+          "message": "Use window.open instead",
+          "name": "open"
+        },
+        {
+          "message": "Use window.opener instead",
+          "name": "opener"
+        },
+        {
+          "message": "Use window.opera instead",
+          "name": "opera"
+        },
+        {
+          "message": "Use window.outerHeight instead",
+          "name": "outerHeight"
+        },
+        {
+          "message": "Use window.outerWidth instead",
+          "name": "outerWidth"
+        },
+        {
+          "message": "Use window.pageXOffset instead",
+          "name": "pageXOffset"
+        },
+        {
+          "message": "Use window.pageYOffset instead",
+          "name": "pageYOffset"
+        },
+        {
+          "message": "Use window.parent instead",
+          "name": "parent"
+        },
+        {
+          "message": "Use window.print instead",
+          "name": "print"
+        },
+        {
+          "message": "Use window.removeEventListener instead",
+          "name": "removeEventListener"
+        },
+        {
+          "message": "Use window.resizeBy instead",
+          "name": "resizeBy"
+        },
+        {
+          "message": "Use window.resizeTo instead",
+          "name": "resizeTo"
+        },
+        {
+          "message": "Use window.screen instead",
+          "name": "screen"
+        },
+        {
+          "message": "Use window.screenLeft instead",
+          "name": "screenLeft"
+        },
+        {
+          "message": "Use window.screenTop instead",
+          "name": "screenTop"
+        },
+        {
+          "message": "Use window.screenX instead",
+          "name": "screenX"
+        },
+        {
+          "message": "Use window.screenY instead",
+          "name": "screenY"
+        },
+        {
+          "message": "Use window.scroll instead",
+          "name": "scroll"
+        },
+        {
+          "message": "Use window.scrollbars instead",
+          "name": "scrollbars"
+        },
+        {
+          "message": "Use window.scrollBy instead",
+          "name": "scrollBy"
+        },
+        {
+          "message": "Use window.scrollTo instead",
+          "name": "scrollTo"
+        },
+        {
+          "message": "Use window.scrollX instead",
+          "name": "scrollX"
+        },
+        {
+          "message": "Use window.scrollY instead",
+          "name": "scrollY"
+        },
+        {
+          "message": "Use window.self instead",
+          "name": "self"
+        },
+        {
+          "message": "Use window.status instead",
+          "name": "status"
+        },
+        {
+          "message": "Use window.statusbar instead",
+          "name": "statusbar"
+        },
+        {
+          "message": "Use window.stop instead",
+          "name": "stop"
+        },
+        {
+          "message": "Use window.toolbar instead",
+          "name": "toolbar"
+        },
+        {
+          "message": "Use window.top instead",
+          "name": "top"
+        }
+      ],
+      "no-restricted-imports": "off",
+      "no-restricted-properties": [
+        "error",
+        {
+          "message": "arguments.callee is deprecated",
+          "object": "arguments",
+          "property": "callee"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "global",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "self",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "window",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "global",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "self",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "window",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineGetter__"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineSetter__"
+        },
+        {
+          "message": "Use the exponentiation operator (**) instead.",
+          "object": "Math",
+          "property": "pow"
+        }
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.",
+          "selector": "LabeledStatement"
+        },
+        {
+          "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
+          "selector": "WithStatement"
+        }
+      ],
+      "no-return-assign": [
+        "error",
+        "always"
+      ],
+      "no-return-await": "off",
+      "no-script-url": "error",
+      "no-self-assign": [
+        "error",
+        {
+          "props": true
+        }
+      ],
+      "no-self-compare": "error",
+      "no-sequences": "error",
+      "no-setter-return": "off",
+      "no-shadow": "off",
+      "no-shadow-restricted-names": "error",
+      "no-space-before-semi": "off",
+      "no-spaced-func": "off",
+      "no-sparse-arrays": "error",
+      "no-tabs": 0,
+      "no-template-curly-in-string": "error",
+      "no-this-before-super": "off",
+      "no-throw-literal": "error",
+      "no-trailing-spaces": "off",
+      "no-undef": "off",
+      "no-undef-init": "error",
+      "no-underscore-dangle": "off",
+      "no-unexpected-multiline": 0,
+      "no-unmodified-loop-condition": "error",
+      "no-unneeded-ternary": [
+        "error",
+        {
+          "defaultAssignment": false
+        }
+      ],
+      "no-unreachable": "off",
+      "no-unreachable-loop": [
+        "error",
+        {
+          "ignore": []
+        }
+      ],
+      "no-unsafe-finally": "error",
+      "no-unsafe-negation": "off",
+      "no-unsafe-optional-chaining": [
+        "error",
+        {
+          "disallowArithmeticOperators": true
+        }
+      ],
+      "no-unused-expressions": "off",
+      "no-unused-labels": "error",
+      "no-unused-private-class-members": "error",
+      "no-unused-vars": "off",
+      "no-useless-backreference": "error",
+      "no-useless-call": "error",
+      "no-useless-catch": "error",
+      "no-useless-computed-key": "error",
+      "no-useless-concat": "error",
+      "no-useless-constructor": "off",
+      "no-useless-escape": "error",
+      "no-useless-rename": [
+        "error",
+        {
+          "ignoreDestructuring": false,
+          "ignoreExport": false,
+          "ignoreImport": false
+        }
+      ],
+      "no-useless-return": "error",
+      "no-var": "error",
+      "no-whitespace-before-property": "off",
+      "no-with": "error",
+      "no-wrap-func": "off",
+      "nonblock-statement-body-position": "off",
+      "object-curly-newline": "off",
+      "object-curly-spacing": "off",
+      "object-property-newline": "off",
+      "object-shorthand": [
+        "error",
+        "always",
+        {
+          "avoidQuotes": true,
+          "ignoreConstructors": false
+        }
+      ],
+      "one-var": [
+        "error",
+        "never"
+      ],
+      "one-var-declaration-per-line": "off",
+      "operator-assignment": [
+        "error",
+        "always"
+      ],
+      "operator-linebreak": "off",
+      "padded-blocks": "off",
+      "prefer-arrow-callback": "off",
+      "prefer-const": "error",
+      "prefer-exponentiation-operator": "error",
+      "prefer-numeric-literals": "error",
+      "prefer-object-has-own": "error",
+      "prefer-object-spread": "error",
+      "prefer-promise-reject-errors": [
+        "error",
+        {
+          "allowEmptyReject": true
+        }
+      ],
+      "prefer-regex-literals": [
+        "error",
+        {
+          "disallowRedundantWrapping": true
+        }
+      ],
+      "prefer-rest-params": "error",
+      "prefer-spread": "error",
+      "prefer-template": "error",
+      "quote-props": "off",
+      "quotes": 0,
+      "radix": "error",
+      "react/jsx-child-element-spacing": "off",
+      "react/jsx-closing-bracket-location": "off",
+      "react/jsx-closing-tag-location": "off",
+      "react/jsx-curly-newline": "off",
+      "react/jsx-curly-spacing": "off",
+      "react/jsx-equals-spacing": "off",
+      "react/jsx-first-prop-new-line": "off",
+      "react/jsx-indent": "off",
+      "react/jsx-indent-props": "off",
+      "react/jsx-max-props-per-line": "off",
+      "react/jsx-newline": "off",
+      "react/jsx-one-expression-per-line": "off",
+      "react/jsx-props-no-multi-spaces": "off",
+      "react/jsx-space-before-closing": "off",
+      "react/jsx-tag-spacing": "off",
+      "react/jsx-wrap-multilines": "off",
+      "require-atomic-updates": "error",
+      "require-yield": "error",
+      "rest-spread-spacing": "off",
+      "semi": "off",
+      "semi-spacing": "off",
+      "semi-style": "off",
+      "space-after-function-name": "off",
+      "space-after-keywords": "off",
+      "space-before-blocks": "off",
+      "space-before-function-paren": "off",
+      "space-before-function-parentheses": "off",
+      "space-before-keywords": "off",
+      "space-in-brackets": "off",
+      "space-in-parens": "off",
+      "space-infix-ops": "off",
+      "space-return-throw-case": "off",
+      "space-unary-ops": "off",
+      "space-unary-word-ops": "off",
+      "standard/array-bracket-even-spacing": "off",
+      "standard/computed-property-even-spacing": "off",
+      "standard/object-curly-even-spacing": "off",
+      "switch-colon-spacing": "off",
+      "symbol-description": "error",
+      "template-curly-spacing": "off",
+      "template-tag-spacing": "off",
+      "unicode-bom": [
+        "error",
+        "never"
+      ],
+      "unicorn/empty-brace-spaces": "off",
+      "unicorn/no-nested-ternary": "off",
+      "unicorn/number-literal-case": "off",
+      "unicorn/template-indent": 0,
+      "use-isnan": "error",
+      "valid-typeof": [
+        "error",
+        {
+          "requireStringLiterals": true
+        }
+      ],
+      "vue/array-bracket-newline": "off",
+      "vue/array-bracket-spacing": "off",
+      "vue/array-element-newline": "off",
+      "vue/arrow-spacing": "off",
+      "vue/block-spacing": "off",
+      "vue/block-tag-newline": "off",
+      "vue/brace-style": "off",
+      "vue/comma-dangle": "off",
+      "vue/comma-spacing": "off",
+      "vue/comma-style": "off",
+      "vue/dot-location": "off",
+      "vue/func-call-spacing": "off",
+      "vue/html-closing-bracket-newline": "off",
+      "vue/html-closing-bracket-spacing": "off",
+      "vue/html-end-tags": "off",
+      "vue/html-indent": "off",
+      "vue/html-quotes": "off",
+      "vue/html-self-closing": 0,
+      "vue/key-spacing": "off",
+      "vue/keyword-spacing": "off",
+      "vue/max-attributes-per-line": "off",
+      "vue/max-len": 0,
+      "vue/multiline-html-element-content-newline": "off",
+      "vue/multiline-ternary": "off",
+      "vue/mustache-interpolation-spacing": "off",
+      "vue/no-extra-parens": "off",
+      "vue/no-multi-spaces": "off",
+      "vue/no-spaces-around-equal-signs-in-attribute": "off",
+      "vue/object-curly-newline": "off",
+      "vue/object-curly-spacing": "off",
+      "vue/object-property-newline": "off",
+      "vue/operator-linebreak": "off",
+      "vue/quote-props": "off",
+      "vue/script-indent": "off",
+      "vue/singleline-html-element-content-newline": "off",
+      "vue/space-in-parens": "off",
+      "vue/space-infix-ops": "off",
+      "vue/space-unary-ops": "off",
+      "vue/template-curly-spacing": "off",
+      "wrap-iife": "off",
+      "wrap-regex": "off",
+      "yield-star-spacing": "off",
+      "yoda": "error"
+    },
+    "settings": {
+      "import-x/extensions": [
+        ".ts",
+        ".tsx",
+        ".cts",
+        ".mts",
+        ".js",
+        ".jsx",
+        ".cjs",
+        ".mjs"
+      ],
+      "import-x/external-module-folders": [
+        "node_modules",
+        "node_modules/@types"
+      ],
+      "import-x/parsers": {
+        "@typescript-eslint/parser": [
+          ".ts",
+          ".tsx",
+          ".cts",
+          ".mts"
+        ]
+      },
+      "import-x/resolver": {
+        "typescript": true
+      }
+    }
+  },
+  {
+    "files": [
+      "**/*.cjs"
+    ],
+    "languageOptions": {
+      "ecmaVersion": "latest",
+      "globals": {
+        "AbortController": false,
+        "AbortSignal": false,
+        "Blob": false,
+        "BroadcastChannel": false,
+        "Buffer": false,
+        "ByteLengthQueuingStrategy": false,
+        "CloseEvent": false,
+        "CompressionStream": false,
+        "CountQueuingStrategy": false,
+        "Crypto": false,
+        "CryptoKey": false,
+        "CustomEvent": false,
+        "DOMException": false,
+        "DecompressionStream": false,
+        "Event": false,
+        "EventTarget": false,
+        "File": false,
+        "FormData": false,
+        "Headers": false,
+        "MessageChannel": false,
+        "MessageEvent": false,
+        "MessagePort": false,
+        "Navigator": false,
+        "Performance": false,
+        "PerformanceEntry": false,
+        "PerformanceMark": false,
+        "PerformanceMeasure": false,
+        "PerformanceObserver": false,
+        "PerformanceObserverEntryList": false,
+        "PerformanceResourceTiming": false,
+        "ReadableByteStreamController": false,
+        "ReadableStream": false,
+        "ReadableStreamBYOBReader": false,
+        "ReadableStreamBYOBRequest": false,
+        "ReadableStreamDefaultController": false,
+        "ReadableStreamDefaultReader": false,
+        "Request": false,
+        "Response": false,
+        "SubtleCrypto": false,
+        "TextDecoder": false,
+        "TextDecoderStream": false,
+        "TextEncoder": false,
+        "TextEncoderStream": false,
+        "TransformStream": false,
+        "TransformStreamDefaultController": false,
+        "URL": false,
+        "URLSearchParams": false,
+        "WebAssembly": false,
+        "WebSocket": false,
+        "WritableStream": false,
+        "WritableStreamDefaultController": false,
+        "WritableStreamDefaultWriter": false,
+        "__dirname": false,
+        "__filename": false,
+        "atob": false,
+        "btoa": false,
+        "clearImmediate": false,
+        "clearInterval": false,
+        "clearTimeout": false,
+        "console": false,
+        "crypto": false,
+        "exports": true,
+        "fetch": false,
+        "global": false,
+        "module": false,
+        "navigator": false,
+        "performance": false,
+        "process": false,
+        "queueMicrotask": false,
+        "require": false,
+        "setImmediate": false,
+        "setInterval": false,
+        "setTimeout": false,
+        "structuredClone": false
+      },
+      "parser": "@qlik/eslint-config/recommended-cjs-parser",
+      "parserOptions": {
+        "warnOnUnsupportedTypeScriptVersion": false
+      },
+      "sourceType": "commonjs"
+    },
+    "name": "@qlik/eslint-config/recommended-cjs",
+    "plugins": {
+      "@typescript-eslint": "@typescript-eslint-plugin",
+      "import-x": "import-x-plugin"
+    },
+    "rules": {
+      "@babel/object-curly-spacing": "off",
+      "@babel/semi": "off",
+      "@stylistic/array-bracket-newline": "off",
+      "@stylistic/array-bracket-spacing": "off",
+      "@stylistic/array-element-newline": "off",
+      "@stylistic/arrow-parens": "off",
+      "@stylistic/arrow-spacing": "off",
+      "@stylistic/block-spacing": "off",
+      "@stylistic/brace-style": "off",
+      "@stylistic/comma-dangle": "off",
+      "@stylistic/comma-spacing": "off",
+      "@stylistic/comma-style": "off",
+      "@stylistic/computed-property-spacing": "off",
+      "@stylistic/dot-location": "off",
+      "@stylistic/eol-last": "off",
+      "@stylistic/func-call-spacing": "off",
+      "@stylistic/function-call-argument-newline": "off",
+      "@stylistic/function-call-spacing": "off",
+      "@stylistic/function-paren-newline": "off",
+      "@stylistic/generator-star-spacing": "off",
+      "@stylistic/implicit-arrow-linebreak": "off",
+      "@stylistic/indent": "off",
+      "@stylistic/indent-binary-ops": "off",
+      "@stylistic/js/array-bracket-newline": "off",
+      "@stylistic/js/array-bracket-spacing": "off",
+      "@stylistic/js/array-element-newline": "off",
+      "@stylistic/js/arrow-parens": "off",
+      "@stylistic/js/arrow-spacing": "off",
+      "@stylistic/js/block-spacing": "off",
+      "@stylistic/js/brace-style": "off",
+      "@stylistic/js/comma-dangle": "off",
+      "@stylistic/js/comma-spacing": "off",
+      "@stylistic/js/comma-style": "off",
+      "@stylistic/js/computed-property-spacing": "off",
+      "@stylistic/js/dot-location": "off",
+      "@stylistic/js/eol-last": "off",
+      "@stylistic/js/func-call-spacing": "off",
+      "@stylistic/js/function-call-argument-newline": "off",
+      "@stylistic/js/function-call-spacing": "off",
+      "@stylistic/js/function-paren-newline": "off",
+      "@stylistic/js/generator-star-spacing": "off",
+      "@stylistic/js/implicit-arrow-linebreak": "off",
+      "@stylistic/js/indent": "off",
+      "@stylistic/js/jsx-quotes": "off",
+      "@stylistic/js/key-spacing": "off",
+      "@stylistic/js/keyword-spacing": "off",
+      "@stylistic/js/linebreak-style": "off",
+      "@stylistic/js/lines-around-comment": 0,
+      "@stylistic/js/max-len": 0,
+      "@stylistic/js/max-statements-per-line": "off",
+      "@stylistic/js/multiline-ternary": "off",
+      "@stylistic/js/new-parens": "off",
+      "@stylistic/js/newline-per-chained-call": "off",
+      "@stylistic/js/no-confusing-arrow": 0,
+      "@stylistic/js/no-extra-parens": "off",
+      "@stylistic/js/no-extra-semi": "off",
+      "@stylistic/js/no-floating-decimal": "off",
+      "@stylistic/js/no-mixed-operators": 0,
+      "@stylistic/js/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/js/no-multi-spaces": "off",
+      "@stylistic/js/no-multiple-empty-lines": "off",
+      "@stylistic/js/no-tabs": 0,
+      "@stylistic/js/no-trailing-spaces": "off",
+      "@stylistic/js/no-whitespace-before-property": "off",
+      "@stylistic/js/nonblock-statement-body-position": "off",
+      "@stylistic/js/object-curly-newline": "off",
+      "@stylistic/js/object-curly-spacing": "off",
+      "@stylistic/js/object-property-newline": "off",
+      "@stylistic/js/one-var-declaration-per-line": "off",
+      "@stylistic/js/operator-linebreak": "off",
+      "@stylistic/js/padded-blocks": "off",
+      "@stylistic/js/quote-props": "off",
+      "@stylistic/js/quotes": 0,
+      "@stylistic/js/rest-spread-spacing": "off",
+      "@stylistic/js/semi": "off",
+      "@stylistic/js/semi-spacing": "off",
+      "@stylistic/js/semi-style": "off",
+      "@stylistic/js/space-before-blocks": "off",
+      "@stylistic/js/space-before-function-paren": "off",
+      "@stylistic/js/space-in-parens": "off",
+      "@stylistic/js/space-infix-ops": "off",
+      "@stylistic/js/space-unary-ops": "off",
+      "@stylistic/js/switch-colon-spacing": "off",
+      "@stylistic/js/template-curly-spacing": "off",
+      "@stylistic/js/template-tag-spacing": "off",
+      "@stylistic/js/wrap-iife": "off",
+      "@stylistic/js/wrap-regex": "off",
+      "@stylistic/js/yield-star-spacing": "off",
+      "@stylistic/jsx-child-element-spacing": "off",
+      "@stylistic/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx-closing-tag-location": "off",
+      "@stylistic/jsx-curly-newline": "off",
+      "@stylistic/jsx-curly-spacing": "off",
+      "@stylistic/jsx-equals-spacing": "off",
+      "@stylistic/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx-indent": "off",
+      "@stylistic/jsx-indent-props": "off",
+      "@stylistic/jsx-max-props-per-line": "off",
+      "@stylistic/jsx-newline": "off",
+      "@stylistic/jsx-one-expression-per-line": "off",
+      "@stylistic/jsx-props-no-multi-spaces": "off",
+      "@stylistic/jsx-quotes": "off",
+      "@stylistic/jsx-tag-spacing": "off",
+      "@stylistic/jsx-wrap-multilines": "off",
+      "@stylistic/jsx/jsx-child-element-spacing": "off",
+      "@stylistic/jsx/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx/jsx-closing-tag-location": "off",
+      "@stylistic/jsx/jsx-curly-newline": "off",
+      "@stylistic/jsx/jsx-curly-spacing": "off",
+      "@stylistic/jsx/jsx-equals-spacing": "off",
+      "@stylistic/jsx/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx/jsx-indent": "off",
+      "@stylistic/jsx/jsx-indent-props": "off",
+      "@stylistic/jsx/jsx-max-props-per-line": "off",
+      "@stylistic/key-spacing": "off",
+      "@stylistic/keyword-spacing": "off",
+      "@stylistic/linebreak-style": "off",
+      "@stylistic/lines-around-comment": 0,
+      "@stylistic/max-len": 0,
+      "@stylistic/max-statements-per-line": "off",
+      "@stylistic/member-delimiter-style": "off",
+      "@stylistic/multiline-ternary": "off",
+      "@stylistic/new-parens": "off",
+      "@stylistic/newline-per-chained-call": "off",
+      "@stylistic/no-confusing-arrow": 0,
+      "@stylistic/no-extra-parens": "off",
+      "@stylistic/no-extra-semi": "off",
+      "@stylistic/no-floating-decimal": "off",
+      "@stylistic/no-mixed-operators": 0,
+      "@stylistic/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/no-multi-spaces": "off",
+      "@stylistic/no-multiple-empty-lines": "off",
+      "@stylistic/no-tabs": 0,
+      "@stylistic/no-trailing-spaces": "off",
+      "@stylistic/no-whitespace-before-property": "off",
+      "@stylistic/nonblock-statement-body-position": "off",
+      "@stylistic/object-curly-newline": "off",
+      "@stylistic/object-curly-spacing": "off",
+      "@stylistic/object-property-newline": "off",
+      "@stylistic/one-var-declaration-per-line": "off",
+      "@stylistic/operator-linebreak": "off",
+      "@stylistic/padded-blocks": "off",
+      "@stylistic/quote-props": "off",
+      "@stylistic/quotes": 0,
+      "@stylistic/rest-spread-spacing": "off",
+      "@stylistic/semi": "off",
+      "@stylistic/semi-spacing": "off",
+      "@stylistic/semi-style": "off",
+      "@stylistic/space-before-blocks": "off",
+      "@stylistic/space-before-function-paren": "off",
+      "@stylistic/space-in-parens": "off",
+      "@stylistic/space-infix-ops": "off",
+      "@stylistic/space-unary-ops": "off",
+      "@stylistic/switch-colon-spacing": "off",
+      "@stylistic/template-curly-spacing": "off",
+      "@stylistic/template-tag-spacing": "off",
+      "@stylistic/ts/block-spacing": "off",
+      "@stylistic/ts/brace-style": "off",
+      "@stylistic/ts/comma-dangle": "off",
+      "@stylistic/ts/comma-spacing": "off",
+      "@stylistic/ts/func-call-spacing": "off",
+      "@stylistic/ts/function-call-spacing": "off",
+      "@stylistic/ts/indent": "off",
+      "@stylistic/ts/key-spacing": "off",
+      "@stylistic/ts/keyword-spacing": "off",
+      "@stylistic/ts/lines-around-comment": 0,
+      "@stylistic/ts/member-delimiter-style": "off",
+      "@stylistic/ts/no-extra-parens": "off",
+      "@stylistic/ts/no-extra-semi": "off",
+      "@stylistic/ts/object-curly-spacing": "off",
+      "@stylistic/ts/quotes": 0,
+      "@stylistic/ts/semi": "off",
+      "@stylistic/ts/space-before-blocks": "off",
+      "@stylistic/ts/space-before-function-paren": "off",
+      "@stylistic/ts/space-infix-ops": "off",
+      "@stylistic/ts/type-annotation-spacing": "off",
+      "@stylistic/type-annotation-spacing": "off",
+      "@stylistic/type-generic-spacing": "off",
+      "@stylistic/type-named-tuple-spacing": "off",
+      "@stylistic/wrap-iife": "off",
+      "@stylistic/wrap-regex": "off",
+      "@stylistic/yield-star-spacing": "off",
+      "@typescript-eslint/block-spacing": "off",
+      "@typescript-eslint/brace-style": "off",
+      "@typescript-eslint/comma-dangle": "off",
+      "@typescript-eslint/comma-spacing": "off",
+      "@typescript-eslint/func-call-spacing": "off",
+      "@typescript-eslint/indent": "off",
+      "@typescript-eslint/key-spacing": "off",
+      "@typescript-eslint/keyword-spacing": "off",
+      "@typescript-eslint/lines-around-comment": 0,
+      "@typescript-eslint/member-delimiter-style": "off",
+      "@typescript-eslint/no-extra-parens": "off",
+      "@typescript-eslint/no-extra-semi": "off",
+      "@typescript-eslint/object-curly-spacing": "off",
+      "@typescript-eslint/quotes": 0,
+      "@typescript-eslint/semi": "off",
+      "@typescript-eslint/space-before-blocks": "off",
+      "@typescript-eslint/space-before-function-paren": "off",
+      "@typescript-eslint/space-infix-ops": "off",
+      "@typescript-eslint/type-annotation-spacing": "off",
+      "array-bracket-newline": "off",
+      "array-bracket-spacing": "off",
+      "array-callback-return": [
+        "error",
+        {
+          "allowImplicit": true
+        }
+      ],
+      "array-element-newline": "off",
+      "arrow-body-style": "off",
+      "arrow-parens": "off",
+      "arrow-spacing": "off",
+      "babel/object-curly-spacing": "off",
+      "babel/quotes": 0,
+      "babel/semi": "off",
+      "block-scoped-var": "error",
+      "block-spacing": "off",
+      "brace-style": "off",
+      "camelcase": [
+        "error",
+        {
+          "ignoreDestructuring": false,
+          "properties": "never"
+        }
+      ],
+      "class-methods-use-this": [
+        "warn",
+        {
+          "exceptMethods": []
+        }
+      ],
+      "comma-dangle": "off",
+      "comma-spacing": "off",
+      "comma-style": "off",
+      "computed-property-spacing": "off",
+      "consistent-return": "error",
+      "constructor-super": "error",
+      "curly": 0,
+      "default-case": [
+        "error",
+        {
+          "commentPattern": "^no default$"
+        }
+      ],
+      "default-case-last": "error",
+      "default-param-last": "error",
+      "dot-location": "off",
+      "eol-last": "off",
+      "eqeqeq": [
+        "error",
+        "always",
+        {
+          "null": "ignore"
+        }
+      ],
+      "flowtype/boolean-style": "off",
+      "flowtype/delimiter-dangle": "off",
+      "flowtype/generic-spacing": "off",
+      "flowtype/object-type-curly-spacing": "off",
+      "flowtype/object-type-delimiter": "off",
+      "flowtype/quotes": "off",
+      "flowtype/semi": "off",
+      "flowtype/space-after-type-colon": "off",
+      "flowtype/space-before-generic-bracket": "off",
+      "flowtype/space-before-type-colon": "off",
+      "flowtype/union-intersection-spacing": "off",
+      "for-direction": "error",
+      "func-call-spacing": "off",
+      "func-names": "warn",
+      "function-call-argument-newline": "off",
+      "function-paren-newline": "off",
+      "generator-star": "off",
+      "generator-star-spacing": "off",
+      "getter-return": [
+        "error",
+        {
+          "allowImplicit": true
+        }
+      ],
+      "grouped-accessor-pairs": "error",
+      "implicit-arrow-linebreak": "off",
+      "import-x/consistent-type-specifier-style": "off",
+      "import-x/default": "error",
+      "import-x/export": "error",
+      "import-x/extensions": [
+        "error",
+        "ignorePackages",
+        {
+          "cjs": "never",
+          "cts": "never",
+          "js": "never",
+          "jsx": "never",
+          "mjs": "never",
+          "mts": "never",
+          "ts": "never",
+          "tsx": "never"
+        }
+      ],
+      "import-x/named": "error",
+      "import-x/namespace": "error",
+      "import-x/newline-after-import": "error",
+      "import-x/no-absolute-path": "error",
+      "import-x/no-amd": "error",
+      "import-x/no-cycle": [
+        "error",
+        {
+          "ignoreExternal": true
+        }
+      ],
+      "import-x/no-deprecated": "warn",
+      "import-x/no-duplicates": "error",
+      "import-x/no-dynamic-require": "error",
+      "import-x/no-empty-named-blocks": "off",
+      "import-x/no-extraneous-dependencies": [
+        "off",
+        {
+          "devDependencies": [
+            "**/test*/**",
+            "**/mocks/**",
+            "**/mock/**",
+            "test/**",
+            "tests/**",
+            "spec/**",
+            "**/__tests__/**",
+            "**/__mocks__/**",
+            "test.{js,jsx,ts,tsx}",
+            "test-*.{js,jsx,ts,tsx}",
+            "**/*{.,_}{test,spec}.{js,jsx,ts,tsx}",
+            "**/jest.config.{cjs,mjs,js,ts}",
+            "**/jest.setup.{cjs,mjs,js,ts}",
+            "**/vitest.config.{cjs,mjs,js,ts}",
+            "**/vue.config.{cjs,mjs,js,ts}",
+            "**/svelte.config.{cjs,mjs,js,ts}",
+            "**/tsup.config.{cjs,mjs,js,ts}",
+            "**/playwright.config.{cjs,mjs,js,ts}",
+            "**/webpack.config.{cjs,mjs,js,ts}",
+            "**/webpack.mod.{cjs,mjs,js,ts}",
+            "**/rollup.config.{cjs,mjs,js,ts}",
+            "**/rollup.config.*cjs,mjs,.{js,ts}",
+            "**/protractor.conf.{cjs,mjs,js,ts}",
+            "**/protractor.conf.*.{cjs,mjs,js,ts}",
+            "**/.eslintrc.{cjs,mjs,js,ts}",
+            "**/eslint.config.{cjs,mjs,js,ts}",
+            "**/.prettierrc.{cjs,mjs,js,ts}",
+            "**/.prettierrc"
+          ],
+          "optionalDependencies": false
+        }
+      ],
+      "import-x/no-import-module-exports": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "import-x/no-mutable-exports": "error",
+      "import-x/no-named-as-default": "error",
+      "import-x/no-named-as-default-member": "off",
+      "import-x/no-named-default": "error",
+      "import-x/no-nodejs-modules": "off",
+      "import-x/no-relative-packages": "error",
+      "import-x/no-self-import": "error",
+      "import-x/no-unresolved": [
+        "error",
+        {
+          "caseSensitive": true,
+          "commonjs": true
+        }
+      ],
+      "import-x/no-unused-modules": "error",
+      "import-x/no-useless-path-segments": [
+        "error",
+        {
+          "commonjs": true
+        }
+      ],
+      "import-x/no-webpack-loader-syntax": "error",
+      "import-x/prefer-default-export": "off",
+      "indent": "off",
+      "indent-legacy": "off",
+      "jsx-quotes": "off",
+      "key-spacing": "off",
+      "keyword-spacing": "off",
+      "linebreak-style": "off",
+      "lines-around-comment": 0,
+      "max-classes-per-file": [
+        "error",
+        1
+      ],
+      "max-len": 0,
+      "max-statements-per-line": "off",
+      "multiline-ternary": "off",
+      "new-cap": [
+        "error",
+        {
+          "capIsNew": false,
+          "capIsNewExceptions": [
+            "Immutable.Map",
+            "Immutable.Set",
+            "Immutable.List"
+          ],
+          "newIsCap": true,
+          "newIsCapExceptions": []
+        }
+      ],
+      "new-parens": "off",
+      "newline-per-chained-call": "off",
+      "no-alert": "error",
+      "no-array-constructor": "error",
+      "no-arrow-condition": "off",
+      "no-async-promise-executor": "error",
+      "no-await-in-loop": "error",
+      "no-bitwise": "error",
+      "no-caller": "error",
+      "no-case-declarations": "error",
+      "no-class-assign": "error",
+      "no-comma-dangle": "off",
+      "no-compare-neg-zero": "error",
+      "no-cond-assign": [
+        "error",
+        "always"
+      ],
+      "no-confusing-arrow": 0,
+      "no-console": "off",
+      "no-const-assign": "error",
+      "no-constant-binary-expression": "error",
+      "no-constant-condition": "warn",
+      "no-constructor-return": "error",
+      "no-continue": "error",
+      "no-control-regex": "error",
+      "no-debugger": "error",
+      "no-delete-var": "error",
+      "no-dupe-args": "error",
+      "no-dupe-class-members": "error",
+      "no-dupe-else-if": "error",
+      "no-dupe-keys": "error",
+      "no-duplicate-case": "error",
+      "no-else-return": [
+        "error",
+        {
+          "allowElseIf": false
+        }
+      ],
+      "no-empty": "error",
+      "no-empty-character-class": "error",
+      "no-empty-function": [
+        "error",
+        {
+          "allow": [
+            "arrowFunctions",
+            "functions",
+            "methods"
+          ]
+        }
+      ],
+      "no-empty-pattern": "error",
+      "no-empty-static-block": "error",
+      "no-eval": "error",
+      "no-ex-assign": "error",
+      "no-extend-native": "error",
+      "no-extra-bind": "error",
+      "no-extra-boolean-cast": "error",
+      "no-extra-label": "error",
+      "no-extra-parens": "off",
+      "no-extra-semi": "off",
+      "no-fallthrough": "error",
+      "no-floating-decimal": "off",
+      "no-func-assign": "error",
+      "no-global-assign": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "no-implied-eval": "error",
+      "no-import-assign": "error",
+      "no-inner-declarations": "error",
+      "no-invalid-regexp": "error",
+      "no-irregular-whitespace": "error",
+      "no-iterator": "error",
+      "no-label-var": "error",
+      "no-labels": [
+        "error",
+        {
+          "allowLoop": false,
+          "allowSwitch": false
+        }
+      ],
+      "no-lone-blocks": "error",
+      "no-lonely-if": "error",
+      "no-loop-func": "error",
+      "no-loss-of-precision": "error",
+      "no-magic-numbers": "off",
+      "no-misleading-character-class": "error",
+      "no-mixed-operators": 0,
+      "no-mixed-spaces-and-tabs": "off",
+      "no-multi-assign": [
+        "error"
+      ],
+      "no-multi-spaces": "off",
+      "no-multi-str": "error",
+      "no-multiple-empty-lines": "off",
+      "no-nested-ternary": "error",
+      "no-new": "error",
+      "no-new-func": "error",
+      "no-new-native-nonconstructor": "error",
+      "no-new-wrappers": "error",
+      "no-nonoctal-decimal-escape": "error",
+      "no-obj-calls": "error",
+      "no-object-constructor": "error",
+      "no-octal": "error",
+      "no-octal-escape": "error",
+      "no-param-reassign": [
+        "error",
+        {
+          "ignorePropertyModificationsFor": [
+            "prev",
+            "acc",
+            "accumulator",
+            "e",
+            "ctx",
+            "context",
+            "req",
+            "request",
+            "res",
+            "response",
+            "$scope",
+            "staticContext",
+            "sharedState",
+            "state"
+          ],
+          "props": true
+        }
+      ],
+      "no-promise-executor-return": "error",
+      "no-proto": "error",
+      "no-prototype-builtins": "error",
+      "no-redeclare": "error",
+      "no-regex-spaces": "error",
+      "no-reserved-keys": "off",
+      "no-restricted-exports": [
+        "error",
+        {
+          "restrictedNamedExports": [
+            "default",
+            "then"
+          ]
+        }
+      ],
+      "no-restricted-globals": [
+        "error",
+        {
+          "message": "Use Number.isFinite instead",
+          "name": "isFinite"
+        },
+        {
+          "message": "Use Number.isNaN instead",
+          "name": "isNaN"
+        },
+        {
+          "message": "Use window.addEventListener instead",
+          "name": "addEventListener"
+        },
+        {
+          "message": "Use window.blur instead",
+          "name": "blur"
+        },
+        {
+          "message": "Use window.close instead",
+          "name": "close"
+        },
+        {
+          "message": "Use window.closed instead",
+          "name": "closed"
+        },
+        {
+          "message": "Use window.confirm instead",
+          "name": "confirm"
+        },
+        {
+          "message": "Use window.defaultStatus instead",
+          "name": "defaultStatus"
+        },
+        {
+          "message": "Use window.defaultstatus instead",
+          "name": "defaultstatus"
+        },
+        {
+          "message": "Use window.event instead",
+          "name": "event"
+        },
+        {
+          "message": "Use window.external instead",
+          "name": "external"
+        },
+        {
+          "message": "Use window.find instead",
+          "name": "find"
+        },
+        {
+          "message": "Use window.focus instead",
+          "name": "focus"
+        },
+        {
+          "message": "Use window.frameElement instead",
+          "name": "frameElement"
+        },
+        {
+          "message": "Use window.frames instead",
+          "name": "frames"
+        },
+        {
+          "message": "Use window.history instead",
+          "name": "history"
+        },
+        {
+          "message": "Use window.innerHeight instead",
+          "name": "innerHeight"
+        },
+        {
+          "message": "Use window.innerWidth instead",
+          "name": "innerWidth"
+        },
+        {
+          "message": "Use window.length instead",
+          "name": "length"
+        },
+        {
+          "message": "Use window.location instead",
+          "name": "location"
+        },
+        {
+          "message": "Use window.locationbar instead",
+          "name": "locationbar"
+        },
+        {
+          "message": "Use window.menubar instead",
+          "name": "menubar"
+        },
+        {
+          "message": "Use window.moveBy instead",
+          "name": "moveBy"
+        },
+        {
+          "message": "Use window.moveTo instead",
+          "name": "moveTo"
+        },
+        {
+          "message": "Use window.name instead",
+          "name": "name"
+        },
+        {
+          "message": "Use window.onblur instead",
+          "name": "onblur"
+        },
+        {
+          "message": "Use window.onerror instead",
+          "name": "onerror"
+        },
+        {
+          "message": "Use window.onfocus instead",
+          "name": "onfocus"
+        },
+        {
+          "message": "Use window.onload instead",
+          "name": "onload"
+        },
+        {
+          "message": "Use window.onresize instead",
+          "name": "onresize"
+        },
+        {
+          "message": "Use window.onunload instead",
+          "name": "onunload"
+        },
+        {
+          "message": "Use window.open instead",
+          "name": "open"
+        },
+        {
+          "message": "Use window.opener instead",
+          "name": "opener"
+        },
+        {
+          "message": "Use window.opera instead",
+          "name": "opera"
+        },
+        {
+          "message": "Use window.outerHeight instead",
+          "name": "outerHeight"
+        },
+        {
+          "message": "Use window.outerWidth instead",
+          "name": "outerWidth"
+        },
+        {
+          "message": "Use window.pageXOffset instead",
+          "name": "pageXOffset"
+        },
+        {
+          "message": "Use window.pageYOffset instead",
+          "name": "pageYOffset"
+        },
+        {
+          "message": "Use window.parent instead",
+          "name": "parent"
+        },
+        {
+          "message": "Use window.print instead",
+          "name": "print"
+        },
+        {
+          "message": "Use window.removeEventListener instead",
+          "name": "removeEventListener"
+        },
+        {
+          "message": "Use window.resizeBy instead",
+          "name": "resizeBy"
+        },
+        {
+          "message": "Use window.resizeTo instead",
+          "name": "resizeTo"
+        },
+        {
+          "message": "Use window.screen instead",
+          "name": "screen"
+        },
+        {
+          "message": "Use window.screenLeft instead",
+          "name": "screenLeft"
+        },
+        {
+          "message": "Use window.screenTop instead",
+          "name": "screenTop"
+        },
+        {
+          "message": "Use window.screenX instead",
+          "name": "screenX"
+        },
+        {
+          "message": "Use window.screenY instead",
+          "name": "screenY"
+        },
+        {
+          "message": "Use window.scroll instead",
+          "name": "scroll"
+        },
+        {
+          "message": "Use window.scrollbars instead",
+          "name": "scrollbars"
+        },
+        {
+          "message": "Use window.scrollBy instead",
+          "name": "scrollBy"
+        },
+        {
+          "message": "Use window.scrollTo instead",
+          "name": "scrollTo"
+        },
+        {
+          "message": "Use window.scrollX instead",
+          "name": "scrollX"
+        },
+        {
+          "message": "Use window.scrollY instead",
+          "name": "scrollY"
+        },
+        {
+          "message": "Use window.self instead",
+          "name": "self"
+        },
+        {
+          "message": "Use window.status instead",
+          "name": "status"
+        },
+        {
+          "message": "Use window.statusbar instead",
+          "name": "statusbar"
+        },
+        {
+          "message": "Use window.stop instead",
+          "name": "stop"
+        },
+        {
+          "message": "Use window.toolbar instead",
+          "name": "toolbar"
+        },
+        {
+          "message": "Use window.top instead",
+          "name": "top"
+        }
+      ],
+      "no-restricted-imports": [
+        "off",
+        {
+          "paths": [],
+          "patterns": []
+        }
+      ],
+      "no-restricted-properties": [
+        "error",
+        {
+          "message": "arguments.callee is deprecated",
+          "object": "arguments",
+          "property": "callee"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "global",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "self",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isFinite instead",
+          "object": "window",
+          "property": "isFinite"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "global",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "self",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Number.isNaN instead",
+          "object": "window",
+          "property": "isNaN"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineGetter__"
+        },
+        {
+          "message": "Please use Object.defineProperty instead.",
+          "property": "__defineSetter__"
+        },
+        {
+          "message": "Use the exponentiation operator (**) instead.",
+          "object": "Math",
+          "property": "pow"
+        }
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.",
+          "selector": "LabeledStatement"
+        },
+        {
+          "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
+          "selector": "WithStatement"
+        }
+      ],
+      "no-return-assign": [
+        "error",
+        "always"
+      ],
+      "no-script-url": "error",
+      "no-self-assign": [
+        "error",
+        {
+          "props": true
+        }
+      ],
+      "no-self-compare": "error",
+      "no-sequences": "error",
+      "no-setter-return": "error",
+      "no-shadow": "error",
+      "no-shadow-restricted-names": "error",
+      "no-space-before-semi": "off",
+      "no-spaced-func": "off",
+      "no-sparse-arrays": "error",
+      "no-tabs": 0,
+      "no-template-curly-in-string": "error",
+      "no-this-before-super": "error",
+      "no-throw-literal": "error",
+      "no-trailing-spaces": "off",
+      "no-undef": "error",
+      "no-undef-init": "error",
+      "no-underscore-dangle": "off",
+      "no-unexpected-multiline": 0,
+      "no-unmodified-loop-condition": "error",
+      "no-unneeded-ternary": [
+        "error",
+        {
+          "defaultAssignment": false
+        }
+      ],
+      "no-unreachable": "error",
+      "no-unreachable-loop": [
+        "error",
+        {
+          "ignore": []
+        }
+      ],
+      "no-unsafe-finally": "error",
+      "no-unsafe-negation": "error",
+      "no-unsafe-optional-chaining": [
+        "error",
+        {
+          "disallowArithmeticOperators": true
+        }
+      ],
+      "no-unused-expressions": [
+        "error",
+        {
+          "allowShortCircuit": false,
+          "allowTaggedTemplates": false,
+          "allowTernary": false
+        }
+      ],
+      "no-unused-labels": "error",
+      "no-unused-private-class-members": "error",
+      "no-unused-vars": [
+        "error",
+        {
+          "args": "after-used",
+          "ignoreRestSiblings": true,
+          "vars": "all"
+        }
+      ],
+      "no-useless-backreference": "error",
+      "no-useless-call": "error",
+      "no-useless-catch": "error",
+      "no-useless-computed-key": "error",
+      "no-useless-concat": "error",
+      "no-useless-constructor": "error",
+      "no-useless-escape": "error",
+      "no-useless-rename": [
+        "error",
+        {
+          "ignoreDestructuring": false,
+          "ignoreExport": false,
+          "ignoreImport": false
+        }
+      ],
+      "no-useless-return": "error",
+      "no-var": "error",
+      "no-whitespace-before-property": "off",
+      "no-with": "error",
+      "no-wrap-func": "off",
+      "nonblock-statement-body-position": "off",
+      "object-curly-newline": "off",
+      "object-curly-spacing": "off",
+      "object-property-newline": "off",
+      "object-shorthand": [
+        "error",
+        "always",
+        {
+          "avoidQuotes": true,
+          "ignoreConstructors": false
+        }
+      ],
+      "one-var": [
+        "error",
+        "never"
+      ],
+      "one-var-declaration-per-line": "off",
+      "operator-assignment": [
+        "error",
+        "always"
+      ],
+      "operator-linebreak": "off",
+      "padded-blocks": "off",
+      "prefer-arrow-callback": "off",
+      "prefer-const": [
+        "error",
+        {
+          "destructuring": "any",
+          "ignoreReadBeforeAssign": true
+        }
+      ],
+      "prefer-exponentiation-operator": "error",
+      "prefer-numeric-literals": "error",
+      "prefer-object-has-own": "error",
+      "prefer-object-spread": "error",
+      "prefer-promise-reject-errors": [
+        "error",
+        {
+          "allowEmptyReject": true
+        }
+      ],
+      "prefer-regex-literals": [
+        "error",
+        {
+          "disallowRedundantWrapping": true
+        }
+      ],
+      "prefer-rest-params": "error",
+      "prefer-spread": "error",
+      "prefer-template": "error",
+      "quote-props": "off",
+      "quotes": 0,
+      "radix": "error",
+      "react/jsx-child-element-spacing": "off",
+      "react/jsx-closing-bracket-location": "off",
+      "react/jsx-closing-tag-location": "off",
+      "react/jsx-curly-newline": "off",
+      "react/jsx-curly-spacing": "off",
+      "react/jsx-equals-spacing": "off",
+      "react/jsx-first-prop-new-line": "off",
+      "react/jsx-indent": "off",
+      "react/jsx-indent-props": "off",
+      "react/jsx-max-props-per-line": "off",
+      "react/jsx-newline": "off",
+      "react/jsx-one-expression-per-line": "off",
+      "react/jsx-props-no-multi-spaces": "off",
+      "react/jsx-space-before-closing": "off",
+      "react/jsx-tag-spacing": "off",
+      "react/jsx-wrap-multilines": "off",
+      "require-atomic-updates": "error",
+      "require-yield": "error",
+      "rest-spread-spacing": "off",
+      "semi": "off",
+      "semi-spacing": "off",
+      "semi-style": "off",
+      "space-after-function-name": "off",
+      "space-after-keywords": "off",
+      "space-before-blocks": "off",
+      "space-before-function-paren": "off",
+      "space-before-function-parentheses": "off",
+      "space-before-keywords": "off",
+      "space-in-brackets": "off",
+      "space-in-parens": "off",
+      "space-infix-ops": "off",
+      "space-return-throw-case": "off",
+      "space-unary-ops": "off",
+      "space-unary-word-ops": "off",
+      "standard/array-bracket-even-spacing": "off",
+      "standard/computed-property-even-spacing": "off",
+      "standard/object-curly-even-spacing": "off",
+      "switch-colon-spacing": "off",
+      "symbol-description": "error",
+      "template-curly-spacing": "off",
+      "template-tag-spacing": "off",
+      "unicode-bom": [
+        "error",
+        "never"
+      ],
+      "unicorn/empty-brace-spaces": "off",
+      "unicorn/no-nested-ternary": "off",
+      "unicorn/number-literal-case": "off",
+      "unicorn/template-indent": 0,
+      "use-isnan": "error",
+      "valid-typeof": [
+        "error",
+        {
+          "requireStringLiterals": true
+        }
+      ],
+      "vue/array-bracket-newline": "off",
+      "vue/array-bracket-spacing": "off",
+      "vue/array-element-newline": "off",
+      "vue/arrow-spacing": "off",
+      "vue/block-spacing": "off",
+      "vue/block-tag-newline": "off",
+      "vue/brace-style": "off",
+      "vue/comma-dangle": "off",
+      "vue/comma-spacing": "off",
+      "vue/comma-style": "off",
+      "vue/dot-location": "off",
+      "vue/func-call-spacing": "off",
+      "vue/html-closing-bracket-newline": "off",
+      "vue/html-closing-bracket-spacing": "off",
+      "vue/html-end-tags": "off",
+      "vue/html-indent": "off",
+      "vue/html-quotes": "off",
+      "vue/html-self-closing": 0,
+      "vue/key-spacing": "off",
+      "vue/keyword-spacing": "off",
+      "vue/max-attributes-per-line": "off",
+      "vue/max-len": 0,
+      "vue/multiline-html-element-content-newline": "off",
+      "vue/multiline-ternary": "off",
+      "vue/mustache-interpolation-spacing": "off",
+      "vue/no-extra-parens": "off",
+      "vue/no-multi-spaces": "off",
+      "vue/no-spaces-around-equal-signs-in-attribute": "off",
+      "vue/object-curly-newline": "off",
+      "vue/object-curly-spacing": "off",
+      "vue/object-property-newline": "off",
+      "vue/operator-linebreak": "off",
+      "vue/quote-props": "off",
+      "vue/script-indent": "off",
+      "vue/singleline-html-element-content-newline": "off",
+      "vue/space-in-parens": "off",
+      "vue/space-infix-ops": "off",
+      "vue/space-unary-ops": "off",
+      "vue/template-curly-spacing": "off",
+      "wrap-iife": "off",
+      "wrap-regex": "off",
+      "yield-star-spacing": "off",
+      "yoda": "error"
+    }
+  },
+  {
+    "files": [
+      "**/*.cts"
+    ],
+    "languageOptions": {
+      "ecmaVersion": "latest",
+      "globals": {
+        "AbortController": false,
+        "AbortSignal": false,
+        "Blob": false,
+        "BroadcastChannel": false,
+        "Buffer": false,
+        "ByteLengthQueuingStrategy": false,
+        "CloseEvent": false,
+        "CompressionStream": false,
+        "CountQueuingStrategy": false,
+        "Crypto": false,
+        "CryptoKey": false,
+        "CustomEvent": false,
+        "DOMException": false,
+        "DecompressionStream": false,
+        "Event": false,
+        "EventTarget": false,
+        "File": false,
+        "FormData": false,
+        "Headers": false,
+        "MessageChannel": false,
+        "MessageEvent": false,
+        "MessagePort": false,
+        "Navigator": false,
+        "Performance": false,
+        "PerformanceEntry": false,
+        "PerformanceMark": false,
+        "PerformanceMeasure": false,
+        "PerformanceObserver": false,
+        "PerformanceObserverEntryList": false,
+        "PerformanceResourceTiming": false,
+        "ReadableByteStreamController": false,
+        "ReadableStream": false,
+        "ReadableStreamBYOBReader": false,
+        "ReadableStreamBYOBRequest": false,
+        "ReadableStreamDefaultController": false,
+        "ReadableStreamDefaultReader": false,
+        "Request": false,
+        "Response": false,
+        "SubtleCrypto": false,
+        "TextDecoder": false,
+        "TextDecoderStream": false,
+        "TextEncoder": false,
+        "TextEncoderStream": false,
+        "TransformStream": false,
+        "TransformStreamDefaultController": false,
+        "URL": false,
+        "URLSearchParams": false,
+        "WebAssembly": false,
+        "WebSocket": false,
+        "WritableStream": false,
+        "WritableStreamDefaultController": false,
+        "WritableStreamDefaultWriter": false,
+        "__dirname": false,
+        "__filename": false,
+        "atob": false,
+        "btoa": false,
+        "clearImmediate": false,
+        "clearInterval": false,
+        "clearTimeout": false,
+        "console": false,
+        "crypto": false,
+        "exports": true,
+        "fetch": false,
+        "global": false,
+        "module": false,
+        "navigator": false,
+        "performance": false,
+        "process": false,
+        "queueMicrotask": false,
+        "require": false,
+        "setImmediate": false,
+        "setInterval": false,
+        "setTimeout": false,
+        "structuredClone": false
+      },
+      "parser": "@qlik/eslint-config/recommended-cts-parser",
+      "parserOptions": {
+        "parser": {
+          "meta": {
+            "name": "typescript-eslint/parser",
+            "version": "8.28.0"
+          },
+          "version": "8.28.0"
+        },
+        "projectService": true,
+        "warnOnUnsupportedTypeScriptVersion": false
+      },
+      "sourceType": "commonjs"
+    },
+    "name": "@qlik/eslint-config/recommended-cts",
+    "plugins": {
+      "@typescript-eslint": "@typescript-eslint-plugin",
+      "import-x": "import-x-plugin"
+    },
+    "rules": {
+      "@babel/object-curly-spacing": "off",
+      "@babel/semi": "off",
+      "@stylistic/array-bracket-newline": "off",
+      "@stylistic/array-bracket-spacing": "off",
+      "@stylistic/array-element-newline": "off",
+      "@stylistic/arrow-parens": "off",
+      "@stylistic/arrow-spacing": "off",
+      "@stylistic/block-spacing": "off",
+      "@stylistic/brace-style": "off",
+      "@stylistic/comma-dangle": "off",
+      "@stylistic/comma-spacing": "off",
+      "@stylistic/comma-style": "off",
+      "@stylistic/computed-property-spacing": "off",
+      "@stylistic/dot-location": "off",
+      "@stylistic/eol-last": "off",
+      "@stylistic/func-call-spacing": "off",
+      "@stylistic/function-call-argument-newline": "off",
+      "@stylistic/function-call-spacing": "off",
+      "@stylistic/function-paren-newline": "off",
+      "@stylistic/generator-star-spacing": "off",
+      "@stylistic/implicit-arrow-linebreak": "off",
+      "@stylistic/indent": "off",
+      "@stylistic/indent-binary-ops": "off",
+      "@stylistic/js/array-bracket-newline": "off",
+      "@stylistic/js/array-bracket-spacing": "off",
+      "@stylistic/js/array-element-newline": "off",
+      "@stylistic/js/arrow-parens": "off",
+      "@stylistic/js/arrow-spacing": "off",
+      "@stylistic/js/block-spacing": "off",
+      "@stylistic/js/brace-style": "off",
+      "@stylistic/js/comma-dangle": "off",
+      "@stylistic/js/comma-spacing": "off",
+      "@stylistic/js/comma-style": "off",
+      "@stylistic/js/computed-property-spacing": "off",
+      "@stylistic/js/dot-location": "off",
+      "@stylistic/js/eol-last": "off",
+      "@stylistic/js/func-call-spacing": "off",
+      "@stylistic/js/function-call-argument-newline": "off",
+      "@stylistic/js/function-call-spacing": "off",
+      "@stylistic/js/function-paren-newline": "off",
+      "@stylistic/js/generator-star-spacing": "off",
+      "@stylistic/js/implicit-arrow-linebreak": "off",
+      "@stylistic/js/indent": "off",
+      "@stylistic/js/jsx-quotes": "off",
+      "@stylistic/js/key-spacing": "off",
+      "@stylistic/js/keyword-spacing": "off",
+      "@stylistic/js/linebreak-style": "off",
+      "@stylistic/js/lines-around-comment": 0,
+      "@stylistic/js/max-len": 0,
+      "@stylistic/js/max-statements-per-line": "off",
+      "@stylistic/js/multiline-ternary": "off",
+      "@stylistic/js/new-parens": "off",
+      "@stylistic/js/newline-per-chained-call": "off",
+      "@stylistic/js/no-confusing-arrow": 0,
+      "@stylistic/js/no-extra-parens": "off",
+      "@stylistic/js/no-extra-semi": "off",
+      "@stylistic/js/no-floating-decimal": "off",
+      "@stylistic/js/no-mixed-operators": 0,
+      "@stylistic/js/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/js/no-multi-spaces": "off",
+      "@stylistic/js/no-multiple-empty-lines": "off",
+      "@stylistic/js/no-tabs": 0,
+      "@stylistic/js/no-trailing-spaces": "off",
+      "@stylistic/js/no-whitespace-before-property": "off",
+      "@stylistic/js/nonblock-statement-body-position": "off",
+      "@stylistic/js/object-curly-newline": "off",
+      "@stylistic/js/object-curly-spacing": "off",
+      "@stylistic/js/object-property-newline": "off",
+      "@stylistic/js/one-var-declaration-per-line": "off",
+      "@stylistic/js/operator-linebreak": "off",
+      "@stylistic/js/padded-blocks": "off",
+      "@stylistic/js/quote-props": "off",
+      "@stylistic/js/quotes": 0,
+      "@stylistic/js/rest-spread-spacing": "off",
+      "@stylistic/js/semi": "off",
+      "@stylistic/js/semi-spacing": "off",
+      "@stylistic/js/semi-style": "off",
+      "@stylistic/js/space-before-blocks": "off",
+      "@stylistic/js/space-before-function-paren": "off",
+      "@stylistic/js/space-in-parens": "off",
+      "@stylistic/js/space-infix-ops": "off",
+      "@stylistic/js/space-unary-ops": "off",
+      "@stylistic/js/switch-colon-spacing": "off",
+      "@stylistic/js/template-curly-spacing": "off",
+      "@stylistic/js/template-tag-spacing": "off",
+      "@stylistic/js/wrap-iife": "off",
+      "@stylistic/js/wrap-regex": "off",
+      "@stylistic/js/yield-star-spacing": "off",
+      "@stylistic/jsx-child-element-spacing": "off",
+      "@stylistic/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx-closing-tag-location": "off",
+      "@stylistic/jsx-curly-newline": "off",
+      "@stylistic/jsx-curly-spacing": "off",
+      "@stylistic/jsx-equals-spacing": "off",
+      "@stylistic/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx-indent": "off",
+      "@stylistic/jsx-indent-props": "off",
+      "@stylistic/jsx-max-props-per-line": "off",
+      "@stylistic/jsx-newline": "off",
+      "@stylistic/jsx-one-expression-per-line": "off",
+      "@stylistic/jsx-props-no-multi-spaces": "off",
+      "@stylistic/jsx-quotes": "off",
+      "@stylistic/jsx-tag-spacing": "off",
+      "@stylistic/jsx-wrap-multilines": "off",
+      "@stylistic/jsx/jsx-child-element-spacing": "off",
+      "@stylistic/jsx/jsx-closing-bracket-location": "off",
+      "@stylistic/jsx/jsx-closing-tag-location": "off",
+      "@stylistic/jsx/jsx-curly-newline": "off",
+      "@stylistic/jsx/jsx-curly-spacing": "off",
+      "@stylistic/jsx/jsx-equals-spacing": "off",
+      "@stylistic/jsx/jsx-first-prop-new-line": "off",
+      "@stylistic/jsx/jsx-indent": "off",
+      "@stylistic/jsx/jsx-indent-props": "off",
+      "@stylistic/jsx/jsx-max-props-per-line": "off",
+      "@stylistic/key-spacing": "off",
+      "@stylistic/keyword-spacing": "off",
+      "@stylistic/linebreak-style": "off",
+      "@stylistic/lines-around-comment": 0,
+      "@stylistic/max-len": 0,
+      "@stylistic/max-statements-per-line": "off",
+      "@stylistic/member-delimiter-style": "off",
+      "@stylistic/multiline-ternary": "off",
+      "@stylistic/new-parens": "off",
+      "@stylistic/newline-per-chained-call": "off",
+      "@stylistic/no-confusing-arrow": 0,
+      "@stylistic/no-extra-parens": "off",
+      "@stylistic/no-extra-semi": "off",
+      "@stylistic/no-floating-decimal": "off",
+      "@stylistic/no-mixed-operators": 0,
+      "@stylistic/no-mixed-spaces-and-tabs": "off",
+      "@stylistic/no-multi-spaces": "off",
+      "@stylistic/no-multiple-empty-lines": "off",
+      "@stylistic/no-tabs": 0,
+      "@stylistic/no-trailing-spaces": "off",
+      "@stylistic/no-whitespace-before-property": "off",
+      "@stylistic/nonblock-statement-body-position": "off",
+      "@stylistic/object-curly-newline": "off",
+      "@stylistic/object-curly-spacing": "off",
+      "@stylistic/object-property-newline": "off",
+      "@stylistic/one-var-declaration-per-line": "off",
+      "@stylistic/operator-linebreak": "off",
+      "@stylistic/padded-blocks": "off",
+      "@stylistic/quote-props": "off",
+      "@stylistic/quotes": 0,
+      "@stylistic/rest-spread-spacing": "off",
+      "@stylistic/semi": "off",
+      "@stylistic/semi-spacing": "off",
+      "@stylistic/semi-style": "off",
+      "@stylistic/space-before-blocks": "off",
+      "@stylistic/space-before-function-paren": "off",
+      "@stylistic/space-in-parens": "off",
+      "@stylistic/space-infix-ops": "off",
+      "@stylistic/space-unary-ops": "off",
+      "@stylistic/switch-colon-spacing": "off",
+      "@stylistic/template-curly-spacing": "off",
+      "@stylistic/template-tag-spacing": "off",
+      "@stylistic/ts/block-spacing": "off",
+      "@stylistic/ts/brace-style": "off",
+      "@stylistic/ts/comma-dangle": "off",
+      "@stylistic/ts/comma-spacing": "off",
+      "@stylistic/ts/func-call-spacing": "off",
+      "@stylistic/ts/function-call-spacing": "off",
+      "@stylistic/ts/indent": "off",
+      "@stylistic/ts/key-spacing": "off",
+      "@stylistic/ts/keyword-spacing": "off",
+      "@stylistic/ts/lines-around-comment": 0,
+      "@stylistic/ts/member-delimiter-style": "off",
+      "@stylistic/ts/no-extra-parens": "off",
+      "@stylistic/ts/no-extra-semi": "off",
+      "@stylistic/ts/object-curly-spacing": "off",
+      "@stylistic/ts/quotes": 0,
+      "@stylistic/ts/semi": "off",
+      "@stylistic/ts/space-before-blocks": "off",
+      "@stylistic/ts/space-before-function-paren": "off",
+      "@stylistic/ts/space-infix-ops": "off",
+      "@stylistic/ts/type-annotation-spacing": "off",
+      "@stylistic/type-annotation-spacing": "off",
+      "@stylistic/type-generic-spacing": "off",
+      "@stylistic/type-named-tuple-spacing": "off",
+      "@stylistic/wrap-iife": "off",
+      "@stylistic/wrap-regex": "off",
+      "@stylistic/yield-star-spacing": "off",
+      "@typescript-eslint/ban-ts-comment": "error",
+      "@typescript-eslint/block-spacing": "off",
+      "@typescript-eslint/brace-style": "off",
+      "@typescript-eslint/class-methods-use-this": [
+        "warn",
+        {
+          "exceptMethods": []
+        }
+      ],
+      "@typescript-eslint/comma-dangle": "off",
+      "@typescript-eslint/comma-spacing": "off",
+      "@typescript-eslint/consistent-type-exports": "error",
+      "@typescript-eslint/consistent-type-imports": "error",
+      "@typescript-eslint/default-param-last": "error",
+      "@typescript-eslint/explicit-module-boundary-types": "off",
+      "@typescript-eslint/func-call-spacing": "off",
+      "@typescript-eslint/indent": "off",
+      "@typescript-eslint/key-spacing": "off",
+      "@typescript-eslint/keyword-spacing": "off",
+      "@typescript-eslint/lines-around-comment": 0,
+      "@typescript-eslint/member-delimiter-style": "off",
+      "@typescript-eslint/method-signature-style": "error",
+      "@typescript-eslint/naming-convention": [
+        "error",
+        {
+          "format": [
+            "camelCase",
+            "PascalCase",
+            "UPPER_CASE"
+          ],
+          "selector": "variable"
+        },
+        {
+          "format": [
+            "camelCase",
+            "PascalCase"
+          ],
+          "selector": "function"
+        },
+        {
+          "format": [
+            "PascalCase"
+          ],
+          "selector": "typeLike"
+        }
+      ],
+      "@typescript-eslint/no-array-constructor": "error",
+      "@typescript-eslint/no-confusing-void-expression": "error",
+      "@typescript-eslint/no-duplicate-enum-values": "error",
+      "@typescript-eslint/no-dynamic-delete": "error",
+      "@typescript-eslint/no-empty-object-type": "error",
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/no-extra-non-null-assertion": "error",
+      "@typescript-eslint/no-extra-parens": "off",
+      "@typescript-eslint/no-extra-semi": "off",
+      "@typescript-eslint/no-extraneous-class": "error",
+      "@typescript-eslint/no-floating-promises": [
+        "error",
+        {
+          "ignoreIIFE": true
+        }
+      ],
+      "@typescript-eslint/no-import-type-side-effects": "error",
+      "@typescript-eslint/no-invalid-void-type": "error",
+      "@typescript-eslint/no-loop-func": "error",
+      "@typescript-eslint/no-magic-numbers": "off",
+      "@typescript-eslint/no-meaningless-void-operator": "error",
+      "@typescript-eslint/no-misused-new": "error",
+      "@typescript-eslint/no-misused-promises": [
+        "error",
+        {
+          "checksConditionals": false
+        }
+      ],
+      "@typescript-eslint/no-mixed-enums": "error",
+      "@typescript-eslint/no-namespace": "error",
+      "@typescript-eslint/no-non-null-asserted-nullish-coalescing": "error",
+      "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
+      "@typescript-eslint/no-non-null-assertion": "error",
+      "@typescript-eslint/no-redeclare": "error",
+      "@typescript-eslint/no-require-imports": "error",
+      "@typescript-eslint/no-restricted-imports": [
+        "off",
+        {
+          "paths": [],
+          "patterns": []
+        }
+      ],
+      "@typescript-eslint/no-restricted-types": [
+        "error",
+        {}
+      ],
+      "@typescript-eslint/no-shadow": "error",
+      "@typescript-eslint/no-this-alias": "error",
+      "@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
+      "@typescript-eslint/no-unnecessary-condition": "error",
+      "@typescript-eslint/no-unnecessary-parameter-property-assignment": "error",
+      "@typescript-eslint/no-unnecessary-qualifier": "error",
+      "@typescript-eslint/no-unnecessary-template-expression": "error",
+      "@typescript-eslint/no-unnecessary-type-arguments": "error",
+      "@typescript-eslint/no-unnecessary-type-constraint": "error",
+      "@typescript-eslint/no-unnecessary-type-parameters": "off",
+      "@typescript-eslint/no-unsafe-declaration-merging": "error",
+      "@typescript-eslint/no-unsafe-function-type": "error",
+      "@typescript-eslint/no-unused-expressions": "error",
+      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/no-useless-constructor": "error",
+      "@typescript-eslint/no-useless-empty-export": "error",
+      "@typescript-eslint/no-wrapper-object-types": "error",
+      "@typescript-eslint/object-curly-spacing": "off",
+      "@typescript-eslint/prefer-as-const": "error",
+      "@typescript-eslint/prefer-enum-initializers": "error",
+      "@typescript-eslint/prefer-for-of": "off",
+      "@typescript-eslint/prefer-literal-enum-member": "error",
+      "@typescript-eslint/prefer-namespace-keyword": "error",
+      "@typescript-eslint/prefer-reduce-type-parameter": "error",
+      "@typescript-eslint/prefer-return-this-type": "error",
+      "@typescript-eslint/quotes": 0,
+      "@typescript-eslint/require-array-sort-compare": "error",
+      "@typescript-eslint/return-await": "error",
+      "@typescript-eslint/semi": "off",
+      "@typescript-eslint/space-before-blocks": "off",
+      "@typescript-eslint/space-before-function-paren": "off",
+      "@typescript-eslint/space-infix-ops": "off",
+      "@typescript-eslint/strict-boolean-expressions": "off",
+      "@typescript-eslint/switch-exhaustiveness-check": "error",
+      "@typescript-eslint/triple-slash-reference": "error",
+      "@typescript-eslint/type-annotation-spacing": "off",
+      "@typescript-eslint/unified-signatures": "error",
+      "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
+      "array-bracket-newline": "off",
+      "array-bracket-spacing": "off",
+      "array-callback-return": [
+        "error",
+        {
+          "allowImplicit": true
+        }
+      ],
+      "array-element-newline": "off",
+      "arrow-body-style": "off",
+      "arrow-parens": "off",
+      "arrow-spacing": "off",
+      "babel/object-curly-spacing": "off",
+      "babel/quotes": 0,
+      "babel/semi": "off",
+      "block-scoped-var": "error",
+      "block-spacing": "off",
+      "brace-style": "off",
+      "camelcase": "off",
+      "class-methods-use-this": "off",
+      "comma-dangle": "off",
+      "comma-spacing": "off",
+      "comma-style": "off",
+      "computed-property-spacing": "off",
+      "consistent-return": "error",
+      "constructor-super": "off",
+      "curly": 0,
+      "default-case": [
+        "error",
+        {
+          "commentPattern": "^no default$"
+        }
+      ],
+      "default-case-last": "error",
+      "default-param-last": "off",
+      "dot-location": "off",
+      "eol-last": "off",
+      "eqeqeq": [
+        "error",
+        "always",
+        {
+          "null": "ignore"
+        }
+      ],
+      "flowtype/boolean-style": "off",
+      "flowtype/delimiter-dangle": "off",
+      "flowtype/generic-spacing": "off",
+      "flowtype/object-type-curly-spacing": "off",
+      "flowtype/object-type-delimiter": "off",
+      "flowtype/quotes": "off",
+      "flowtype/semi": "off",
+      "flowtype/space-after-type-colon": "off",
+      "flowtype/space-before-generic-bracket": "off",
+      "flowtype/space-before-type-colon": "off",
+      "flowtype/union-intersection-spacing": "off",
+      "for-direction": "error",
+      "func-call-spacing": "off",
+      "func-names": "warn",
+      "function-call-argument-newline": "off",
+      "function-paren-newline": "off",
+      "generator-star": "off",
+      "generator-star-spacing": "off",
+      "getter-return": "off",
+      "grouped-accessor-pairs": "error",
+      "implicit-arrow-linebreak": "off",
+      "import-x/consistent-type-specifier-style": "off",
+      "import-x/default": "error",
+      "import-x/export": "error",
+      "import-x/extensions": [
+        "error",
+        "ignorePackages",
+        {
+          "cjs": "never",
+          "cts": "never",
+          "js": "never",
+          "jsx": "never",
+          "mjs": "never",
+          "mts": "never",
+          "ts": "never",
+          "tsx": "never"
+        }
+      ],
+      "import-x/named": "off",
+      "import-x/namespace": "error",
+      "import-x/newline-after-import": "error",
+      "import-x/no-absolute-path": "error",
+      "import-x/no-amd": "error",
+      "import-x/no-cycle": [
+        "error",
+        {
+          "ignoreExternal": true
+        }
+      ],
+      "import-x/no-deprecated": "warn",
+      "import-x/no-duplicates": "error",
+      "import-x/no-dynamic-require": "error",
+      "import-x/no-empty-named-blocks": "off",
+      "import-x/no-extraneous-dependencies": [
+        "off",
+        {
+          "devDependencies": [
+            "**/test*/**",
+            "**/mocks/**",
+            "**/mock/**",
+            "test/**",
+            "tests/**",
+            "spec/**",
+            "**/__tests__/**",
+            "**/__mocks__/**",
+            "test.{js,jsx,ts,tsx}",
+            "test-*.{js,jsx,ts,tsx}",
+            "**/*{.,_}{test,spec}.{js,jsx,ts,tsx}",
+            "**/jest.config.{cjs,mjs,js,ts}",
+            "**/jest.setup.{cjs,mjs,js,ts}",
+            "**/vitest.config.{cjs,mjs,js,ts}",
+            "**/vue.config.{cjs,mjs,js,ts}",
+            "**/svelte.config.{cjs,mjs,js,ts}",
+            "**/tsup.config.{cjs,mjs,js,ts}",
+            "**/playwright.config.{cjs,mjs,js,ts}",
+            "**/webpack.config.{cjs,mjs,js,ts}",
+            "**/webpack.mod.{cjs,mjs,js,ts}",
+            "**/rollup.config.{cjs,mjs,js,ts}",
+            "**/rollup.config.*cjs,mjs,.{js,ts}",
+            "**/protractor.conf.{cjs,mjs,js,ts}",
+            "**/protractor.conf.*.{cjs,mjs,js,ts}",
+            "**/.eslintrc.{cjs,mjs,js,ts}",
+            "**/eslint.config.{cjs,mjs,js,ts}",
+            "**/.prettierrc.{cjs,mjs,js,ts}",
+            "**/.prettierrc"
+          ],
+          "optionalDependencies": false
+        }
+      ],
+      "import-x/no-import-module-exports": [
+        "error",
+        {
+          "exceptions": []
+        }
+      ],
+      "import-x/no-mutable-exports": "error",
+      "import-x/no-named-as-default": "error",
+      "import-x/no-named-as-default-member": "off",
+      "import-x/no-named-default": "error",
+      "import-x/no-nodejs-modules": "off",
+      "import-x/no-relative-packages": "error",
+      "import-x/no-self-import": "error",
+      "import-x/no-unresolved": [
+        "error",
+        {
+          "caseSensitive": true,
+          "commonjs": true
+        }
+      ],
+      "import-x/no-unused-modules": "error",
+      "import-x/no-useless-path-segments": [
+        "error",
+        {
+          "commonjs": true
+        }
+      ],
+      "import-x/no-webpack-loader-syntax": "error",
+      "import-x/prefer-default-export": "off",
+      "indent": "off",
+      "indent-legacy": "off",
+      "jsx-quotes": "off",
+      "key-spacing": "off",
+      "keyword-spacing": "off",
+      "linebreak-style": "off",
+      "lines-around-comment": 0,
+      "max-classes-per-file": [
+        "error",
+        1
+      ],
+      "max-len": 0,
+      "max-statements-per-line": "off",
+      "multiline-ternary": "off",
+      "new-cap": [
+        "error",
+        {
+          "capIsNew": false,
+          "capIsNewExceptions": [
+            "Immutable.Map",
+            "Immutable.Set",
+            "Immutable.List"
+          ],
+          "newIsCap": true,
+          "newIsCapExceptions": []
+        }
+      ],
+      "new-parens": "off",
+      "newline-per-chained-call": "off",
+      "no-alert": "error",
+      "no-array-constructor": "off",
+      "no-arrow-condition": "off",
+      "no-async-promise-executor": "error",
+      "no-await-in-loop": "error",
+      "no-bitwise": "error",
+      "no-caller": "error",
+      "no-case-declarations": "error",
+      "no-class-assign": "off",
+      "no-comma-dangle": "off",
+      "no-compare-neg-zero": "error",
+      "no-cond-assign": [
+        "error",
+        "always"
+      ],
+      "no-confusing-arrow": 0,
+      "no-console": "off",
       "no-const-assign": "off",
       "no-constant-binary-expression": "error",
       "no-constant-condition": "warn",

--- a/packages/eslint-config/test/generated/svelte-final-config.js
+++ b/packages/eslint-config/test/generated/svelte-final-config.js
@@ -2,8 +2,7 @@ export default [
   {
     "files": [
       "**/*.js",
-      "**/*.mjs",
-      "**/*.cjs"
+      "**/*.mjs"
     ],
     "languageOptions": {
       "ecmaVersion": "latest",
@@ -2256,9 +2255,7 @@ export default [
   {
     "files": [
       "**/*.ts",
-      "**/*.tsx",
       "**/*.mts",
-      "**/*.cts",
       "**/*.d.ts"
     ],
     "languageOptions": {
@@ -3398,9 +3395,9 @@ export default [
         "parser": {
           "meta": {
             "name": "typescript-eslint/parser",
-            "version": "8.27.0"
+            "version": "8.28.0"
           },
-          "version": "8.27.0"
+          "version": "8.28.0"
         },
         "projectService": true,
         "warnOnUnsupportedTypeScriptVersion": false
@@ -4628,7 +4625,7 @@ export default [
         "parser": {
           "meta": {
             "name": "typescript-eslint/parser",
-            "version": "8.27.0"
+            "version": "8.28.0"
           }
         }
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,20 +26,20 @@ importers:
   packages/eslint-config:
     dependencies:
       '@eslint-react/eslint-plugin':
-        specifier: ^1.37.2
-        version: 1.37.2(eslint@9.23.0)(ts-api-utils@2.1.0(typescript@5.7.3))(typescript@5.7.3)
+        specifier: ^1.38.0
+        version: 1.38.0(eslint@9.23.0)(ts-api-utils@2.1.0(typescript@5.7.3))(typescript@5.7.3)
       '@eslint/js':
         specifier: ^9.23.0
         version: 9.23.0
       '@typescript-eslint/parser':
-        specifier: ^8.27.0
-        version: 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+        specifier: ^8.28.0
+        version: 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       '@typescript-eslint/utils':
-        specifier: ^8.27.0
-        version: 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+        specifier: ^8.28.0
+        version: 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       '@vitest/eslint-plugin':
         specifier: ^1.1.38
-        version: 1.1.38(@typescript-eslint/utils@8.27.0(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3)(vitest@3.0.9(@types/node@22.13.11))
+        version: 1.1.38(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3)(vitest@3.0.9(@types/node@22.13.13))
       confusing-browser-globals:
         specifier: ^1.0.11
         version: 1.0.11
@@ -54,7 +54,7 @@ importers:
         version: 4.9.1(eslint@9.23.0)(typescript@5.7.3)
       eslint-plugin-jest:
         specifier: ^28.11.0
-        version: 28.11.0(@typescript-eslint/eslint-plugin@8.27.0(@typescript-eslint/parser@8.27.0(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3)
+        version: 28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3)
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.23.0)
@@ -69,7 +69,7 @@ importers:
         version: 5.2.0(eslint@9.23.0)
       eslint-plugin-svelte:
         specifier: ^3.3.3
-        version: 3.3.3(eslint@9.23.0)(svelte@5.25.2)
+        version: 3.3.3(eslint@9.23.0)(svelte@5.25.3)
       eslint-plugin-testing-library:
         specifier: ^7.1.1
         version: 7.1.1(eslint@9.23.0)(typescript@5.7.3)
@@ -78,13 +78,13 @@ importers:
         version: 16.0.0
       svelte:
         specifier: ^3.37.0 || ^4.0.0 || ^5.0.0
-        version: 5.25.2
+        version: 5.25.3
       svelte-eslint-parser:
         specifier: ^1.1.0
-        version: 1.1.0(svelte@5.25.2)
+        version: 1.1.0(svelte@5.25.3)
       typescript-eslint:
-        specifier: ^8.27.0
-        version: 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+        specifier: ^8.28.0
+        version: 8.28.0(eslint@9.23.0)(typescript@5.7.3)
     devDependencies:
       '@qlik/tsconfig':
         specifier: workspace:*
@@ -102,8 +102,8 @@ importers:
         specifier: ^9.14.0
         version: 9.14.0
       '@types/node':
-        specifier: ^22.13.11
-        version: 22.13.11
+        specifier: ^22.13.13
+        version: 22.13.13
       eslint:
         specifier: ^9.23.0
         version: 9.23.0
@@ -112,7 +112,7 @@ importers:
         version: 3.5.3
       vitest:
         specifier: ^3.0.9
-        version: 3.0.9(@types/node@22.13.11)
+        version: 3.0.9(@types/node@22.13.13)
 
   packages/prettier-config:
     dependencies:
@@ -130,7 +130,7 @@ importers:
         version: 0.15.0(prettier@3.5.3)
       prettier-plugin-svelte:
         specifier: ^3.3.3
-        version: 3.3.3(prettier@3.5.3)(svelte@5.25.2)
+        version: 3.3.3(prettier@3.5.3)(svelte@5.25.3)
 
   packages/tsconfig: {}
 
@@ -150,7 +150,7 @@ importers:
         version: 9.23.0
       vitest:
         specifier: ^3.0.9
-        version: 3.0.9(@types/node@22.13.11)
+        version: 3.0.9(@types/node@22.13.13)
 
   test/test-react:
     dependencies:
@@ -177,8 +177,8 @@ importers:
         specifier: ^19.0.0
         version: 19.0.0
       svelte:
-        specifier: ^5.25.2
-        version: 5.25.2
+        specifier: ^5.25.3
+        version: 5.25.3
     devDependencies:
       '@qlik/eslint-config':
         specifier: workspace:*
@@ -199,8 +199,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@babel/runtime@7.26.10':
-    resolution: {integrity: sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==}
+  '@babel/runtime@7.27.0':
+    resolution: {integrity: sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==}
     engines: {node: '>=6.9.0'}
 
   '@changesets/apply-release-plan@7.0.10':
@@ -427,20 +427,20 @@ packages:
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint-react/ast@1.37.2':
-    resolution: {integrity: sha512-+uo8n/NuN440tTH+wFMx7Sk5vb44y/JCnk0NANkGVQs8mQvPbCAmqqK3TiSbofn4rikMS8FN8f7hX2SlE/aOLw==}
+  '@eslint-react/ast@1.38.0':
+    resolution: {integrity: sha512-4nZtK57dcWB/QgqEzTOX56w8QL5HIDjqv7xqd1X3XR+T8nQum/XXqGIaQzL7SkX8oC2VosOykFJyI0s3cLdVLQ==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
 
-  '@eslint-react/core@1.37.2':
-    resolution: {integrity: sha512-46/87kSm87xPMZrjouSu9NiiWkhHvdaZMTV7LVx4nGj0XvV2g9rRUWocQvuA23OszcHUuNdXhGY2GdlZLp65vA==}
+  '@eslint-react/core@1.38.0':
+    resolution: {integrity: sha512-IJ8HO0BN1fAWCfeP4eBTAi3PAMq4Hb1wAHBLII7XPukyoRsIxqUpIYCowyZquxT0MUOPqJn6XQ/yk0RWOtCHXQ==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
 
-  '@eslint-react/eff@1.37.2':
-    resolution: {integrity: sha512-Fhucd+afu+4/5d3qJkVi/Hsznt/X/eIMCUfCqCAZHXmAjZMP8IdkcunEQnrifbaIreSSr6AXhDhuUCkJTSc6+g==}
+  '@eslint-react/eff@1.38.0':
+    resolution: {integrity: sha512-09x1sQlvaoUEQVh2doARQcG3xsniRCOyI8ykKSqfsOBE3iA3tyufnHkliOJjcJPpascxk5xr/+u5keJ5kLUQcQ==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
 
-  '@eslint-react/eslint-plugin@1.37.2':
-    resolution: {integrity: sha512-jz+rVJgpv7BZi1EUwCeZbONJekSJYsnu6G6PmNBWDCOKp0Q3wZ2u5Hb7VtGX+TMrbIO7zqds/HqcqpcGYwa0wQ==}
+  '@eslint-react/eslint-plugin@1.38.0':
+    resolution: {integrity: sha512-dQ0pyFCkR5JvCaGhSFfYRr/cX+W8xt9Eb73Eh6WP1F5wj1hUaXpZ2mAEZqhKbm3gMzgG3kpvKYNM+SfmhUJw3w==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -449,16 +449,20 @@ packages:
       typescript:
         optional: true
 
-  '@eslint-react/jsx@1.37.2':
-    resolution: {integrity: sha512-cr95dQMN2+auLHEc70BtPRN0ZbRmLoYtDPr3ri3L+mNdaeMuUuWzoi3EU5ATIG0Dplf3+fu2Kjy+JEQqB+YEBA==}
+  '@eslint-react/jsx@1.38.0':
+    resolution: {integrity: sha512-UawUz686U0Fj24vOPff/xZntnFTo6/Yp0syw6qhtYqOagECoewTUwJ3DUfKoyjExZOUukojXSLLbintujvgCuA==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
 
-  '@eslint-react/shared@1.37.2':
-    resolution: {integrity: sha512-p1wCbzJRxmqATbt+LwMk95X8I3h1TvEwKVETGuCWdk30N+MExHuWaeqRjsR0+Z1MVlRDA+dSIJNJO5XKn1f40Q==}
+  '@eslint-react/kit@1.38.0':
+    resolution: {integrity: sha512-ngIvZxucEMWPpYqzeaAagK8igdMGOyLjZdhrh1XRnbllNESryNV6t8HGoiOE/wsfZo8KhZMD4IbY/4hPTSKGVQ==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
 
-  '@eslint-react/var@1.37.2':
-    resolution: {integrity: sha512-EcEx0maukOQAMLc99LrxVVNWrrpaKgD8TSlTsUxeLe8CCOuxiqtLqwRsabeTc5cDdQSqYgVAICxX2yNxF75cMA==}
+  '@eslint-react/shared@1.38.0':
+    resolution: {integrity: sha512-8g61tCr5Qj8UBSVEbq4rs71OVrN7aDHpQRY3YCEGtSWr8OBPmgJ+rrxfBAx1Zq3p4B2KZFDy3R2ho/haII/5Vg==}
+    engines: {bun: '>=1.0.15', node: '>=18.18.0'}
+
+  '@eslint-react/var@1.38.0':
+    resolution: {integrity: sha512-qsytJEj4Es4fZVW5kpLHx4Yh+k5DWz8h2OeXlmNJCzIvSIYC0bRTgd43lWsexwDAVfWINWMs32qFeR88HpMU8Q==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
 
   '@eslint/config-array@0.19.2':
@@ -552,98 +556,103 @@ packages:
     resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@rollup/rollup-android-arm-eabi@4.36.0':
-    resolution: {integrity: sha512-jgrXjjcEwN6XpZXL0HUeOVGfjXhPyxAbbhD0BlXUB+abTOpbPiN5Wb3kOT7yb+uEtATNYF5x5gIfwutmuBA26w==}
+  '@rollup/rollup-android-arm-eabi@4.37.0':
+    resolution: {integrity: sha512-l7StVw6WAa8l3vA1ov80jyetOAEo1FtHvZDbzXDO/02Sq/QVvqlHkYoFwDJPIMj0GKiistsBudfx5tGFnwYWDQ==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.36.0':
-    resolution: {integrity: sha512-NyfuLvdPdNUfUNeYKUwPwKsE5SXa2J6bCt2LdB/N+AxShnkpiczi3tcLJrm5mA+eqpy0HmaIY9F6XCa32N5yzg==}
+  '@rollup/rollup-android-arm64@4.37.0':
+    resolution: {integrity: sha512-6U3SlVyMxezt8Y+/iEBcbp945uZjJwjZimu76xoG7tO1av9VO691z8PkhzQ85ith2I8R2RddEPeSfcbyPfD4hA==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.36.0':
-    resolution: {integrity: sha512-JQ1Jk5G4bGrD4pWJQzWsD8I1n1mgPXq33+/vP4sk8j/z/C2siRuxZtaUA7yMTf71TCZTZl/4e1bfzwUmFb3+rw==}
+  '@rollup/rollup-darwin-arm64@4.37.0':
+    resolution: {integrity: sha512-+iTQ5YHuGmPt10NTzEyMPbayiNTcOZDWsbxZYR1ZnmLnZxG17ivrPSWFO9j6GalY0+gV3Jtwrrs12DBscxnlYA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.36.0':
-    resolution: {integrity: sha512-6c6wMZa1lrtiRsbDziCmjE53YbTkxMYhhnWnSW8R/yqsM7a6mSJ3uAVT0t8Y/DGt7gxUWYuFM4bwWk9XCJrFKA==}
+  '@rollup/rollup-darwin-x64@4.37.0':
+    resolution: {integrity: sha512-m8W2UbxLDcmRKVjgl5J/k4B8d7qX2EcJve3Sut7YGrQoPtCIQGPH5AMzuFvYRWZi0FVS0zEY4c8uttPfX6bwYQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.36.0':
-    resolution: {integrity: sha512-KXVsijKeJXOl8QzXTsA+sHVDsFOmMCdBRgFmBb+mfEb/7geR7+C8ypAml4fquUt14ZyVXaw2o1FWhqAfOvA4sg==}
+  '@rollup/rollup-freebsd-arm64@4.37.0':
+    resolution: {integrity: sha512-FOMXGmH15OmtQWEt174v9P1JqqhlgYge/bUjIbiVD1nI1NeJ30HYT9SJlZMqdo1uQFyt9cz748F1BHghWaDnVA==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.36.0':
-    resolution: {integrity: sha512-dVeWq1ebbvByI+ndz4IJcD4a09RJgRYmLccwlQ8bPd4olz3Y213uf1iwvc7ZaxNn2ab7bjc08PrtBgMu6nb4pQ==}
+  '@rollup/rollup-freebsd-x64@4.37.0':
+    resolution: {integrity: sha512-SZMxNttjPKvV14Hjck5t70xS3l63sbVwl98g3FlVVx2YIDmfUIy29jQrsw06ewEYQ8lQSuY9mpAPlmgRD2iSsA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.36.0':
-    resolution: {integrity: sha512-bvXVU42mOVcF4le6XSjscdXjqx8okv4n5vmwgzcmtvFdifQ5U4dXFYaCB87namDRKlUL9ybVtLQ9ztnawaSzvg==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.37.0':
+    resolution: {integrity: sha512-hhAALKJPidCwZcj+g+iN+38SIOkhK2a9bqtJR+EtyxrKKSt1ynCBeqrQy31z0oWU6thRZzdx53hVgEbRkuI19w==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.36.0':
-    resolution: {integrity: sha512-JFIQrDJYrxOnyDQGYkqnNBtjDwTgbasdbUiQvcU8JmGDfValfH1lNpng+4FWlhaVIR4KPkeddYjsVVbmJYvDcg==}
+  '@rollup/rollup-linux-arm-musleabihf@4.37.0':
+    resolution: {integrity: sha512-jUb/kmn/Gd8epbHKEqkRAxq5c2EwRt0DqhSGWjPFxLeFvldFdHQs/n8lQ9x85oAeVb6bHcS8irhTJX2FCOd8Ag==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.36.0':
-    resolution: {integrity: sha512-KqjYVh3oM1bj//5X7k79PSCZ6CvaVzb7Qs7VMWS+SlWB5M8p3FqufLP9VNp4CazJ0CsPDLwVD9r3vX7Ci4J56A==}
+  '@rollup/rollup-linux-arm64-gnu@4.37.0':
+    resolution: {integrity: sha512-oNrJxcQT9IcbcmKlkF+Yz2tmOxZgG9D9GRq+1OE6XCQwCVwxixYAa38Z8qqPzQvzt1FCfmrHX03E0pWoXm1DqA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.36.0':
-    resolution: {integrity: sha512-QiGnhScND+mAAtfHqeT+cB1S9yFnNQ/EwCg5yE3MzoaZZnIV0RV9O5alJAoJKX/sBONVKeZdMfO8QSaWEygMhw==}
+  '@rollup/rollup-linux-arm64-musl@4.37.0':
+    resolution: {integrity: sha512-pfxLBMls+28Ey2enpX3JvjEjaJMBX5XlPCZNGxj4kdJyHduPBXtxYeb8alo0a7bqOoWZW2uKynhHxF/MWoHaGQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.36.0':
-    resolution: {integrity: sha512-1ZPyEDWF8phd4FQtTzMh8FQwqzvIjLsl6/84gzUxnMNFBtExBtpL51H67mV9xipuxl1AEAerRBgBwFNpkw8+Lg==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.37.0':
+    resolution: {integrity: sha512-yCE0NnutTC/7IGUq/PUHmoeZbIwq3KRh02e9SfFh7Vmc1Z7atuJRYWhRME5fKgT8aS20mwi1RyChA23qSyRGpA==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.36.0':
-    resolution: {integrity: sha512-VMPMEIUpPFKpPI9GZMhJrtu8rxnp6mJR3ZzQPykq4xc2GmdHj3Q4cA+7avMyegXy4n1v+Qynr9fR88BmyO74tg==}
+  '@rollup/rollup-linux-powerpc64le-gnu@4.37.0':
+    resolution: {integrity: sha512-NxcICptHk06E2Lh3a4Pu+2PEdZ6ahNHuK7o6Np9zcWkrBMuv21j10SQDJW3C9Yf/A/P7cutWoC/DptNLVsZ0VQ==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.36.0':
-    resolution: {integrity: sha512-ttE6ayb/kHwNRJGYLpuAvB7SMtOeQnVXEIpMtAvx3kepFQeowVED0n1K9nAdraHUPJ5hydEMxBpIR7o4nrm8uA==}
+  '@rollup/rollup-linux-riscv64-gnu@4.37.0':
+    resolution: {integrity: sha512-PpWwHMPCVpFZLTfLq7EWJWvrmEuLdGn1GMYcm5MV7PaRgwCEYJAwiN94uBuZev0/J/hFIIJCsYw4nLmXA9J7Pw==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.36.0':
-    resolution: {integrity: sha512-4a5gf2jpS0AIe7uBjxDeUMNcFmaRTbNv7NxI5xOCs4lhzsVyGR/0qBXduPnoWf6dGC365saTiwag8hP1imTgag==}
+  '@rollup/rollup-linux-riscv64-musl@4.37.0':
+    resolution: {integrity: sha512-DTNwl6a3CfhGTAOYZ4KtYbdS8b+275LSLqJVJIrPa5/JuIufWWZ/QFvkxp52gpmguN95eujrM68ZG+zVxa8zHA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.37.0':
+    resolution: {integrity: sha512-hZDDU5fgWvDdHFuExN1gBOhCuzo/8TMpidfOR+1cPZJflcEzXdCy1LjnklQdW8/Et9sryOPJAKAQRw8Jq7Tg+A==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.36.0':
-    resolution: {integrity: sha512-5KtoW8UWmwFKQ96aQL3LlRXX16IMwyzMq/jSSVIIyAANiE1doaQsx/KRyhAvpHlPjPiSU/AYX/8m+lQ9VToxFQ==}
+  '@rollup/rollup-linux-x64-gnu@4.37.0':
+    resolution: {integrity: sha512-pKivGpgJM5g8dwj0ywBwe/HeVAUSuVVJhUTa/URXjxvoyTT/AxsLTAbkHkDHG7qQxLoW2s3apEIl26uUe08LVQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.36.0':
-    resolution: {integrity: sha512-sycrYZPrv2ag4OCvaN5js+f01eoZ2U+RmT5as8vhxiFz+kxwlHrsxOwKPSA8WyS+Wc6Epid9QeI/IkQ9NkgYyQ==}
+  '@rollup/rollup-linux-x64-musl@4.37.0':
+    resolution: {integrity: sha512-E2lPrLKE8sQbY/2bEkVTGDEk4/49UYRVWgj90MY8yPjpnGBQ+Xi1Qnr7b7UIWw1NOggdFQFOLZ8+5CzCiz143w==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.36.0':
-    resolution: {integrity: sha512-qbqt4N7tokFwwSVlWDsjfoHgviS3n/vZ8LK0h1uLG9TYIRuUTJC88E1xb3LM2iqZ/WTqNQjYrtmtGmrmmawB6A==}
+  '@rollup/rollup-win32-arm64-msvc@4.37.0':
+    resolution: {integrity: sha512-Jm7biMazjNzTU4PrQtr7VS8ibeys9Pn29/1bm4ph7CP2kf21950LgN+BaE2mJ1QujnvOc6p54eWWiVvn05SOBg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.36.0':
-    resolution: {integrity: sha512-t+RY0JuRamIocMuQcfwYSOkmdX9dtkr1PbhKW42AMvaDQa+jOdpUYysroTF/nuPpAaQMWp7ye+ndlmmthieJrQ==}
+  '@rollup/rollup-win32-ia32-msvc@4.37.0':
+    resolution: {integrity: sha512-e3/1SFm1OjefWICB2Ucstg2dxYDkDTZGDYgwufcbsxTHyqQps1UQf33dFEChBNmeSsTOyrjw2JJq0zbG5GF6RA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.36.0':
-    resolution: {integrity: sha512-aRXd7tRZkWLqGbChgcMMDEHjOKudo1kChb1Jt1IfR8cY/KIpgNviLeJy5FUb9IpSuQj8dU2fAYNMPW/hLKOSTw==}
+  '@rollup/rollup-win32-x64-msvc@4.37.0':
+    resolution: {integrity: sha512-LWbXUBwn/bcLx2sSsqy7pK5o+Nr+VCoRoAohfJ5C/aBio9nfJmGQqHAhU6pwxV/RmyTk5AqdySma7uwWGlmeuA==}
     cpu: [x64]
     os: [win32]
 
@@ -677,63 +686,66 @@ packages:
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
+  '@types/estree@1.0.7':
+    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@22.13.11':
-    resolution: {integrity: sha512-iEUCUJoU0i3VnrCmgoWCXttklWcvoCIx4jzcP22fioIVSdTmjgoEvmAO/QPw6TcS9k5FrNgn4w7q5lGOd1CT5g==}
+  '@types/node@22.13.13':
+    resolution: {integrity: sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==}
 
   '@types/react@19.0.12':
     resolution: {integrity: sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==}
 
-  '@typescript-eslint/eslint-plugin@8.27.0':
-    resolution: {integrity: sha512-4henw4zkePi5p252c8ncBLzLce52SEUz2Ebj8faDnuUXz2UuHEONYcJ+G0oaCF+bYCWVZtrGzq3FD7YXetmnSA==}
+  '@typescript-eslint/eslint-plugin@8.28.0':
+    resolution: {integrity: sha512-lvFK3TCGAHsItNdWZ/1FkvpzCxTHUVuFrdnOGLMa0GGCFIbCgQWVk3CzCGdA7kM3qGVc+dfW9tr0Z/sHnGDFyg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/parser@8.27.0':
-    resolution: {integrity: sha512-XGwIabPallYipmcOk45DpsBSgLC64A0yvdAkrwEzwZ2viqGqRUJ8eEYoPz0CWnutgAFbNMPdsGGvzjSmcWVlEA==}
+  '@typescript-eslint/parser@8.28.0':
+    resolution: {integrity: sha512-LPcw1yHD3ToaDEoljFEfQ9j2xShY367h7FZ1sq5NJT9I3yj4LHer1Xd1yRSOdYy9BpsrxU7R+eoDokChYM53lQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/scope-manager@8.27.0':
-    resolution: {integrity: sha512-8oI9GwPMQmBryaaxG1tOZdxXVeMDte6NyJA4i7/TWa4fBwgnAXYlIQP+uYOeqAaLJ2JRxlG9CAyL+C+YE9Xknw==}
+  '@typescript-eslint/scope-manager@8.28.0':
+    resolution: {integrity: sha512-u2oITX3BJwzWCapoZ/pXw6BCOl8rJP4Ij/3wPoGvY8XwvXflOzd1kLrDUUUAIEdJSFh+ASwdTHqtan9xSg8buw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/type-utils@8.27.0':
-    resolution: {integrity: sha512-wVArTVcz1oJOIEJxui/nRhV0TXzD/zMSOYi/ggCfNq78EIszddXcJb7r4RCp/oBrjt8n9A0BSxRMKxHftpDxDA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
-
-  '@typescript-eslint/types@8.27.0':
-    resolution: {integrity: sha512-/6cp9yL72yUHAYq9g6DsAU+vVfvQmd1a8KyA81uvfDE21O2DwQ/qxlM4AR8TSdAu+kJLBDrEHKC5/W2/nxsY0A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.27.0':
-    resolution: {integrity: sha512-BnKq8cqPVoMw71O38a1tEb6iebEgGA80icSxW7g+kndx0o6ot6696HjG7NdgfuAVmVEtwXUr3L8R9ZuVjoQL6A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <5.9.0'
-
-  '@typescript-eslint/utils@8.27.0':
-    resolution: {integrity: sha512-njkodcwH1yvmo31YWgRHNb/x1Xhhq4/m81PhtvmRngD8iHPehxffz1SNCO+kwaePhATC+kOa/ggmvPoPza5i0Q==}
+  '@typescript-eslint/type-utils@8.28.0':
+    resolution: {integrity: sha512-oRoXu2v0Rsy/VoOGhtWrOKDiIehvI+YNrDk5Oqj40Mwm0Yt01FC/Q7nFqg088d3yAsR1ZcZFVfPCTTFCe/KPwg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/visitor-keys@8.27.0':
-    resolution: {integrity: sha512-WsXQwMkILJvffP6z4U3FYJPlbf/j07HIxmDjZpbNvBJkMfvwXj5ACRkkHwBDvLBbDbtX5TdU64/rcvKJ/vuInQ==}
+  '@typescript-eslint/types@8.28.0':
+    resolution: {integrity: sha512-bn4WS1bkKEjx7HqiwG2JNB3YJdC1q6Ue7GyGlwPHyt0TnVq6TtD/hiOdTZt71sq0s7UzqBFXD8t8o2e63tXgwA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.28.0':
+    resolution: {integrity: sha512-H74nHEeBGeklctAVUvmDkxB1mk+PAZ9FiOMPFncdqeRBXxk1lWSYraHw8V12b7aa6Sg9HOBNbGdSHobBPuQSuA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/utils@8.28.0':
+    resolution: {integrity: sha512-OELa9hbTYciYITqgurT1u/SzpQVtDLmQMFzy/N8pQE+tefOyCWT79jHsav294aTqV1q1u+VzqDGbuujvRYaeSQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/visitor-keys@8.28.0':
+    resolution: {integrity: sha512-hbn8SZ8w4u2pRwgQ1GlUrPKE+t2XvcCW5tTRF7j6SMYIuYG37XuzIW44JCZPa36evi0Oy2SnM664BlIaAuQcvg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@unrs/rspack-resolver-binding-darwin-arm64@1.2.2':
@@ -1202,8 +1214,8 @@ packages:
     peerDependencies:
       eslint: '>=8.40.0'
 
-  eslint-plugin-react-debug@1.37.2:
-    resolution: {integrity: sha512-1a5RNiXiS5+g1KujET+Xq8xdGEnU27Tp17hKAnH50f69eWObKwmU1B6HHqdhMTfZ7TsVXGjXZlSccPW7a0BEGA==}
+  eslint-plugin-react-debug@1.38.0:
+    resolution: {integrity: sha512-k/VLEAimM3GRMnvWaf9ionKWbxMCN9aFKmbXvx56t2HezniRfW7lEi9l6S8s/7JToXvm+tHAWy8IdulwLXcwdA==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -1212,8 +1224,8 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-react-dom@1.37.2:
-    resolution: {integrity: sha512-Ir458cbmCDbvP72l2Q2IiP8h6DaWImBCanuGzr1Oe1/pYw/otzDJ/DsgP99sTRfJyrON7o3u6jezkzD6u/0Elw==}
+  eslint-plugin-react-dom@1.38.0:
+    resolution: {integrity: sha512-xfxVeRmYDeYvrm63ltIh7Hn+/9Y/NHIfwPwYqo3j3thgmtTAagWhhy/nwFG/qQjXkGPoxERAw4OCqOqXvIJ+4g==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -1222,8 +1234,8 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-react-hooks-extra@1.37.2:
-    resolution: {integrity: sha512-D+UQ4tNSZY/B3ZDtamVhdz2r+SWFQsQSClGHrXI6UEdimu8rqvgMgiIWuqRCcn9IgxrY3Xoc0i9UKywqmjHmFw==}
+  eslint-plugin-react-hooks-extra@1.38.0:
+    resolution: {integrity: sha512-1nzFpfPPJ7hcZwlabpTV7svMwDCJFYpqECfUVijjKqVUEcZO98UpV/olj4WZfPBp2ll4nsm+escxO85qOrLqpg==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -1238,8 +1250,8 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
-  eslint-plugin-react-naming-convention@1.37.2:
-    resolution: {integrity: sha512-Onu0Qj7pRJsueihlzrJQ7KFRRokTW1AT/s+E1UOHhAaCTapMy0s3g7aQze8Bc6WqcdrmZZ7RimgjOTj8abCThA==}
+  eslint-plugin-react-naming-convention@1.38.0:
+    resolution: {integrity: sha512-QX2MRfDEubTb0EbcNY33ek4faizU+edQgKCRwUWVcBgI4Yw1AWJrbQ5dOZQjJHYRP0s/tDpBj0MZ+CCxdS3URQ==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -1248,8 +1260,8 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-react-web-api@1.37.2:
-    resolution: {integrity: sha512-nAGQiCzMvmKshEpzeFywmOA6QeEZX3KiOMaV1jCBKVAGoIVYplA31f68wrEqyBGxrHZyVD4K70jwHB3HxnFlLg==}
+  eslint-plugin-react-web-api@1.38.0:
+    resolution: {integrity: sha512-ub1y17j2qiJWdrMTEd+9ZKq+SBkP6W/a8H67YCIZxMvS/XKcNptLXlDJqK/ZnioC6E9WRJzzWfaatVV644218A==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -1258,8 +1270,8 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-react-x@1.37.2:
-    resolution: {integrity: sha512-zNXjPwbqKU5H1e40UFnasBw4QPRKcc/evIjPdOIBUZ+JxYyU3Cj+jls+6VpccwIi9tmWlGn/KshP2DxdxmqGug==}
+  eslint-plugin-react-x@1.38.0:
+    resolution: {integrity: sha512-IBdmaZvJGA+NShlERuCLnEfSxLERP8lDdgvrgF3Kt2inDL8K8Wr40t969IycYHczcIUk9iGpVu2SQlp/YGnIjA==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2045,8 +2057,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rollup@4.36.0:
-    resolution: {integrity: sha512-zwATAXNQxUcd40zgtQG0ZafcRK4g004WtEl7kbuhTWPvf07PsfohXl39jVUvPF7jvNAIkKPQ2XrsDlWuxBd++Q==}
+  rollup@4.37.0:
+    resolution: {integrity: sha512-iAtQy/L4QFU+rTJ1YUjXqJOJzuwEghqWzCEYD2FEghT7Gsy1VdABntrO4CLopA5IkflTyqNiLNwPcOJ3S7UKLg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -2212,8 +2224,8 @@ packages:
       svelte:
         optional: true
 
-  svelte@5.25.2:
-    resolution: {integrity: sha512-IxmBz4x15+bNbowhygUlwoVgqMLfEIDtyjUFDfOwb1f+7Fe5qeLfwGJHMql7QUSJBqNtXcOCPsZDDmuieZcpfA==}
+  svelte@5.25.3:
+    resolution: {integrity: sha512-J9rcZ/xVJonAoESqVGHHZhrNdVbrCfkdB41BP6eiwHMoFShD9it3yZXApVYMHdGfCshBsZCKsajwJeBbS/M1zg==}
     engines: {node: '>=18'}
 
   synckit@0.9.2:
@@ -2260,8 +2272,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
-  ts-declaration-location@1.0.6:
-    resolution: {integrity: sha512-QwtM5UZ8S/NpDvSx4u2EHJgLx2+we7qN8sgyOia4nTpJlke3NO1s1Eb2ea/8IFlkc60b71SILGqWBzGGDnNeSw==}
+  ts-declaration-location@1.0.7:
+    resolution: {integrity: sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==}
     peerDependencies:
       typescript: '>=4.0.0'
 
@@ -2329,8 +2341,8 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript-eslint@8.27.0:
-    resolution: {integrity: sha512-ZZ/8+Y0rRUMuW1gJaPtLWe4ryHbsPLzzibk5Sq+IFa2aOH1Vo0gPr1fbA6pOnzBke7zC2Da4w8AyCgxKXo3lqA==}
+  typescript-eslint@8.28.0:
+    resolution: {integrity: sha512-jfZtxJoHm59bvoCMYCe2BM0/baMswRhMmYhy+w6VfcyHrjxZ0OJe0tGasydCpIpA+A/WIJhTyZfb3EtwNC/kHQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2363,8 +2375,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@6.2.2:
-    resolution: {integrity: sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==}
+  vite@6.2.3:
+    resolution: {integrity: sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -2479,7 +2491,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@babel/runtime@7.26.10':
+  '@babel/runtime@7.27.0':
     dependencies:
       regenerator-runtime: 0.14.1
 
@@ -2723,12 +2735,12 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint-react/ast@1.37.2(eslint@9.23.0)(typescript@5.7.3)':
+  '@eslint-react/ast@1.38.0(eslint@9.23.0)(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/eff': 1.37.2
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/typescript-estree': 8.27.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/eff': 1.38.0
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -2736,17 +2748,18 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/core@1.37.2(eslint@9.23.0)(typescript@5.7.3)':
+  '@eslint-react/core@1.38.0(eslint@9.23.0)(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/ast': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/eff': 1.37.2
-      '@eslint-react/jsx': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/shared': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/var': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/type-utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/ast': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/eff': 1.38.0
+      '@eslint-react/jsx': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/kit': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/shared': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/var': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/type-utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       birecord: 0.1.1
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -2754,47 +2767,59 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/eff@1.37.2': {}
+  '@eslint-react/eff@1.38.0': {}
 
-  '@eslint-react/eslint-plugin@1.37.2(eslint@9.23.0)(ts-api-utils@2.1.0(typescript@5.7.3))(typescript@5.7.3)':
+  '@eslint-react/eslint-plugin@1.38.0(eslint@9.23.0)(ts-api-utils@2.1.0(typescript@5.7.3))(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/eff': 1.37.2
-      '@eslint-react/shared': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/type-utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/eff': 1.38.0
+      '@eslint-react/kit': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/shared': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/type-utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       eslint: 9.23.0
-      eslint-plugin-react-debug: 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      eslint-plugin-react-dom: 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      eslint-plugin-react-hooks-extra: 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      eslint-plugin-react-naming-convention: 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      eslint-plugin-react-web-api: 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      eslint-plugin-react-x: 1.37.2(eslint@9.23.0)(ts-api-utils@2.1.0(typescript@5.7.3))(typescript@5.7.3)
+      eslint-plugin-react-debug: 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      eslint-plugin-react-dom: 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      eslint-plugin-react-hooks-extra: 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      eslint-plugin-react-naming-convention: 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      eslint-plugin-react-web-api: 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      eslint-plugin-react-x: 1.38.0(eslint@9.23.0)(ts-api-utils@2.1.0(typescript@5.7.3))(typescript@5.7.3)
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
       - ts-api-utils
 
-  '@eslint-react/jsx@1.37.2(eslint@9.23.0)(typescript@5.7.3)':
+  '@eslint-react/jsx@1.38.0(eslint@9.23.0)(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/ast': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/eff': 1.37.2
-      '@eslint-react/var': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/ast': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/eff': 1.38.0
+      '@eslint-react/var': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       ts-pattern: 5.6.2
     transitivePeerDependencies:
       - eslint
       - supports-color
       - typescript
 
-  '@eslint-react/shared@1.37.2(eslint@9.23.0)(typescript@5.7.3)':
+  '@eslint-react/kit@1.38.0(eslint@9.23.0)(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/eff': 1.37.2
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/eff': 1.38.0
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
+      ts-pattern: 5.6.2
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - typescript
+
+  '@eslint-react/shared@1.38.0(eslint@9.23.0)(typescript@5.7.3)':
+    dependencies:
+      '@eslint-react/eff': 1.38.0
+      '@eslint-react/kit': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       picomatch: 4.0.2
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -2802,13 +2827,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/var@1.37.2(eslint@9.23.0)(typescript@5.7.3)':
+  '@eslint-react/var@1.38.0(eslint@9.23.0)(typescript@5.7.3)':
     dependencies:
-      '@eslint-react/ast': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/eff': 1.37.2
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/ast': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/eff': 1.38.0
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       string-ts: 2.2.1
       ts-pattern: 5.6.2
     transitivePeerDependencies:
@@ -2885,14 +2910,14 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.0
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.0
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -2920,61 +2945,64 @@ snapshots:
 
   '@pkgr/core@0.1.2': {}
 
-  '@rollup/rollup-android-arm-eabi@4.36.0':
+  '@rollup/rollup-android-arm-eabi@4.37.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.36.0':
+  '@rollup/rollup-android-arm64@4.37.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.36.0':
+  '@rollup/rollup-darwin-arm64@4.37.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.36.0':
+  '@rollup/rollup-darwin-x64@4.37.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.36.0':
+  '@rollup/rollup-freebsd-arm64@4.37.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.36.0':
+  '@rollup/rollup-freebsd-x64@4.37.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.36.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.37.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.36.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.37.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.36.0':
+  '@rollup/rollup-linux-arm64-gnu@4.37.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.36.0':
+  '@rollup/rollup-linux-arm64-musl@4.37.0':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.36.0':
+  '@rollup/rollup-linux-loongarch64-gnu@4.37.0':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.36.0':
+  '@rollup/rollup-linux-powerpc64le-gnu@4.37.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.36.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.37.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.36.0':
+  '@rollup/rollup-linux-riscv64-musl@4.37.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.36.0':
+  '@rollup/rollup-linux-s390x-gnu@4.37.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.36.0':
+  '@rollup/rollup-linux-x64-gnu@4.37.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.36.0':
+  '@rollup/rollup-linux-x64-musl@4.37.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.36.0':
+  '@rollup/rollup-win32-arm64-msvc@4.37.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.36.0':
+  '@rollup/rollup-win32-ia32-msvc@4.37.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.37.0':
     optional: true
 
   '@sveltejs/acorn-typescript@1.0.5(acorn@8.14.1)':
@@ -2998,7 +3026,7 @@ snapshots:
 
   '@types/eslint@9.6.1':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/json-schema': 7.0.15
 
   '@types/eslint__js@9.14.0':
@@ -3007,11 +3035,13 @@ snapshots:
 
   '@types/estree@1.0.6': {}
 
+  '@types/estree@1.0.7': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.13.11':
+  '@types/node@22.13.13':
     dependencies:
       undici-types: 6.20.0
 
@@ -3019,14 +3049,14 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
-  '@typescript-eslint/eslint-plugin@8.27.0(@typescript-eslint/parser@8.27.0(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/type-utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 8.27.0
+      '@typescript-eslint/parser': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/type-utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.28.0
       eslint: 9.23.0
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -3036,27 +3066,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.27.0(eslint@9.23.0)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.28.0(eslint@9.23.0)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/typescript-estree': 8.27.0(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 8.27.0
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.28.0
       debug: 4.4.0
       eslint: 9.23.0
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.27.0':
+  '@typescript-eslint/scope-manager@8.28.0':
     dependencies:
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/visitor-keys': 8.27.0
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/visitor-keys': 8.28.0
 
-  '@typescript-eslint/type-utils@8.27.0(eslint@9.23.0)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.28.0(eslint@9.23.0)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.27.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       debug: 4.4.0
       eslint: 9.23.0
       ts-api-utils: 2.1.0(typescript@5.7.3)
@@ -3064,12 +3094,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.27.0': {}
+  '@typescript-eslint/types@8.28.0': {}
 
-  '@typescript-eslint/typescript-estree@8.27.0(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.28.0(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/visitor-keys': 8.27.0
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/visitor-keys': 8.28.0
       debug: 4.4.0
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -3080,20 +3110,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.27.0(eslint@9.23.0)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.5.1(eslint@9.23.0)
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/typescript-estree': 8.27.0(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.7.3)
       eslint: 9.23.0
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.27.0':
+  '@typescript-eslint/visitor-keys@8.28.0':
     dependencies:
-      '@typescript-eslint/types': 8.27.0
+      '@typescript-eslint/types': 8.28.0
       eslint-visitor-keys: 4.2.0
 
   '@unrs/rspack-resolver-binding-darwin-arm64@1.2.2':
@@ -3131,13 +3161,13 @@ snapshots:
   '@unrs/rspack-resolver-binding-win32-x64-msvc@1.2.2':
     optional: true
 
-  '@vitest/eslint-plugin@1.1.38(@typescript-eslint/utils@8.27.0(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3)(vitest@3.0.9(@types/node@22.13.11))':
+  '@vitest/eslint-plugin@1.1.38(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3)(vitest@3.0.9(@types/node@22.13.13))':
     dependencies:
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       eslint: 9.23.0
     optionalDependencies:
       typescript: 5.7.3
-      vitest: 3.0.9(@types/node@22.13.11)
+      vitest: 3.0.9(@types/node@22.13.13)
 
   '@vitest/expect@3.0.9':
     dependencies:
@@ -3146,13 +3176,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.9(vite@6.2.2(@types/node@22.13.11))':
+  '@vitest/mocker@3.0.9(vite@6.2.3(@types/node@22.13.13))':
     dependencies:
       '@vitest/spy': 3.0.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.2(@types/node@22.13.11)
+      vite: 6.2.3(@types/node@22.13.13)
 
   '@vitest/pretty-format@3.0.9':
     dependencies:
@@ -3603,7 +3633,7 @@ snapshots:
   eslint-plugin-import-x@4.9.1(eslint@9.23.0)(typescript@5.7.3):
     dependencies:
       '@types/doctrine': 0.0.9
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       debug: 4.4.0
       doctrine: 3.0.0
       eslint: 9.23.0
@@ -3619,12 +3649,12 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.27.0(@typescript-eslint/parser@8.27.0(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3):
+  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       eslint: 9.23.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.27.0(@typescript-eslint/parser@8.27.0(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3653,18 +3683,19 @@ snapshots:
       eslint: 9.23.0
       globals: 13.24.0
 
-  eslint-plugin-react-debug@1.37.2(eslint@9.23.0)(typescript@5.7.3):
+  eslint-plugin-react-debug@1.38.0(eslint@9.23.0)(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/core': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/eff': 1.37.2
-      '@eslint-react/jsx': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/shared': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/var': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/type-utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/ast': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/core': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/eff': 1.38.0
+      '@eslint-react/jsx': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/kit': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/shared': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/var': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/type-utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       eslint: 9.23.0
       string-ts: 2.2.1
       ts-pattern: 5.6.2
@@ -3673,17 +3704,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-dom@1.37.2(eslint@9.23.0)(typescript@5.7.3):
+  eslint-plugin-react-dom@1.38.0(eslint@9.23.0)(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/core': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/eff': 1.37.2
-      '@eslint-react/jsx': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/shared': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/var': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/ast': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/core': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/eff': 1.38.0
+      '@eslint-react/jsx': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/kit': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/shared': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/var': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       compare-versions: 6.1.1
       eslint: 9.23.0
       string-ts: 2.2.1
@@ -3693,18 +3725,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks-extra@1.37.2(eslint@9.23.0)(typescript@5.7.3):
+  eslint-plugin-react-hooks-extra@1.38.0(eslint@9.23.0)(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/core': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/eff': 1.37.2
-      '@eslint-react/jsx': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/shared': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/var': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/type-utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/ast': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/core': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/eff': 1.38.0
+      '@eslint-react/jsx': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/kit': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/shared': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/var': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/type-utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       eslint: 9.23.0
       string-ts: 2.2.1
       ts-pattern: 5.6.2
@@ -3717,18 +3750,19 @@ snapshots:
     dependencies:
       eslint: 9.23.0
 
-  eslint-plugin-react-naming-convention@1.37.2(eslint@9.23.0)(typescript@5.7.3):
+  eslint-plugin-react-naming-convention@1.38.0(eslint@9.23.0)(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/core': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/eff': 1.37.2
-      '@eslint-react/jsx': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/shared': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/var': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/type-utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/ast': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/core': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/eff': 1.38.0
+      '@eslint-react/jsx': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/kit': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/shared': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/var': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/type-utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       eslint: 9.23.0
       string-ts: 2.2.1
       ts-pattern: 5.6.2
@@ -3737,17 +3771,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-web-api@1.37.2(eslint@9.23.0)(typescript@5.7.3):
+  eslint-plugin-react-web-api@1.38.0(eslint@9.23.0)(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/core': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/eff': 1.37.2
-      '@eslint-react/jsx': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/shared': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/var': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/ast': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/core': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/eff': 1.38.0
+      '@eslint-react/jsx': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/kit': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/shared': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/var': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       eslint: 9.23.0
       string-ts: 2.2.1
       ts-pattern: 5.6.2
@@ -3756,18 +3791,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-x@1.37.2(eslint@9.23.0)(ts-api-utils@2.1.0(typescript@5.7.3))(typescript@5.7.3):
+  eslint-plugin-react-x@1.38.0(eslint@9.23.0)(ts-api-utils@2.1.0(typescript@5.7.3))(typescript@5.7.3):
     dependencies:
-      '@eslint-react/ast': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/core': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/eff': 1.37.2
-      '@eslint-react/jsx': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/shared': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@eslint-react/var': 1.37.2(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/type-utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/ast': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/core': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/eff': 1.38.0
+      '@eslint-react/jsx': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/kit': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/shared': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@eslint-react/var': 1.38.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/type-utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/types': 8.28.0
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       compare-versions: 6.1.1
       eslint: 9.23.0
       is-immutable-type: 5.0.1(eslint@9.23.0)(typescript@5.7.3)
@@ -3801,7 +3837,7 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-svelte@3.3.3(eslint@9.23.0)(svelte@5.25.2):
+  eslint-plugin-svelte@3.3.3(eslint@9.23.0)(svelte@5.25.3):
     dependencies:
       '@eslint-community/eslint-utils': 4.5.1(eslint@9.23.0)
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -3813,16 +3849,16 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.3)
       postcss-safe-parser: 7.0.1(postcss@8.5.3)
       semver: 7.7.1
-      svelte-eslint-parser: 1.1.0(svelte@5.25.2)
+      svelte-eslint-parser: 1.1.0(svelte@5.25.3)
     optionalDependencies:
-      svelte: 5.25.2
+      svelte: 5.25.3
     transitivePeerDependencies:
       - ts-node
 
   eslint-plugin-testing-library@7.1.1(eslint@9.23.0)(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       eslint: 9.23.0
     transitivePeerDependencies:
       - supports-color
@@ -3850,7 +3886,7 @@ snapshots:
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.2
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/json-schema': 7.0.15
       ajv: 6.12.6
       chalk: 4.1.2
@@ -3903,7 +3939,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   esutils@2.0.3: {}
 
@@ -4171,10 +4207,10 @@ snapshots:
 
   is-immutable-type@5.0.1(eslint@9.23.0)(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/type-utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       eslint: 9.23.0
       ts-api-utils: 2.1.0(typescript@5.7.3)
-      ts-declaration-location: 1.0.6(typescript@5.7.3)
+      ts-declaration-location: 1.0.7(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -4192,7 +4228,7 @@ snapshots:
 
   is-reference@3.0.3:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   is-regex@1.2.1:
     dependencies:
@@ -4509,10 +4545,10 @@ snapshots:
       prettier: 3.5.3
       sh-syntax: 0.4.2
 
-  prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.25.2):
+  prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.25.3):
     dependencies:
       prettier: 3.5.3
-      svelte: 5.25.2
+      svelte: 5.25.3
 
   prettier@2.8.8: {}
 
@@ -4583,29 +4619,30 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rollup@4.36.0:
+  rollup@4.37.0:
     dependencies:
       '@types/estree': 1.0.6
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.36.0
-      '@rollup/rollup-android-arm64': 4.36.0
-      '@rollup/rollup-darwin-arm64': 4.36.0
-      '@rollup/rollup-darwin-x64': 4.36.0
-      '@rollup/rollup-freebsd-arm64': 4.36.0
-      '@rollup/rollup-freebsd-x64': 4.36.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.36.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.36.0
-      '@rollup/rollup-linux-arm64-gnu': 4.36.0
-      '@rollup/rollup-linux-arm64-musl': 4.36.0
-      '@rollup/rollup-linux-loongarch64-gnu': 4.36.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.36.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.36.0
-      '@rollup/rollup-linux-s390x-gnu': 4.36.0
-      '@rollup/rollup-linux-x64-gnu': 4.36.0
-      '@rollup/rollup-linux-x64-musl': 4.36.0
-      '@rollup/rollup-win32-arm64-msvc': 4.36.0
-      '@rollup/rollup-win32-ia32-msvc': 4.36.0
-      '@rollup/rollup-win32-x64-msvc': 4.36.0
+      '@rollup/rollup-android-arm-eabi': 4.37.0
+      '@rollup/rollup-android-arm64': 4.37.0
+      '@rollup/rollup-darwin-arm64': 4.37.0
+      '@rollup/rollup-darwin-x64': 4.37.0
+      '@rollup/rollup-freebsd-arm64': 4.37.0
+      '@rollup/rollup-freebsd-x64': 4.37.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.37.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.37.0
+      '@rollup/rollup-linux-arm64-gnu': 4.37.0
+      '@rollup/rollup-linux-arm64-musl': 4.37.0
+      '@rollup/rollup-linux-loongarch64-gnu': 4.37.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.37.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.37.0
+      '@rollup/rollup-linux-riscv64-musl': 4.37.0
+      '@rollup/rollup-linux-s390x-gnu': 4.37.0
+      '@rollup/rollup-linux-x64-gnu': 4.37.0
+      '@rollup/rollup-linux-x64-musl': 4.37.0
+      '@rollup/rollup-win32-arm64-msvc': 4.37.0
+      '@rollup/rollup-win32-ia32-msvc': 4.37.0
+      '@rollup/rollup-win32-x64-msvc': 4.37.0
       fsevents: 2.3.3
 
   rspack-resolver@1.2.2:
@@ -4811,7 +4848,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-eslint-parser@1.1.0(svelte@5.25.2):
+  svelte-eslint-parser@1.1.0(svelte@5.25.3):
     dependencies:
       eslint-scope: 8.3.0
       eslint-visitor-keys: 4.2.0
@@ -4820,14 +4857,14 @@ snapshots:
       postcss-scss: 4.0.9(postcss@8.5.3)
       postcss-selector-parser: 7.1.0
     optionalDependencies:
-      svelte: 5.25.2
+      svelte: 5.25.3
 
-  svelte@5.25.2:
+  svelte@5.25.3:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
       '@sveltejs/acorn-typescript': 1.0.5(acorn@8.14.1)
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       acorn: 8.14.1
       aria-query: 5.3.2
       axobject-query: 4.1.0
@@ -4873,9 +4910,9 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
-  ts-declaration-location@1.0.6(typescript@5.7.3):
+  ts-declaration-location@1.0.7(typescript@5.7.3):
     dependencies:
-      minimatch: 9.0.5
+      picomatch: 4.0.2
       typescript: 5.7.3
 
   ts-pattern@5.6.2: {}
@@ -4948,11 +4985,11 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.27.0(eslint@9.23.0)(typescript@5.7.3):
+  typescript-eslint@8.28.0(eslint@9.23.0)(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.27.0(@typescript-eslint/parser@8.27.0(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0)(typescript@5.7.3))(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.7.3)
       eslint: 9.23.0
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -4977,13 +5014,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@3.0.9(@types/node@22.13.11):
+  vite-node@3.0.9(@types/node@22.13.13):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.2(@types/node@22.13.11)
+      vite: 6.2.3(@types/node@22.13.13)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4998,19 +5035,19 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.2(@types/node@22.13.11):
+  vite@6.2.3(@types/node@22.13.13):
     dependencies:
       esbuild: 0.25.1
       postcss: 8.5.3
-      rollup: 4.36.0
+      rollup: 4.37.0
     optionalDependencies:
-      '@types/node': 22.13.11
+      '@types/node': 22.13.13
       fsevents: 2.3.3
 
-  vitest@3.0.9(@types/node@22.13.11):
+  vitest@3.0.9(@types/node@22.13.13):
     dependencies:
       '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(vite@6.2.2(@types/node@22.13.11))
+      '@vitest/mocker': 3.0.9(vite@6.2.3(@types/node@22.13.13))
       '@vitest/pretty-format': 3.0.9
       '@vitest/runner': 3.0.9
       '@vitest/snapshot': 3.0.9
@@ -5026,11 +5063,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.2(@types/node@22.13.11)
-      vite-node: 3.0.9(@types/node@22.13.11)
+      vite: 6.2.3(@types/node@22.13.13)
+      vite-node: 3.0.9(@types/node@22.13.13)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.13.11
+      '@types/node': 22.13.13
     transitivePeerDependencies:
       - jiti
       - less

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
-  - "packages/*"
-  - "test/*"
+  - packages/*
+  - test/*
+onlyBuiltDependencies:
+  - esbuild

--- a/test/test-react-svelte/package.json
+++ b/test/test-react-svelte/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "react": "^19.0.0",
-    "svelte": "^5.25.2"
+    "svelte": "^5.25.3"
   },
   "devDependencies": {
     "@qlik/eslint-config": "workspace:*",


### PR DESCRIPTION
Update default configs to auto-handle cjs modules.

If a project using using esm modules, with our default configs, adds a .cjs file that file will be automatically linted with the commonjs node config.