### PR TITLE
feat(oxlint-config): enable typed oxlint defaults

### DIFF
--- a/.changeset/curly-seahorses-fold.md
+++ b/.changeset/curly-seahorses-fold.md
@@ -1,0 +1,5 @@
+---
+"@qlik/oxlint-config": minor
+---
+
+Enable typed oxlint defaults and document the updated oxlint migration guidance.

--- a/.github/prompts/migrate-to-oxlint.prompt.md
+++ b/.github/prompts/migrate-to-oxlint.prompt.md
@@ -24,7 +24,7 @@ Follow these steps carefully and explain changes where non-trivial:
    - unsupported rule that may require `jsPlugins`, or only if that still fails, a temporary ESLint fallback
 
 3. Update dependencies:
-   - add oxlint and @qlik/oxlint-config
+   - add oxlint, @qlik/oxlint-config, and oxlint-tsgolint
    - keep ESLint plugin packages that will be loaded through `jsPlugins`
    - remove ESLint packages only when no remaining rule requires ESLint
    - remove obsolete plugins, resolvers, compatibility packages, and pinned overrides
@@ -32,8 +32,10 @@ Follow these steps carefully and explain changes where non-trivial:
 4. Create oxlint.config.ts using @qlik/oxlint-config:
    - import qlik from "@qlik/oxlint-config"
    - import { defineConfig } from "oxlint"
+   - prefer a compact root `extends` array such as `[qlik.recommended, qlik.react]`; do not expand shared presets into copied rule lists
+   - keep the config as small as technically possible: usually `extends`, `ignorePatterns`, and a few targeted overrides are enough
+   - keep the shared preset defaults for `options: { typeAware: true, typeCheck: true }` unless there is a deliberate repo-specific reason to relax them
    - add root `ignorePatterns` for repo-wide exclusions such as `node_modules/**`, `dist/**`, `coverage/**`, and `build/**` when applicable
-   - compose qlik.recommended, qlik.react, qlik.esm, qlik.cjs, or qlik.vitest as appropriate
    - use project-local `jsPlugins` or override-level `jsPlugins` for plugin gaps such as `eslint-plugin-testing-library`
    - if a JS plugin has no Oxlint preset, either handwrite the rules you want or import/spread the plugin's recommended/default rules into the override `rules`
    - keep overrides small and tied to real file groups
@@ -48,13 +50,15 @@ Follow these steps carefully and explain changes where non-trivial:
 
 6. Handle remaining lint failures:
    - prefer code fixes over rule disables
-   - delete stale eslint-disable comments or convert only the ones still needed to `oxlint-disable` or config-based ignores
+   - delete stale `eslint-disable` comments first
+   - keep still-needed `eslint-disable` comments when there are many of them; oxlint already supports those directives
+   - if only a small number of still-needed directives remain, convert them to `oxlint-disable` during the migration, or use `@oxlint/migrate --replace-eslint-comments`
    - for every disabled oxlint rule, add a short justification
    - avoid runtime behavior changes unless explicitly required and reviewed
 
 7. Decide whether ESLint still needs to run:
    - prefer `jsPlugins` for high-value gaps before keeping ESLint, including `eslint-plugin-testing-library`
-   - keep ESLint temporarily only for plugins that still do not run correctly in Oxlint, depend on unsupported APIs, require custom file formats, or rely on type-aware plugin behavior that Oxlint cannot cover yet
+   - keep ESLint temporarily only for plugins that still do not run correctly in Oxlint, depend on unsupported APIs, require custom file formats, or rely on type-aware plugin behavior that Oxlint still cannot cover even with `typeAware` and `typeCheck` enabled
    - document why each remaining ESLint rule/plugin is still needed
    - add a follow-up to remove it when oxlint gains native support
 
@@ -69,6 +73,7 @@ Important:
 - Be opinionated and modern.
 - Prefer deletion over preserving historical config.
 - Prefer native oxlint first, then `jsPlugins`, and only keep ESLint when neither is viable.
