### PR TITLE
fix: use flat config resolver option for import-x

### DIFF
--- a/.changeset/cute-apples-dress.md
+++ b/.changeset/cute-apples-dress.md
@@ -1,0 +1,5 @@
+---
+"@qlik/eslint-config": patch
+---
+
+Use flat config typescript resolver for import-x-plugin

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -7,7 +7,6 @@
 - 3bf3c27: BREAKING CHANGES
 
   `@qlik/eslint-config` now supports ESLint 10
-
   - `eslint-plugin-jsx-a11y` - Removed
   - `eslint-plugin-jest` - Removed
   - `eslint-plugin-playwright` - Removed

--- a/packages/eslint-config/src/__tests__/fixtures/vitest.setup.ts
+++ b/packages/eslint-config/src/__tests__/fixtures/vitest.setup.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import vitestPlugin from "@vitest/eslint-plugin";
+
+describe("resolver-next regression", () => {
+  it("keeps package imports resolvable", () => {
+    expect(vitestPlugin.configs).toBeDefined();
+  });
+});

--- a/packages/eslint-config/src/__tests__/qlik-eslint.test.ts
+++ b/packages/eslint-config/src/__tests__/qlik-eslint.test.ts
@@ -1,9 +1,29 @@
 import { describe, expect, it } from "vitest";
+import { ESLint } from "eslint";
 import qlikEslint from "../index.js";
 
 describe("qlik-eslint", () => {
   it("should export a base config", () => {
     const base = qlikEslint.configs.recommended;
     expect(base[0]).toHaveProperty("rules");
+  });
+
+  it("should resolve TypeScript vitest imports without resolver interface errors", async () => {
+    const eslint = new ESLint({
+      overrideConfig: qlikEslint.configs.recommended,
+      overrideConfigFile: true,
+      cwd: process.cwd(),
+    });
+
+    const [result] = await eslint.lintFiles(["src/__tests__/fixtures/vitest.setup.ts"]);
+
+    const messages = result.messages.map((message) => message.message);
+
+    expect(messages).not.toContainEqual(expect.stringContaining("invalid interface loaded as resolver"));
+    expect(messages).not.toContainEqual(expect.stringContaining("Resolve error"));
+    expect(messages).not.toContainEqual(expect.stringContaining("Unable to resolve path to module 'vitest'"));
+    expect(messages).not.toContainEqual(
+      expect.stringContaining("Unable to resolve path to module '@vitest/eslint-plugin'"),
+    );
   });
 });

--- a/packages/eslint-config/src/configs/shared/base.js
+++ b/packages/eslint-config/src/configs/shared/base.js
@@ -1,5 +1,6 @@
 import js from "@eslint/js";
-import { importX } from "eslint-plugin-import-x";
+import { createTypeScriptImportResolver } from "eslint-import-resolver-typescript";
+import { createNodeResolver, importX } from "eslint-plugin-import-x";
 import globals from "globals";
 import tsconfig from "typescript-eslint";
 import { mergeConfigs } from "../../utils/config.js";
@@ -69,6 +70,12 @@ const baseConfigTS = mergeConfigs(
       parserOptions: {
         projectService: true,
       },
+    },
+    settings: {
+      // Use import-x resolver-next for TypeScript and keep node resolution as fallback.
+      "import-x/resolver-next": [createTypeScriptImportResolver({ alwaysTryTypes: true }), createNodeResolver()],
+      // Disable legacy resolver config from the import-x TypeScript preset.
+      "import-x/resolver": false,
     },
     rules: {
       ...typescriptRules,

--- a/packages/eslint-config/test/generated/cjs-final-config.js
+++ b/packages/eslint-config/test/generated/cjs-final-config.js
@@ -2349,9 +2349,17 @@ export default [
           ".mts"
         ]
       },
-      "import-x/resolver": {
-        "typescript": true
-      }
+      "import-x/resolver": false,
+      "import-x/resolver-next": [
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-import-resolver-typescript"
+        },
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-plugin-import-x:node"
+        }
+      ]
     }
   },
   {
@@ -4694,9 +4702,17 @@ export default [
           ".mts"
         ]
       },
-      "import-x/resolver": {
-        "typescript": true
-      }
+      "import-x/resolver": false,
+      "import-x/resolver-next": [
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-import-resolver-typescript"
+        },
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-plugin-import-x:node"
+        }
+      ]
     }
   }
 ]

--- a/packages/eslint-config/test/generated/esbrowser-final-config.js
+++ b/packages/eslint-config/test/generated/esbrowser-final-config.js
@@ -4535,9 +4535,17 @@ export default [
           ".mts"
         ]
       },
-      "import-x/resolver": {
-        "typescript": true
-      }
+      "import-x/resolver": false,
+      "import-x/resolver-next": [
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-import-resolver-typescript"
+        },
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-plugin-import-x:node"
+        }
+      ]
     }
   },
   {
@@ -6890,9 +6898,17 @@ export default [
           ".mts"
         ]
       },
-      "import-x/resolver": {
-        "typescript": true
-      }
+      "import-x/resolver": false,
+      "import-x/resolver-next": [
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-import-resolver-typescript"
+        },
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-plugin-import-x:node"
+        }
+      ]
     }
   }
 ]

--- a/packages/eslint-config/test/generated/esm-final-config.js
+++ b/packages/eslint-config/test/generated/esm-final-config.js
@@ -2339,9 +2339,17 @@ export default [
           ".mts"
         ]
       },
-      "import-x/resolver": {
-        "typescript": true
-      }
+      "import-x/resolver": false,
+      "import-x/resolver-next": [
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-import-resolver-typescript"
+        },
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-plugin-import-x:node"
+        }
+      ]
     }
   },
   {
@@ -4694,9 +4702,17 @@ export default [
           ".mts"
         ]
       },
-      "import-x/resolver": {
-        "typescript": true
-      }
+      "import-x/resolver": false,
+      "import-x/resolver-next": [
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-import-resolver-typescript"
+        },
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-plugin-import-x:node"
+        }
+      ]
     }
   }
 ]

--- a/packages/eslint-config/test/generated/react-final-config.js
+++ b/packages/eslint-config/test/generated/react-final-config.js
@@ -4698,9 +4698,17 @@ export default [
           ".mts"
         ]
       },
-      "import-x/resolver": {
-        "typescript": true
-      },
+      "import-x/resolver": false,
+      "import-x/resolver-next": [
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-import-resolver-typescript"
+        },
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-plugin-import-x:node"
+        }
+      ],
       "react-x": {
         "importSource": "react",
         "polymorphicPropName": "as",

--- a/packages/eslint-config/test/generated/recommended-final-config.js
+++ b/packages/eslint-config/test/generated/recommended-final-config.js
@@ -4538,9 +4538,17 @@ export default [
           ".mts"
         ]
       },
-      "import-x/resolver": {
-        "typescript": true
-      }
+      "import-x/resolver": false,
+      "import-x/resolver-next": [
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-import-resolver-typescript"
+        },
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-plugin-import-x:node"
+        }
+      ]
     }
   },
   {
@@ -6893,9 +6901,17 @@ export default [
           ".mts"
         ]
       },
-      "import-x/resolver": {
-        "typescript": true
-      }
+      "import-x/resolver": false,
+      "import-x/resolver-next": [
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-import-resolver-typescript"
+        },
+        {
+          "interfaceVersion": 3,
+          "name": "eslint-plugin-import-x:node"
+        }
+      ]
     }
   }
 ]


### PR DESCRIPTION
Use the new flat config setting for ESLint 10 in import-x-plugin. Described here https://github.com/un-ts/eslint-plugin-import-x#import-xresolver-next
