### PR TITLE
feat: add jest config, fix scoping for test rules

### DIFF
--- a/.changeset/nervous-pants-run.md
+++ b/.changeset/nervous-pants-run.md
@@ -1,0 +1,5 @@
+---
+"@qlik/oxlint-config": patch
+---
+
+fix: scope oxlint vitest rules to test files

--- a/.changeset/nervous-pants-run.md
+++ b/.changeset/nervous-pants-run.md
@@ -1,5 +1,5 @@
 ---
-"@qlik/oxlint-config": patch
+"@qlik/oxlint-config": minor
 ---
 
-fix: scope oxlint vitest rules to test files
+feat: add jest config, fix scoping for test rules

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -33,6 +33,7 @@ The same presets are also available under `qlik.configs` for parity with `@qlik/
 | `esbrowser`   | Explicit browser ESM projects; currently equivalent to `recommended`        |
 | `esm`         | Node.js ESM projects and tooling                                            |
 | `cjs`         | Node.js CommonJS projects and tooling                                       |
+| `jest`        | Jest test files or test-focused lint runs                                   |
 | `react`       | React projects using oxlint's native React rules                            |
 | `vitest`      | Vitest test files or test-focused lint runs                                 |
 
@@ -57,7 +58,7 @@ export default defineConfig({
 
 - Prefer native oxlint rules and built-in oxlint plugins.
 - Do not use JS plugins in the shared config. Add project-local JS plugins only for gaps that are genuinely important to that project.
-- Preserve oxlint's default native plugin set (`unicorn`, `typescript`, `oxc`) when enabling `import`, `react`, or `vitest`.
+- Preserve oxlint's default native plugin set (`unicorn`, `typescript`, `oxc`) when enabling `import`, `jest`, `react`, or `vitest`.
 - Use oxlint categories for broad bug-finding intent, then list only rules that differ from defaults or represent explicit Qlik policy.
 - Prefer modern code rules over legacy compatibility rules.
 - Keep CommonJS support scoped to CommonJS files and Node-focused presets.
@@ -191,7 +192,7 @@ With `typeAware` and `typeCheck` enabled, the shared presets intentionally stay 
 | ESLint behavior                                      | oxlint decision                                                                                                                                                                                                                                                                                                  |
 | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `eslint-plugin-jsx-a11y`                             | Removed from the current ESLint config, so it is not included here. Add project-local a11y rules only when needed.                                                                                                                                                                                               |
-| `eslint-plugin-jest`                                 | Removed. Vitest is the shared test target.                                                                                                                                                                                                                                                                       |
+| `eslint-plugin-jest`                                 | Use the shared `jest` preset for Jest repos. The `vitest` preset keeps Vitest rules explicit so Jest rules do not leak in through native plugin defaults.                                                                                                                                                        |
 | `camelcase` / `@typescript-eslint/naming-convention` | No native oxlint equivalent. Prefer TypeScript API design and code review over a heavy naming rule.                                                                                                                                                                                                              |
 | `@typescript-eslint/method-signature-style`          | No native oxlint equivalent. Not worth a JS plugin by default.                                                                                                                                                                                                                                                   |
 | `no-restricted-properties`                           | No native oxlint equivalent. Use project-specific rules only for concrete migration hazards.                                                                                                                                                                                                                     |

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -88,6 +88,7 @@ Follow these steps carefully and explain changes where non-trivial:
    - eslint.config.js/ts or legacy .eslintrc files
    - package.json scripts and dependencies
    - ignore files and inline eslint-disable comments
+   - test runner split by file group, such as Vitest vs Jest, plus any test-only plugins
    - project-specific rules, plugins, resolvers, parser options, and overrides
 
 2. Classify the existing rules:
@@ -111,6 +112,8 @@ Follow these steps carefully and explain changes where non-trivial:
    - keep the config as small as technically possible: usually `extends`, `ignorePatterns`, and a few targeted overrides are enough
    - keep the shared preset defaults for `options: { typeAware: true, typeCheck: true }` unless there is a deliberate repo-specific reason to relax them
    - add root `ignorePatterns` for repo-wide exclusions such as `node_modules/**`, `dist/**`, `coverage/**`, and `build/**` when applicable
+   - for native test-runner coverage, prefer the shared `qlik.vitest` or `qlik.jest` preset in a file-scoped override instead of recreating those rules by hand
+   - do not rely on `env` alone for Jest or Vitest migrations; `env` enables globals, but the native test rules should come from the shared preset or from explicit rules
    - use project-local `jsPlugins` or override-level `jsPlugins` for plugin gaps such as `eslint-plugin-testing-library`
    - if a JS plugin has no Oxlint preset, either handwrite the rules you want or import/spread the plugin's recommended/default rules into the override `rules`
    - keep overrides small and tied to real file groups
@@ -132,6 +135,7 @@ Follow these steps carefully and explain changes where non-trivial:
    - avoid runtime behavior changes unless explicitly required and reviewed
 
 7. Decide whether ESLint still needs to run:
+   - prefer the shared `qlik.vitest` or `qlik.jest` preset for native test-runner coverage before reaching for JS plugins for test-only gaps
    - prefer `jsPlugins` for high-value gaps before keeping ESLint, including `eslint-plugin-testing-library`
    - keep ESLint temporarily only for plugins that still do not run correctly in Oxlint, depend on unsupported APIs, require custom file formats, or rely on type-aware plugin behavior that Oxlint still cannot cover even with `typeAware` and `typeCheck` enabled
    - document why each remaining ESLint rule/plugin is still needed

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -20,7 +20,7 @@
     "check-types": "tsc --noEmit",
     "format:check": "oxfmt --check .",
     "format:write": "oxfmt .",
-    "test": "./test/verify-configs.sh",
+    "test": "vitest run && ./test/verify-configs.sh",
     "test:update": "./test/update-configs.sh"
   },
   "dependencies": {

--- a/packages/oxlint-config/src/configs/jest.js
+++ b/packages/oxlint-config/src/configs/jest.js
@@ -1,28 +1,28 @@
 // @ts-check
+import jestRules from "./shared/default-rules/jest.js";
 import testRules from "./shared/default-rules/test.js";
-import vitestRules from "./shared/default-rules/vitest.js";
 import { baseBrowserConfig, commonjsOverride } from "./shared/base.js";
-import { vitestPlugins } from "./shared/plugins.js";
+import { jestPlugins } from "./shared/plugins.js";
 import testFiles from "./shared/test-files.js";
 
 /** @type {NonNullable<import("oxlint").OxlintConfig["overrides"]>[number]} */