+- Prefer `extends` so the final oxlint config stays as small and readable as technically possible.
 - Prefer oxlint defaults and categories over explicit rule lists.
 - Keep repo-wide ignores explicit in root `ignorePatterns`.
 - Do not preserve rules only because they existed in the old ESLint setup.

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -7,11 +7,12 @@ This package is the oxlint sibling of `@qlik/eslint-config`. It mirrors the curr
 ## Requirements
 
 - `oxlint >= 1.61.0`
+- `oxlint-tsgolint >= 0.18.0` (required because the shared presets enable `typeAware` and `typeCheck`)
 - Node.js version supported by your installed `oxlint` release
 
 ## Configs
 
-Import the package root and compose the presets you need with `defineConfig`:
+Import the package root and prefer a compact `extends` array:
 
 ```ts
 import qlik from "@qlik/oxlint-config";
@@ -19,11 +20,10 @@ import { defineConfig } from "oxlint";
 
 export default defineConfig({
   extends: [qlik.recommended, qlik.react],
-  rules: {
-    "eslint/no-unused-vars": "error",
-  },
 });
 ```
+
+Most projects only need `extends`, optional `ignorePatterns`, and a few targeted overrides. The shared presets already enable `options.typeAware` and `options.typeCheck`, so you should not need to restate them in every project config.
 
 The same presets are also available under `qlik.configs` for parity with `@qlik/eslint-config`.
 
@@ -36,7 +36,7 @@ The same presets are also available under `qlik.configs` for parity with `@qlik/
 | `react`       | React projects using oxlint's native React rules                            |
 | `vitest`      | Vitest test files or test-focused lint runs                                 |
 
-Named exports are available when you only need one preset:
+Named exports are available when you want to attach a preset to a narrower file group via `extends`:
 
 ```ts
 import { recommended, vitest } from "@qlik/oxlint-config";