-const vitestOverride = {
+const jestOverride = {
   files: testFiles,
-  plugins: vitestPlugins,
+  plugins: jestPlugins,
   env: {
     ...baseBrowserConfig.env,
-    vitest: true,
+    jest: true,
   },
   rules: {
     ...testRules,
-    ...vitestRules,
+    ...jestRules,
   },
 };
 
 /** @type {import("oxlint").OxlintConfig} */
-const vitest = {
+const jest = {
   ...baseBrowserConfig,
-  overrides: [commonjsOverride, vitestOverride],
+  overrides: [commonjsOverride, jestOverride],
 };
 
-export default vitest;
+export default jest;

--- a/packages/oxlint-config/src/configs/shared/default-rules/jest.js
+++ b/packages/oxlint-config/src/configs/shared/default-rules/jest.js
@@ -1,0 +1,20 @@
+// @ts-check
+
+/** @type {import("oxlint").OxlintConfig["rules"]} */
+const rules = {
+  "jest/expect-expect": "error",
+  "jest/no-commented-out-tests": "error",
+  "jest/no-conditional-expect": "error",
+  "jest/no-disabled-tests": "error",
+  "jest/no-export": "error",
+  "jest/no-focused-tests": "error",
+  "jest/no-standalone-expect": "error",
+  "jest/prefer-snapshot-hint": "error",
+  "jest/require-to-throw-message": "error",
+  "jest/valid-describe-callback": "error",
+  "jest/valid-expect": "error",
+  "jest/valid-expect-in-promise": "error",
+  "jest/valid-title": "error",
+};
+
+export default rules;

--- a/packages/oxlint-config/src/configs/shared/default-rules/test.js
+++ b/packages/oxlint-config/src/configs/shared/default-rules/test.js
@@ -2,7 +2,6 @@
 
 /** @type {import("oxlint").OxlintConfig["rules"]} */
 const rules = {
-  "no-console": "off",
   "typescript/no-explicit-any": "warn",
   "typescript/no-non-null-assertion": "off",
   "typescript/no-unsafe-argument": "off",

--- a/packages/oxlint-config/src/configs/shared/default-rules/test.js
+++ b/packages/oxlint-config/src/configs/shared/default-rules/test.js
@@ -1,0 +1,16 @@
+// @ts-check
+
+/** @type {import("oxlint").OxlintConfig["rules"]} */
+const rules = {
+  "no-console": "off",
+  "typescript/no-explicit-any": "warn",
+  "typescript/no-non-null-assertion": "off",
+  "typescript/no-unsafe-argument": "off",
+  "typescript/no-unsafe-assignment": "off",
+  "typescript/no-unsafe-call": "off",
+  "typescript/no-unsafe-member-access": "off",
+  "typescript/no-unsafe-return": "off",
+  "typescript/unbound-method": "off",
+};
+
+export default rules;

--- a/packages/oxlint-config/src/configs/shared/default-rules/vitest.js
+++ b/packages/oxlint-config/src/configs/shared/default-rules/vitest.js
@@ -1,0 +1,21 @@
+// @ts-check
+
+/** @type {import("oxlint").OxlintConfig["rules"]} */
+const rules = {
+  "vitest/consistent-each-for": "error",
+  "vitest/expect-expect": "error",
+  "vitest/hoisted-apis-on-top": "error",
+  "vitest/no-commented-out-tests": "error",
+  "vitest/no-conditional-expect": "error",
+  "vitest/no-conditional-tests": "error",
+  "vitest/no-disabled-tests": "error",
+  "vitest/no-focused-tests": "error",
+  "vitest/require-awaited-expect-poll": "error",
+  "vitest/require-local-test-context-for-concurrent-snapshots": "error",
+  "vitest/require-mock-type-parameters": "off",
+  "vitest/valid-expect": "error",
+  "vitest/valid-title": "error",
+  "vitest/warn-todo": "error",
+};
+
+export default rules;

--- a/packages/oxlint-config/src/configs/shared/plugins.js
+++ b/packages/oxlint-config/src/configs/shared/plugins.js
@@ -5,6 +5,9 @@ const basePlugins = ["unicorn", "typescript", "oxc", "import"];
 const reactPlugins = [...basePlugins, "react"];
 
 /** @type {NonNullable<import("oxlint").OxlintConfig["plugins"]>} */
+const jestPlugins = [...basePlugins, "jest"];
+
+/** @type {NonNullable<import("oxlint").OxlintConfig["plugins"]>} */
 const vitestPlugins = [...basePlugins, "vitest"];
 
-export { basePlugins, reactPlugins, vitestPlugins };
+export { basePlugins, reactPlugins, jestPlugins, vitestPlugins };

--- a/packages/oxlint-config/src/configs/shared/test-files.js
+++ b/packages/oxlint-config/src/configs/shared/test-files.js
@@ -1,0 +1,9 @@
+// @ts-check
+
+const testFiles = [
+  "**/__test{,s}__/**/*.{js,jsx,ts,tsx}",
+  "**/{test{,s},mock{,s}}/**/*.{js,jsx,ts,tsx}",
+  "**/*.{test,spec}.{js,jsx,ts,tsx}",
+];
+
+export default testFiles;

--- a/packages/oxlint-config/src/configs/vitest.js
+++ b/packages/oxlint-config/src/configs/vitest.js
@@ -8,16 +8,15 @@ const testFiles = [
   "**/*.{test,spec}.{js,jsx,ts,tsx}",
 ];
 
-/** @type {import("oxlint").OxlintConfig} */
-const vitest = {
-  ...baseBrowserConfig,
+/** @type {NonNullable<import("oxlint").OxlintConfig["overrides"]>[number]} */
+const vitestOverride = {
+  files: testFiles,
   plugins: vitestPlugins,
   env: {
     ...baseBrowserConfig.env,
     vitest: true,
   },
   rules: {
-    ...baseBrowserConfig.rules,
     "no-console": "off",
     "typescript/no-explicit-any": "warn",
     "typescript/no-non-null-assertion": "off",
@@ -29,15 +28,12 @@ const vitest = {
     "typescript/unbound-method": "off",
     "vitest/require-mock-type-parameters": "off",
   },
-  overrides: [
-    commonjsOverride,
-    {
-      files: testFiles,
-      env: {
-        vitest: true,
-      },
-    },
-  ],
+};
+
+/** @type {import("oxlint").OxlintConfig} */
+const vitest = {
+  ...baseBrowserConfig,
+  overrides: [commonjsOverride, vitestOverride],
 };
 
 export default vitest;

--- a/packages/oxlint-config/src/index.d.ts
+++ b/packages/oxlint-config/src/index.d.ts
@@ -4,6 +4,7 @@ type Configs = {
   cjs: OxlintConfig;
   esbrowser: OxlintConfig;
   esm: OxlintConfig;
+  jest: OxlintConfig;
   react: OxlintConfig;
   recommended: OxlintConfig;
   vitest: OxlintConfig;
@@ -17,6 +18,7 @@ export default qlikOxlintConfig;
 export const cjs: OxlintConfig;
 export const esbrowser: OxlintConfig;
 export const esm: OxlintConfig;
+export const jest: OxlintConfig;
 export const react: OxlintConfig;
 export const recommended: OxlintConfig;
 export const vitest: OxlintConfig;

--- a/packages/oxlint-config/src/index.js
+++ b/packages/oxlint-config/src/index.js
@@ -2,6 +2,7 @@
 import cjs from "./configs/cjs.js";
 import esbrowser from "./configs/esbrowser.js";
 import esm from "./configs/esm.js";
+import jest from "./configs/jest.js";
 import react from "./configs/react.js";
 import recommended from "./configs/recommended.js";
 import vitest from "./configs/vitest.js";
@@ -10,21 +11,23 @@ const configs = {
   cjs,
   esbrowser,
   esm,
+  jest,
   react,
   recommended,
   vitest,
 };
 
-/** @type {{ configs: typeof configs, cjs: import("oxlint").OxlintConfig, esbrowser: import("oxlint").OxlintConfig, esm: import("oxlint").OxlintConfig, react: import("oxlint").OxlintConfig, recommended: import("oxlint").OxlintConfig, vitest: import("oxlint").OxlintConfig }} */
+/** @type {{ configs: typeof configs, cjs: import("oxlint").OxlintConfig, esbrowser: import("oxlint").OxlintConfig, esm: import("oxlint").OxlintConfig, jest: import("oxlint").OxlintConfig, react: import("oxlint").OxlintConfig, recommended: import("oxlint").OxlintConfig, vitest: import("oxlint").OxlintConfig }} */
 const qlikOxlintConfig = {
   configs,
   cjs,
   esbrowser,
   esm,
+  jest,
   react,
   recommended,
   vitest,
 };
 
 export default qlikOxlintConfig;
-export { cjs, esbrowser, esm, react, recommended, vitest };
+export { cjs, esbrowser, esm, jest, react, recommended, vitest };

--- a/packages/oxlint-config/test/extends.test.ts
+++ b/packages/oxlint-config/test/extends.test.ts
@@ -1,3 +1,4 @@
+import type { OxlintConfig } from "oxlint";
 import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -5,9 +6,18 @@ import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import qlik from "../src/index.js";
 
-const presetNames = ["recommended", "react", "vitest"] as const;
+const presetNames = ["recommended", "react", "jest", "vitest"] as const;
+const testFiles = [
+  "**/__test{,s}__/**/*.{js,jsx,ts,tsx}",
+  "**/{test{,s},mock{,s}}/**/*.{js,jsx,ts,tsx}",
+  "**/*.{test,spec}.{js,jsx,ts,tsx}",
+] as const;
 
 type PresetName = (typeof presetNames)[number];
+type TestOxlintConfig = Omit<OxlintConfig, "extends"> & {
+  extends?: string[];
+};
+
 type OxlintDiagnostic = {
   code: string;
   severity: string;
@@ -15,6 +25,29 @@ type OxlintDiagnostic = {
 
 type OxlintLintResult = {
   diagnostics: OxlintDiagnostic[];
+};
+
+const rootVitestPluginConfig: TestOxlintConfig = {
+  plugins: ["unicorn", "typescript", "oxc", "import", "vitest"],
+  env: {
+    browser: true,
+    builtin: true,
+    vitest: true,
+  },
+};
+
+const overrideVitestPluginConfig: TestOxlintConfig = {
+  overrides: [
+    {
+      files: [...testFiles],
+      plugins: ["unicorn", "typescript", "oxc", "import", "vitest"],
+      env: {
+        browser: true,
+        builtin: true,
+        vitest: true,
+      },
+    },
+  ],
 };
 
 const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
@@ -53,18 +86,18 @@ function getLintOutput(error: unknown): string {
   throw error;
 }
 
-async function lintFile(extendsPresets: PresetName[], filePath: string, contents: string): Promise<OxlintLintResult> {
+function getDiagnostics(result: OxlintLintResult): string[] {
+  return result.diagnostics.map((diagnostic) => `${diagnostic.code}:${diagnostic.severity}`);
+}
+
+async function lintWithConfig(config: TestOxlintConfig, filePath: string, contents: string): Promise<OxlintLintResult> {
   const runId = fileCounter++;
   const configFile = path.join(tempDir, `config-${runId}.json`);
   const targetFile = path.join(tempDir, filePath);
 
   await fs.mkdir(path.dirname(targetFile), { recursive: true });
   await fs.writeFile(targetFile, contents, "utf8");
-  await fs.writeFile(
-    configFile,
-    `${JSON.stringify({ extends: extendsPresets.map((preset) => presetPaths[preset]) }, null, 2)}\n`,
-    "utf8",
-  );
+  await fs.writeFile(configFile, `${JSON.stringify(config, null, 2)}\n`, "utf8");
 
   try {
     const lintOutput = execFileSync(oxlintBin, ["--config", configFile, "--format", "json", targetFile], {
@@ -79,33 +112,87 @@ async function lintFile(extendsPresets: PresetName[], filePath: string, contents
   }
 }
 
+async function lintWithPresets(
+  extendsPresets: PresetName[],
+  filePath: string,
+  contents: string,
+): Promise<OxlintLintResult> {
+  return lintWithConfig(
+    {
+      extends: extendsPresets.map((preset) => presetPaths[preset]),
+    },
+    filePath,
+    contents,
+  );
+}
+
 describe("preset extension resolution", () => {
+  it("only gets the native Vitest default rules when the plugin is enabled at the root", async () => {
+    const rootResult = await lintWithConfig(
+      rootVitestPluginConfig,
+      "src/plugin-root.test.ts",
+      'it.skip("skipped", () => {});\n',
+    );
+    const overrideResult = await lintWithConfig(
+      overrideVitestPluginConfig,
+      "src/plugin-override.test.ts",
+      'it.skip("skipped", () => {});\n',
+    );
+
+    expect(getDiagnostics(rootResult)).toContain("eslint-plugin-vitest(no-disabled-tests):warning");
+    expect(overrideResult.diagnostics).toHaveLength(0);
+  });
+
   it("keeps browser rules on non-test files when vitest is extended at the root", async () => {
-    const result = await lintFile(
+    const result = await lintWithPresets(
       ["recommended", "react", "vitest"],
       "src/component.tsx",
       "const value: any = 1;\nconsole.log(value);\n",
     );
-    const diagnostics = result.diagnostics.map((diagnostic) => `${diagnostic.code}:${diagnostic.severity}`);
+    const diagnostics = getDiagnostics(result);
 
     expect(diagnostics).toContain("eslint(no-console):warning");
     expect(diagnostics).toContain("typescript-eslint(no-explicit-any):error");
   });
 
   it("applies vitest-specific relaxations only to matching test files", async () => {
-    const result = await lintFile(
+    const result = await lintWithPresets(
       ["recommended", "react", "vitest"],
       "src/component.test.tsx",
       "const value: any = 1;\nconsole.log(value);\n",
     );
-    const diagnostics = result.diagnostics.map((diagnostic) => `${diagnostic.code}:${diagnostic.severity}`);
+    const diagnostics = getDiagnostics(result);
 
     expect(diagnostics).not.toContain("eslint(no-console):warning");
     expect(diagnostics).toContain("typescript-eslint(no-explicit-any):warning");
   });
 
+  it("keeps only Vitest plugin rules in the vitest preset", async () => {
+    const result = await lintWithPresets(
+      ["recommended", "react", "vitest"],
+      "src/vitest-only.test.ts",
+      'it.skip("skipped", () => {});\n',
+    );
+    const diagnostics = getDiagnostics(result);
+
+    expect(diagnostics).toContain("eslint-plugin-vitest(no-disabled-tests):error");
+    expect(diagnostics).not.toContain("eslint-plugin-jest(no-disabled-tests):error");
+  });
+
+  it("exposes Jest plugin rules through the jest preset", async () => {
+    const result = await lintWithPresets(
+      ["recommended", "react", "jest"],
+      "src/jest-only.test.ts",
+      'it.skip("skipped", () => {});\n',
+    );
+    const diagnostics = getDiagnostics(result);
+
+    expect(diagnostics).toContain("eslint-plugin-jest(no-disabled-tests):error");
+    expect(diagnostics).not.toContain("eslint-plugin-vitest(no-disabled-tests):error");
+  });
+
   it("still allows console usage in CommonJS files", async () => {
-    const result = await lintFile(["recommended", "react"], "eslint.config.cjs", 'console.log("x");\n');
+    const result = await lintWithPresets(["recommended", "react"], "eslint.config.cjs", 'console.log("x");\n');
 
     expect(result.diagnostics).toHaveLength(0);
   });

--- a/packages/oxlint-config/test/extends.test.ts
+++ b/packages/oxlint-config/test/extends.test.ts
@@ -163,7 +163,7 @@ describe("preset extension resolution", () => {
     );
     const diagnostics = getDiagnostics(result);
 
-    expect(diagnostics).not.toContain("eslint(no-console):warning");
+    expect(diagnostics).toContain("eslint(no-console):warning");
     expect(diagnostics).toContain("typescript-eslint(no-explicit-any):warning");
   });
 
@@ -183,10 +183,11 @@ describe("preset extension resolution", () => {
     const result = await lintWithPresets(
       ["recommended", "react", "jest"],
       "src/jest-only.test.ts",
-      'it.skip("skipped", () => {});\n',
+      'it.skip("skipped", () => {});\nconsole.log("still warn");\n',
     );
     const diagnostics = getDiagnostics(result);
 
+    expect(diagnostics).toContain("eslint(no-console):warning");
     expect(diagnostics).toContain("eslint-plugin-jest(no-disabled-tests):error");
     expect(diagnostics).not.toContain("eslint-plugin-vitest(no-disabled-tests):error");
   });

--- a/packages/oxlint-config/test/extends.test.ts
+++ b/packages/oxlint-config/test/extends.test.ts
@@ -17,8 +17,8 @@ type OxlintLintResult = {
   diagnostics: OxlintDiagnostic[];
 };
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const packageRoot = path.resolve(__dirname, "..");
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(currentDirectory, "..");
 const oxlintBin = path.resolve(packageRoot, "node_modules/.bin/oxlint");
 
 let tempDir: string;

--- a/packages/oxlint-config/test/extends.test.ts
+++ b/packages/oxlint-config/test/extends.test.ts
@@ -1,0 +1,112 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import qlik from "../src/index.js";
+
+const presetNames = ["recommended", "react", "vitest"] as const;
+
+type PresetName = (typeof presetNames)[number];
+type OxlintDiagnostic = {
+  code: string;
+  severity: string;
+};
+
+type OxlintLintResult = {
+  diagnostics: OxlintDiagnostic[];
+};
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(__dirname, "..");
+const oxlintBin = path.resolve(packageRoot, "node_modules/.bin/oxlint");
+
+let tempDir: string;
+let fileCounter = 0;
+let presetPaths: Record<PresetName, string>;
+
+beforeAll(async () => {
+  tempDir = await fs.mkdtemp(path.join(packageRoot, ".tmp-oxlint-config-"));
+
+  presetPaths = Object.fromEntries(
+    presetNames.map((preset) => [preset, path.join(tempDir, `${preset}.json`)]),
+  ) as Record<PresetName, string>;
+
+  await Promise.all(
+    presetNames.map((preset) => {
+      return fs.writeFile(presetPaths[preset], `${JSON.stringify(qlik[preset], null, 2)}\n`, "utf8");
+    }),
+  );
+});
+
+afterAll(async () => {
+  if (tempDir) {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+function getLintOutput(error: unknown): string {
+  if (typeof error === "object" && error !== null && "stdout" in error && typeof error.stdout === "string") {
+    return error.stdout;
+  }
+
+  throw error;
+}
+
+async function lintFile(extendsPresets: PresetName[], filePath: string, contents: string): Promise<OxlintLintResult> {
+  const runId = fileCounter++;
+  const configFile = path.join(tempDir, `config-${runId}.json`);
+  const targetFile = path.join(tempDir, filePath);
+
+  await fs.mkdir(path.dirname(targetFile), { recursive: true });
+  await fs.writeFile(targetFile, contents, "utf8");
+  await fs.writeFile(
+    configFile,
+    `${JSON.stringify({ extends: extendsPresets.map((preset) => presetPaths[preset]) }, null, 2)}\n`,
+    "utf8",
+  );
+
+  try {
+    const lintOutput = execFileSync(oxlintBin, ["--config", configFile, "--format", "json", targetFile], {
+      cwd: packageRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    return JSON.parse(lintOutput) as OxlintLintResult;
+  } catch (error) {
+    return JSON.parse(getLintOutput(error)) as OxlintLintResult;
+  }
+}
+
+describe("preset extension resolution", () => {
+  it("keeps browser rules on non-test files when vitest is extended at the root", async () => {
+    const result = await lintFile(
+      ["recommended", "react", "vitest"],
+      "src/component.tsx",
+      "const value: any = 1;\nconsole.log(value);\n",
+    );
+    const diagnostics = result.diagnostics.map((diagnostic) => `${diagnostic.code}:${diagnostic.severity}`);
+
+    expect(diagnostics).toContain("eslint(no-console):warning");
+    expect(diagnostics).toContain("typescript-eslint(no-explicit-any):error");
+  });
+
+  it("applies vitest-specific relaxations only to matching test files", async () => {
+    const result = await lintFile(
+      ["recommended", "react", "vitest"],
+      "src/component.test.tsx",
+      "const value: any = 1;\nconsole.log(value);\n",
+    );
+    const diagnostics = result.diagnostics.map((diagnostic) => `${diagnostic.code}:${diagnostic.severity}`);
+
+    expect(diagnostics).not.toContain("eslint(no-console):warning");
+    expect(diagnostics).toContain("typescript-eslint(no-explicit-any):warning");
+  });
+
+  it("still allows console usage in CommonJS files", async () => {
+    const result = await lintFile(["recommended", "react"], "eslint.config.cjs", 'console.log("x");\n');
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-config/test/generate-configs.js
+++ b/packages/oxlint-config/test/generate-configs.js
@@ -25,11 +25,12 @@ await fs.mkdir(generatedDir, { recursive: true });
  * Configs to snapshot.
  */
 const configs = qlik.configs;
+const testConfigNames = new Set(["jest", "vitest"]);
 
 await Promise.all(
   Object.entries(configs).map(async ([name, config]) => {
     const configFile = path.resolve(__dirname, `_print-config-${name}.mjs`);
-    const dummyExtension = name === "vitest" ? ".test.tsx" : ".js";
+    const dummyExtension = testConfigNames.has(name) ? ".test.tsx" : ".js";
     const dummyFile = path.resolve(__dirname, `_print-config-${name}-dummy${dummyExtension}`);
 
     await fs.writeFile(dummyFile, "");

--- a/packages/oxlint-config/test/generate-configs.js
+++ b/packages/oxlint-config/test/generate-configs.js
@@ -26,13 +26,13 @@ await fs.mkdir(generatedDir, { recursive: true });
  */
 const configs = qlik.configs;
 
-// Reusable dummy file for --print-config (just needs to exist)
-const dummyFile = path.resolve(__dirname, "_print-config-dummy.js");
-await fs.writeFile(dummyFile, "");
-
 await Promise.all(
   Object.entries(configs).map(async ([name, config]) => {
     const configFile = path.resolve(__dirname, `_print-config-${name}.mjs`);
+    const dummyExtension = name === "vitest" ? ".test.tsx" : ".js";
+    const dummyFile = path.resolve(__dirname, `_print-config-${name}-dummy${dummyExtension}`);
+
+    await fs.writeFile(dummyFile, "");
 
     await fs.writeFile(
       configFile,
@@ -55,6 +55,7 @@ await Promise.all(
       process.exitCode = 1;
       return;
     } finally {
+      await fs.rm(dummyFile, { force: true });
       await fs.rm(configFile, { force: true });
     }
 
@@ -68,9 +69,6 @@ await Promise.all(
     console.log(`  ✓  ${name} → test/generated/${name}-final-config.json`);
   }),
 );
-
-// Clean up the shared dummy file
-await fs.rm(dummyFile, { force: true });
 
 /**
  * Recursively sorts object keys for a stable representation.

--- a/packages/oxlint-config/test/generated/jest-final-config.json
+++ b/packages/oxlint-config/test/generated/jest-final-config.json
@@ -33,7 +33,7 @@
       "env": {
         "browser": true,
         "builtin": true,
-        "vitest": true
+        "jest": true
       },
       "files": [
         "**/__test{,s}__/**/*.{js,jsx,ts,tsx}",
@@ -46,9 +46,22 @@
         "typescript",
         "oxc",
         "import",
-        "vitest"
+        "jest"
       ],
       "rules": {
+        "jest/expect-expect": "deny",
+        "jest/no-commented-out-tests": "deny",
+        "jest/no-conditional-expect": "deny",
+        "jest/no-disabled-tests": "deny",
+        "jest/no-export": "deny",
+        "jest/no-focused-tests": "deny",
+        "jest/no-standalone-expect": "deny",
+        "jest/prefer-snapshot-hint": "deny",
+        "jest/require-to-throw-message": "deny",
+        "jest/valid-describe-callback": "deny",
+        "jest/valid-expect": "deny",
+        "jest/valid-expect-in-promise": "deny",
+        "jest/valid-title": "deny",
         "no-console": "allow",
         "typescript/no-explicit-any": "warn",
         "typescript/no-non-null-assertion": "allow",
@@ -57,21 +70,7 @@
         "typescript/no-unsafe-call": "allow",
         "typescript/no-unsafe-member-access": "allow",
         "typescript/no-unsafe-return": "allow",
-        "typescript/unbound-method": "allow",
-        "vitest/consistent-each-for": "deny",
-        "vitest/expect-expect": "deny",
-        "vitest/hoisted-apis-on-top": "deny",
-        "vitest/no-commented-out-tests": "deny",
-        "vitest/no-conditional-expect": "deny",
-        "vitest/no-conditional-tests": "deny",
-        "vitest/no-disabled-tests": "deny",
-        "vitest/no-focused-tests": "deny",
-        "vitest/require-awaited-expect-poll": "deny",
-        "vitest/require-local-test-context-for-concurrent-snapshots": "deny",
-        "vitest/require-mock-type-parameters": "allow",
-        "vitest/valid-expect": "deny",
-        "vitest/valid-title": "deny",
-        "vitest/warn-todo": "deny"
+        "typescript/unbound-method": "allow"
       }
     }
   ],

--- a/packages/oxlint-config/test/generated/jest-final-config.json
+++ b/packages/oxlint-config/test/generated/jest-final-config.json
@@ -62,7 +62,6 @@
         "jest/valid-expect": "deny",
         "jest/valid-expect-in-promise": "deny",
         "jest/valid-title": "deny",
-        "no-console": "allow",
         "typescript/no-explicit-any": "warn",
         "typescript/no-non-null-assertion": "allow",
         "typescript/no-unsafe-argument": "allow",

--- a/packages/oxlint-config/test/generated/vitest-final-config.json
+++ b/packages/oxlint-config/test/generated/vitest-final-config.json
@@ -49,7 +49,6 @@
         "vitest"
       ],
       "rules": {
-        "no-console": "allow",
         "typescript/no-explicit-any": "warn",
         "typescript/no-non-null-assertion": "allow",
         "typescript/no-unsafe-argument": "allow",

--- a/packages/oxlint-config/test/generated/vitest-final-config.json
+++ b/packages/oxlint-config/test/generated/vitest-final-config.json
@@ -5,8 +5,7 @@
   },
   "env": {
     "browser": true,
-    "builtin": true,
-    "vitest": true
+    "builtin": true
   },
   "globals": {},
   "ignorePatterns": [],
@@ -32,6 +31,8 @@
     },
     {
       "env": {
+        "browser": true,
+        "builtin": true,
         "vitest": true
       },
       "files": [
@@ -40,16 +41,32 @@
         "**/*.{test,spec}.{js,jsx,ts,tsx}"
       ],
       "globals": null,
-      "plugins": null,
-      "rules": {}
+      "plugins": [
+        "unicorn",
+        "typescript",
+        "oxc",
+        "import",
+        "vitest"
+      ],
+      "rules": {
+        "no-console": "allow",
+        "typescript/no-explicit-any": "warn",
+        "typescript/no-non-null-assertion": "allow",
+        "typescript/no-unsafe-argument": "allow",
+        "typescript/no-unsafe-assignment": "allow",
+        "typescript/no-unsafe-call": "allow",
+        "typescript/no-unsafe-member-access": "allow",
+        "typescript/no-unsafe-return": "allow",
+        "typescript/unbound-method": "allow",
+        "vitest/require-mock-type-parameters": "allow"
+      }
     }
   ],
   "plugins": [
     "unicorn",
     "typescript",
     "oxc",
-    "import",
-    "vitest"
+    "import"
   ],
   "rules": {
     "array-callback-return": [
@@ -122,19 +139,6 @@
     "import/no-self-import": "deny",
     "import/no-unassigned-import": "deny",
     "import/no-webpack-loader-syntax": "deny",
-    "jest/expect-expect": "deny",
-    "jest/no-commented-out-tests": "deny",
-    "jest/no-conditional-expect": "deny",
-    "jest/no-disabled-tests": "deny",
-    "jest/no-export": "deny",
-    "jest/no-focused-tests": "deny",
-    "jest/no-standalone-expect": "deny",
-    "jest/prefer-snapshot-hint": "deny",
-    "jest/require-to-throw-message": "deny",
-    "jest/valid-describe-callback": "deny",
-    "jest/valid-expect": "deny",
-    "jest/valid-expect-in-promise": "deny",
-    "jest/valid-title": "deny",
     "new-cap": [
       "deny",
       [
@@ -158,7 +162,7 @@
     "no-class-assign": "deny",
     "no-compare-neg-zero": "deny",
     "no-cond-assign": "deny",
-    "no-console": "allow",
+    "no-console": "warn",
     "no-const-assign": "deny",
     "no-constant-binary-expression": "deny",
     "no-constant-condition": "deny",
@@ -597,7 +601,7 @@
     "typescript/no-duplicate-type-constituents": "deny",
     "typescript/no-dynamic-delete": "deny",
     "typescript/no-empty-object-type": "deny",
-    "typescript/no-explicit-any": "warn",
+    "typescript/no-explicit-any": "deny",
     "typescript/no-extra-non-null-assertion": "deny",
     "typescript/no-extraneous-class": "deny",
     "typescript/no-floating-promises": "deny",
@@ -619,7 +623,7 @@
     "typescript/no-mixed-enums": "deny",
     "typescript/no-non-null-asserted-nullish-coalescing": "deny",
     "typescript/no-non-null-asserted-optional-chain": "deny",
-    "typescript/no-non-null-assertion": "allow",
+    "typescript/no-non-null-assertion": "deny",
     "typescript/no-redundant-type-constituents": "deny",
     "typescript/no-this-alias": "deny",
     "typescript/no-unnecessary-boolean-literal-compare": "deny",
@@ -632,13 +636,13 @@
     "typescript/no-unnecessary-type-constraint": "deny",
     "typescript/no-unnecessary-type-conversion": "deny",
     "typescript/no-unnecessary-type-parameters": "deny",
-    "typescript/no-unsafe-argument": "allow",
-    "typescript/no-unsafe-assignment": "allow",
-    "typescript/no-unsafe-call": "allow",
+    "typescript/no-unsafe-argument": "deny",
+    "typescript/no-unsafe-assignment": "deny",
+    "typescript/no-unsafe-call": "deny",
     "typescript/no-unsafe-declaration-merging": "deny",
     "typescript/no-unsafe-enum-comparison": "deny",
-    "typescript/no-unsafe-member-access": "allow",
-    "typescript/no-unsafe-return": "allow",
+    "typescript/no-unsafe-member-access": "deny",
+    "typescript/no-unsafe-return": "deny",
     "typescript/no-unsafe-type-assertion": "allow",
     "typescript/no-unsafe-unary-minus": "deny",
     "typescript/no-useless-default-assignment": "deny",
@@ -662,7 +666,7 @@
     "typescript/restrict-template-expressions": "deny",
     "typescript/switch-exhaustiveness-check": "deny",
     "typescript/triple-slash-reference": "deny",
-    "typescript/unbound-method": "allow",
+    "typescript/unbound-method": "deny",
     "typescript/unified-signatures": "deny",
     "typescript/use-unknown-in-catch-callback-variable": "deny",
     "unicode-bom": [
@@ -694,20 +698,6 @@
     "unicorn/require-post-message-target-origin": "deny",
     "use-isnan": "deny",
     "valid-typeof": "deny",
-    "vitest/consistent-each-for": "deny",
-    "vitest/expect-expect": "deny",
-    "vitest/hoisted-apis-on-top": "deny",
-    "vitest/no-commented-out-tests": "deny",
-    "vitest/no-conditional-expect": "deny",
-    "vitest/no-conditional-tests": "deny",
-    "vitest/no-disabled-tests": "deny",
-    "vitest/no-focused-tests": "deny",
-    "vitest/require-awaited-expect-poll": "deny",
-    "vitest/require-local-test-context-for-concurrent-snapshots": "deny",
-    "vitest/require-mock-type-parameters": "allow",
-    "vitest/valid-expect": "deny",
-    "vitest/valid-title": "deny",
-    "vitest/warn-todo": "deny",
     "yoda": "deny"
   },
   "settings": {


### PR DESCRIPTION
## Summary
- restore the missing native Vitest test-plugin rules after moving test behavior into file-scoped overrides
- add a dedicated `jest` preset so Jest rules are exposed explicitly instead of leaking through the Vitest plugin defaults
- add typed regression coverage proving that native test-plugin defaults appear when the plugin is enabled at the root, but are lost when the plugin only lives inside an override
- refresh the generated `jest` and `vitest` Oxlint snapshots to match the new preset behavior

## Validation
- `pnpm exec vitest run test/extends.test.ts`
- `pnpm lint`
- `pnpm check-types`
- `pnpm test`