@@ -62,9 +62,17 @@ export default defineConfig({
 - Prefer modern code rules over legacy compatibility rules.
 - Keep CommonJS support scoped to CommonJS files and Node-focused presets.
 
+## Typed linting defaults
+
+All shared presets enable oxlint's `options.typeAware` and `options.typeCheck` settings. That keeps `@qlik/oxlint-config` close to the current `@qlik/eslint-config` TypeScript intent, which already relies on type-aware `typescript-eslint` rules plus TypeScript project-service diagnostics.
+
+In practice, that means the native `typescript/*` rules active under typed linting cover the same core areas as the current shared ESLint profile: type imports and exports, promise misuse, unnecessary conditions, unsafe operations, enum safety, return and void correctness, and switch exhaustiveness. The remaining intentional gaps are documented in [Rule Coverage Notes](#rule-coverage-notes).
+
 ## Migration From ESLint
 
 Use the workspace prompt at [`.github/prompts/migrate-to-oxlint.prompt.md`](../../.github/prompts/migrate-to-oxlint.prompt.md), or copy the prompt below into a Copilot agent chat. It is modeled after the ESLint 9 to 10 migration prompt in `@qlik/eslint-config`, but it focuses on modernization and deletion rather than config translation.
+
+Prefer a compact root config that mostly uses `extends`. In most migrations, the final `oxlint.config.ts` should be only a handful of lines plus `ignorePatterns` and any genuinely project-specific overrides.
 
 ### AI Prompt
 
@@ -90,7 +98,7 @@ Follow these steps carefully and explain changes where non-trivial:
    - unsupported rule that may require `jsPlugins`, or only if that still fails, a temporary ESLint fallback
 
 3. Update dependencies:
-   - add oxlint and @qlik/oxlint-config
+   - add oxlint, @qlik/oxlint-config, and oxlint-tsgolint
    - keep ESLint plugin packages that will be loaded through `jsPlugins`
    - remove ESLint packages only when no remaining rule requires ESLint
    - remove obsolete plugins, resolvers, compatibility packages, and pinned overrides
@@ -98,8 +106,10 @@ Follow these steps carefully and explain changes where non-trivial:
 4. Create oxlint.config.ts using @qlik/oxlint-config:
    - import qlik from "@qlik/oxlint-config"
    - import { defineConfig } from "oxlint"
+   - prefer a compact root `extends` array such as `[qlik.recommended, qlik.react]`; do not expand shared presets into copied rule lists
+   - keep the config as small as technically possible: usually `extends`, `ignorePatterns`, and a few targeted overrides are enough
+   - keep the shared preset defaults for `options: { typeAware: true, typeCheck: true }` unless there is a deliberate repo-specific reason to relax them
    - add root `ignorePatterns` for repo-wide exclusions such as `node_modules/**`, `dist/**`, `coverage/**`, and `build/**` when applicable
-   - compose qlik.recommended, qlik.react, qlik.esm, qlik.cjs, or qlik.vitest as appropriate
    - use project-local `jsPlugins` or override-level `jsPlugins` for plugin gaps such as `eslint-plugin-testing-library`
    - if a JS plugin has no Oxlint preset, either handwrite the rules you want or import/spread the plugin's recommended/default rules into the override `rules`
    - keep overrides small and tied to real file groups
@@ -114,13 +124,15 @@ Follow these steps carefully and explain changes where non-trivial:
 
 6. Handle remaining lint failures:
    - prefer code fixes over rule disables
-   - delete stale eslint-disable comments or convert only the ones still needed to `oxlint-disable` or config-based ignores
+   - delete stale `eslint-disable` comments first
+   - keep still-needed `eslint-disable` comments when there are many of them; oxlint already supports those directives
+   - if only a small number of still-needed directives remain, convert them to `oxlint-disable` during the migration, or use `@oxlint/migrate --replace-eslint-comments`
    - for every disabled oxlint rule, add a short justification
    - avoid runtime behavior changes unless explicitly required and reviewed
 
 7. Decide whether ESLint still needs to run:
    - prefer `jsPlugins` for high-value gaps before keeping ESLint, including `eslint-plugin-testing-library`
-   - keep ESLint temporarily only for plugins that still do not run correctly in Oxlint, depend on unsupported APIs, require custom file formats, or rely on type-aware plugin behavior that Oxlint cannot cover yet
+   - keep ESLint temporarily only for plugins that still do not run correctly in Oxlint, depend on unsupported APIs, require custom file formats, or rely on type-aware plugin behavior that Oxlint still cannot cover even with `typeAware` and `typeCheck` enabled
    - document why each remaining ESLint rule/plugin is still needed
    - add a follow-up to remove it when oxlint gains native support
 
@@ -134,6 +146,7 @@ Important:
 - Be opinionated and modern.
 - Prefer deletion over preserving historical config.
 - Prefer native oxlint first, then `jsPlugins`, and only keep ESLint when neither is viable.
+- Prefer `extends` so the final oxlint config stays as small and readable as technically possible.
 - Prefer oxlint defaults and categories over explicit rule lists.
 - Keep repo-wide ignores explicit in root `ignorePatterns`.
 - Do not preserve rules only because they existed in the old ESLint setup.
@@ -167,9 +180,13 @@ export default defineConfig({
 });
 ```
 
+## Inline disable directives
+
+Oxlint already honors `eslint-disable`, `eslint-disable-next-line`, and related directives. During migration, remove stale disables first. If a repo only has a small number of still-needed directives, converting them to `oxlint-disable` in the same PR is fine. Otherwise, keep the existing ESLint directives for now and do the rename as a follow-up cleanup. Use `@oxlint/migrate --replace-eslint-comments` only when you intentionally want to make that rename part of the migration.
+
 ## Rule Coverage Notes
 
-Some ESLint behavior is intentionally not carried forward:
+With `typeAware` and `typeCheck` enabled, the shared presets intentionally stay close to the current `@qlik/eslint-config` TypeScript profile rather than enabling a random new rule surface. Some ESLint behavior is still intentionally not carried forward:
 
 | ESLint behavior                                      | oxlint decision                                                                                                                                                                                                                                                                                                  |
 | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -27,9 +27,11 @@
     "confusing-browser-globals": "^1.0.11"
   },
   "devDependencies": {
-    "oxlint": "^1.61.0"
+    "oxlint": "^1.61.0",
+    "oxlint-tsgolint": "^0.22.1"
   },
   "peerDependencies": {
-    "oxlint": ">=1.61.0"
+    "oxlint": ">=1.61.0",
+    "oxlint-tsgolint": ">=0.18.0"
   }
 }

--- a/packages/oxlint-config/src/configs/shared/base.js
+++ b/packages/oxlint-config/src/configs/shared/base.js
@@ -26,8 +26,17 @@ const commonjsEnv = {
   commonjs: true,
 };
 
+/** @type {Pick<import("oxlint").OxlintConfig, "options">} */
+const typedLinting = {
+  options: {
+    typeAware: true,
+    typeCheck: true,
+  },
+};
+
 /** @type {import("oxlint").OxlintConfig} */
 const baseBrowserConfig = {
+  ...typedLinting,
   plugins: basePlugins,
   env: browserEnv,
   categories,
@@ -36,6 +45,7 @@ const baseBrowserConfig = {
 
 /** @type {import("oxlint").OxlintConfig} */
 const baseNodeConfig = {
+  ...typedLinting,
   plugins: basePlugins,
   env: nodeEnv,
   categories,

--- a/packages/oxlint-config/test/generated/cjs-final-config.json
+++ b/packages/oxlint-config/test/generated/cjs-final-config.json
@@ -10,6 +10,10 @@
   },
   "globals": {},
   "ignorePatterns": [],
+  "options": {
+    "typeAware": true,
+    "typeCheck": true
+  },
   "overrides": [
     {
       "env": {

--- a/packages/oxlint-config/test/generated/esbrowser-final-config.json
+++ b/packages/oxlint-config/test/generated/esbrowser-final-config.json
@@ -9,6 +9,10 @@
   },
   "globals": {},
   "ignorePatterns": [],
+  "options": {
+    "typeAware": true,
+    "typeCheck": true
+  },
   "overrides": [
     {
       "env": {

--- a/packages/oxlint-config/test/generated/esm-final-config.json
+++ b/packages/oxlint-config/test/generated/esm-final-config.json
@@ -9,6 +9,10 @@
   },
   "globals": {},
   "ignorePatterns": [],
+  "options": {
+    "typeAware": true,
+    "typeCheck": true
+  },
   "overrides": [
     {
       "env": {

--- a/packages/oxlint-config/test/generated/react-final-config.json
+++ b/packages/oxlint-config/test/generated/react-final-config.json
@@ -9,6 +9,10 @@
   },
   "globals": {},
   "ignorePatterns": [],
+  "options": {
+    "typeAware": true,
+    "typeCheck": true
+  },
   "overrides": [
     {
       "env": {

--- a/packages/oxlint-config/test/generated/recommended-final-config.json
+++ b/packages/oxlint-config/test/generated/recommended-final-config.json
@@ -9,6 +9,10 @@
   },
   "globals": {},
   "ignorePatterns": [],
+  "options": {
+    "typeAware": true,
+    "typeCheck": true
+  },
   "overrides": [
     {
       "env": {

--- a/packages/oxlint-config/test/generated/vitest-final-config.json
+++ b/packages/oxlint-config/test/generated/vitest-final-config.json
@@ -10,6 +10,10 @@
   },
   "globals": {},
   "ignorePatterns": [],
+  "options": {
+    "typeAware": true,
+    "typeCheck": true
+  },
   "overrides": [
     {
       "env": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,7 +104,10 @@ importers:
     devDependencies:
       oxlint:
         specifier: ^1.61.0
-        version: 1.61.0
+        version: 1.61.0(oxlint-tsgolint@0.22.1)
+      oxlint-tsgolint:
+        specifier: ^0.22.1
+        version: 0.22.1
 
   packages/prettier-config:
     dependencies:
@@ -574,6 +577,36 @@ packages:
   '@oxfmt/binding-win32-x64-msvc@0.46.0':
     resolution: {integrity: sha512-IXxiQpkYnOwNfP23vzwSfhdpxJzyiPTY7eTn6dn3DsriKddESzM8i6kfq9R7CD/PUJwCvQT22NgtygBeug3KoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint-tsgolint/darwin-arm64@0.22.1':
+    resolution: {integrity: sha512-4150Lpgc1YM09GcjA6GSrra1JoPjC7aOpfywLjWEY4vW0Sd1qKzqHF1WRaiw0/qUZ40OATYdv3aRd7ipPkWQbw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@0.22.1':
+    resolution: {integrity: sha512-vFWcPWYOgZs4HWcgS1EjUZg33NLcNfEYU49KGImmCfZWkflENrmBYV4HN/C0YeAPum6ZZ/goPSvQrB/cOD+NfA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@0.22.1':
+    resolution: {integrity: sha512-6LiUpP0Zir3+29FvBm7Y28q/dBjSHqTZ5MhG1Ckw4fGhI4cAvbcwXaKvbjx1TP7rRmBNOoq/M5xdpHjTb+GAew==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@0.22.1':
+    resolution: {integrity: sha512-fuX1hEQfpHauUbXADsfqVhRzrUrGabzGXbj5wsp2vKhV5uk/Rze8Mba9GdjFGECzvXudMGqHqxB4r6jGRdhxVA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@0.22.1':
+    resolution: {integrity: sha512-8SZidAj+jrbZf9ZjBEYW0tiNZ+KasqB2zgW26qdiPpQSF/DzURnPmXz651IeA9YsmbVdHGIooEHUmev6QJdquA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@0.22.1':
+    resolution: {integrity: sha512-QweSk9H5lFh5Y+WUf2Kq/OAN88V6+62ZwGhP38gqdRotI90luXSMkruFTj7Q2rYrzH4ZVNaSqx7NY8JpSfIzqg==}
     cpu: [x64]
     os: [win32]
 
@@ -1919,6 +1952,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  oxlint-tsgolint@0.22.1:
+    resolution: {integrity: sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg==}
+    hasBin: true
+
   oxlint@1.61.0:
     resolution: {integrity: sha512-ZC0ALuhDZ6ivOFG+sy0D0pEDN49EvsId98zVlmYdkcXHsEM14m/qTNUEsUpiFiCVbpIxYtVBmmLE87nsbUHohQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2881,6 +2918,24 @@ snapshots:
     optional: true
 
   '@oxfmt/binding-win32-x64-msvc@0.46.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-arm64@0.22.1':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@0.22.1':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@0.22.1':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@0.22.1':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@0.22.1':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@0.22.1':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.61.0':
@@ -4247,7 +4302,16 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.46.0
       '@oxfmt/binding-win32-x64-msvc': 0.46.0
 
-  oxlint@1.61.0:
+  oxlint-tsgolint@0.22.1:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 0.22.1
+      '@oxlint-tsgolint/darwin-x64': 0.22.1
+      '@oxlint-tsgolint/linux-arm64': 0.22.1
+      '@oxlint-tsgolint/linux-x64': 0.22.1
+      '@oxlint-tsgolint/win32-arm64': 0.22.1
+      '@oxlint-tsgolint/win32-x64': 0.22.1
+
+  oxlint@1.61.0(oxlint-tsgolint@0.22.1):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.61.0
       '@oxlint/binding-android-arm64': 1.61.0
@@ -4268,6 +4332,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.61.0
       '@oxlint/binding-win32-ia32-msvc': 1.61.0
       '@oxlint/binding-win32-x64-msvc': 1.61.0
+      oxlint-tsgolint: 0.22.1
 
   p-filter@2.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

- enable `options.typeAware: true` and `options.typeCheck: true` in the shared `@qlik/oxlint-config` base presets
- add `oxlint-tsgolint` as both a local dev dependency and a published peer requirement for `@qlik/oxlint-config`
- document the typed defaults and explain that the shared presets now enable typed oxlint by default
- tighten the migration guide and prompt so they recommend compact configs built around `extends`
- clarify migration handling for legacy `eslint-disable` directives now that oxlint supports them directly
- update the generated resolved-config snapshots to reflect the new typed defaults

## Notes

- the migration guidance now recommends keeping project configs as small as technically possible: mostly `extends`, `ignorePatterns`, and a few narrow overrides
- the prompt now tells migrations to keep existing `eslint-disable` directives when there are many of them, and only convert to `oxlint-disable` during the initial migration when the remaining count is small enough to be worth the cleanup
- the resolved oxlint snapshot diff only adds the new `options` block; the explicit shared rule surface stays stable
- the rule-coverage docs call out that typed oxlint is intended to stay close to the current `@qlik/eslint-config` TypeScript profile rather than expanding into an unrelated rule surface

## Validation

- `pnpm lint`
- `pnpm check-types`
- `pnpm test`
- `pnpm format:check`
