### PR TITLE
fix(oxlint-config): apply jest and vitest presets correctly when extending configs

### DIFF
--- a/.changeset/puny-trains-notice.md
+++ b/.changeset/puny-trains-notice.md
@@ -1,0 +1,5 @@
+---
+"@qlik/oxlint-config": patch
+---
+
+fix: apply jest and vitest presets correctly when extending configs

--- a/.github/prompts/migrate-to-oxlint.prompt.md
+++ b/.github/prompts/migrate-to-oxlint.prompt.md
@@ -36,6 +36,10 @@ Follow these steps carefully and explain changes where non-trivial:
    - keep the config as small as technically possible: usually `extends`, `ignorePatterns`, and a few targeted overrides are enough
    - keep the shared preset defaults for `options: { typeAware: true, typeCheck: true }` unless there is a deliberate repo-specific reason to relax them
    - add root `ignorePatterns` for repo-wide exclusions such as `node_modules/**`, `dist/**`, `coverage/**`, and `build/**` when applicable
+   - for native test-runner coverage, prefer adding the shared `qlik.vitest` or `qlik.jest` preset to the root `extends` array; those presets already scope their test-only behavior internally
+   - do not unpack `qlik.vitest` or `qlik.jest` into copied `env`, `plugins`, or `rules` inside a repo-local override; keep repo-specific test overrides additive
+   - `oxlint` does not support `overrides[].extends`, so compose shared test presets at the root instead of trying to nest them
+   - do not rely on `env` alone for Jest or Vitest migrations; `env` enables globals, but the native test rules should come from the shared preset or from explicit rules
    - use project-local `jsPlugins` or override-level `jsPlugins` for plugin gaps such as `eslint-plugin-testing-library`
    - if a JS plugin has no Oxlint preset, either handwrite the rules you want or import/spread the plugin's recommended/default rules into the override `rules`
    - keep overrides small and tied to real file groups
@@ -57,6 +61,7 @@ Follow these steps carefully and explain changes where non-trivial:
    - avoid runtime behavior changes unless explicitly required and reviewed
 
 7. Decide whether ESLint still needs to run:
+   - prefer the shared `qlik.vitest` or `qlik.jest` preset at the root for native test-runner coverage before reaching for JS plugins for test-only gaps
    - prefer `jsPlugins` for high-value gaps before keeping ESLint, including `eslint-plugin-testing-library`
    - keep ESLint temporarily only for plugins that still do not run correctly in Oxlint, depend on unsupported APIs, require custom file formats, or rely on type-aware plugin behavior that Oxlint still cannot cover even with `typeAware` and `typeCheck` enabled
    - document why each remaining ESLint rule/plugin is still needed

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -108,7 +108,9 @@ Follow these steps carefully and explain changes where non-trivial:
    - keep the config as small as technically possible: usually `extends`, `ignorePatterns`, and a few targeted overrides are enough
    - keep the shared preset defaults for `options: { typeAware: true, typeCheck: true }` unless there is a deliberate repo-specific reason to relax them
    - add root `ignorePatterns` for repo-wide exclusions such as `node_modules/**`, `dist/**`, `coverage/**`, and `build/**` when applicable
-   - for native test-runner coverage, prefer the shared `qlik.vitest` or `qlik.jest` preset in a file-scoped override instead of recreating those rules by hand
+   - for native test-runner coverage, prefer adding the shared `qlik.vitest` or `qlik.jest` preset to the root `extends` array; those presets already scope their test-only behavior internally
+   - do not unpack `qlik.vitest` or `qlik.jest` into copied `env`, `plugins`, or `rules` inside a repo-local override; keep repo-specific test overrides additive
+   - `oxlint` does not support `overrides[].extends`, so compose shared test presets at the root instead of trying to nest them
    - do not rely on `env` alone for Jest or Vitest migrations; `env` enables globals, but the native test rules should come from the shared preset or from explicit rules
    - use project-local `jsPlugins` or override-level `jsPlugins` for plugin gaps such as `eslint-plugin-testing-library`
    - if a JS plugin has no Oxlint preset, either handwrite the rules you want or import/spread the plugin's recommended/default rules into the override `rules`
@@ -131,7 +133,7 @@ Follow these steps carefully and explain changes where non-trivial:
    - avoid runtime behavior changes unless explicitly required and reviewed
 
 7. Decide whether ESLint still needs to run:
-   - prefer the shared `qlik.vitest` or `qlik.jest` preset for native test-runner coverage before reaching for JS plugins for test-only gaps
+   - prefer the shared `qlik.vitest` or `qlik.jest` preset at the root for native test-runner coverage before reaching for JS plugins for test-only gaps
    - prefer `jsPlugins` for high-value gaps before keeping ESLint, including `eslint-plugin-testing-library`
    - keep ESLint temporarily only for plugins that still do not run correctly in Oxlint, depend on unsupported APIs, require custom file formats, or rely on type-aware plugin behavior that Oxlint still cannot cover even with `typeAware` and `typeCheck` enabled
    - document why each remaining ESLint rule/plugin is still needed

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -37,22 +37,18 @@ The same presets are also available under `qlik.configs` for parity with `@qlik/
 | `react`       | React projects using oxlint's native React rules                            |
 | `vitest`      | Vitest test files or test-focused lint runs                                 |
 
-Named exports are available when you want to attach a preset to a narrower file group via `extends`:
+Named exports are available when you prefer shorter imports, but the `jest` and `vitest` presets should still be added at the root. Those presets already scope their test-only behavior internally:
 
 ```ts
 import { recommended, vitest } from "@qlik/oxlint-config";
 import { defineConfig } from "oxlint";
 
 export default defineConfig({
-  extends: [recommended],
-  overrides: [
-    {
-      files: ["**/__test{,s}__/**/*", "**/*.{test,spec}.*"],
-      extends: [vitest],
-    },
-  ],
+  extends: [recommended, vitest],
 });
 ```
+
+Use project-local overrides only for extra repo-specific test rules. `oxlint` does not support `overrides[].extends`, so adding `jest` or `vitest` at the root is the supported way to compose these presets.
 
 ## Design Principles
 
@@ -208,6 +204,8 @@ With `typeAware` and `typeCheck` enabled, the shared presets intentionally stay 
 ## Development
 
 Snapshot files in [`packages/oxlint-config/test/generated/`](./test/generated) show the fully resolved rule set for each preset as printed by `oxlint --print-config`.
+
+`oxlint --rules` is also covered by the package tests so the `Enabled?` column stays aligned with the shared Jest and Vitest presets when they are added through a normal root `oxlint.config.ts` `extends` array.
 
 ```sh
 pnpm test

--- a/packages/oxlint-config/src/configs/jest.js
+++ b/packages/oxlint-config/src/configs/jest.js
@@ -1,28 +1,17 @@
 // @ts-check
 import jestRules from "./shared/default-rules/jest.js";
-import testRules from "./shared/default-rules/test.js";
 import { baseBrowserConfig, commonjsOverride } from "./shared/base.js";
 import { jestPlugins } from "./shared/plugins.js";
-import testFiles from "./shared/test-files.js";
-
-/** @type {NonNullable<import("oxlint").OxlintConfig["overrides"]>[number]} */
-const jestOverride = {
-  files: testFiles,
-  plugins: jestPlugins,
-  env: {
-    ...baseBrowserConfig.env,
-    jest: true,
-  },
-  rules: {
-    ...testRules,
-    ...jestRules,
-  },
-};
+import { createScopedTestRunnerPreset } from "./shared/test-preset.js";
 
 /** @type {import("oxlint").OxlintConfig} */
-const jest = {
-  ...baseBrowserConfig,
-  overrides: [commonjsOverride, jestOverride],
-};
+const jest = createScopedTestRunnerPreset({
+  baseConfig: baseBrowserConfig,
+  commonjsOverride,
+  plugins: jestPlugins,
+  rootRules: jestRules,
+  runnerRules: jestRules,
+  runnerEnvName: "jest",
+});
 
 export default jest;

--- a/packages/oxlint-config/src/configs/shared/default-rules/jest.js
+++ b/packages/oxlint-config/src/configs/shared/default-rules/jest.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-/** @type {import("oxlint").OxlintConfig["rules"]} */
+/** @type {NonNullable<import("oxlint").OxlintConfig["rules"]>} */
 const rules = {
   "jest/expect-expect": "error",
   "jest/no-commented-out-tests": "error",

--- a/packages/oxlint-config/src/configs/shared/default-rules/react.js
+++ b/packages/oxlint-config/src/configs/shared/default-rules/react.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-/** @type {import("oxlint").OxlintConfig["rules"]} */
+/** @type {NonNullable<import("oxlint").OxlintConfig["rules"]>} */
 const rules = {
   "react/exhaustive-deps": "warn",
   "react/jsx-no-comment-textnodes": "warn",

--- a/packages/oxlint-config/src/configs/shared/default-rules/recommended.js
+++ b/packages/oxlint-config/src/configs/shared/default-rules/recommended.js
@@ -10,7 +10,7 @@ const restrictedBrowserGlobals = [
   })),
 ];
 
-/** @type {import("oxlint").OxlintConfig["rules"]} */
+/** @type {NonNullable<import("oxlint").OxlintConfig["rules"]>} */
 const rules = {
   "array-callback-return": ["error", { allowImplicit: true }],
   eqeqeq: ["error", "always", { null: "ignore" }],

--- a/packages/oxlint-config/src/configs/shared/default-rules/test.js
+++ b/packages/oxlint-config/src/configs/shared/default-rules/test.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-/** @type {import("oxlint").OxlintConfig["rules"]} */
+/** @type {NonNullable<import("oxlint").OxlintConfig["rules"]>} */
 const rules = {
   "typescript/no-explicit-any": "warn",
   "typescript/no-non-null-assertion": "off",

--- a/packages/oxlint-config/src/configs/shared/default-rules/vitest.js
+++ b/packages/oxlint-config/src/configs/shared/default-rules/vitest.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-/** @type {import("oxlint").OxlintConfig["rules"]} */
+/** @type {NonNullable<import("oxlint").OxlintConfig["rules"]>} */
 const rules = {
   "vitest/consistent-each-for": "error",
   "vitest/expect-expect": "error",

--- a/packages/oxlint-config/src/configs/shared/test-preset.js
+++ b/packages/oxlint-config/src/configs/shared/test-preset.js
@@ -1,0 +1,66 @@
+// @ts-check
+import testRules from "./default-rules/test.js";
+import testFiles from "./test-files.js";
+
+/** @type {NonNullable<NonNullable<import("oxlint").OxlintConfig["overrides"]>[number]["files"]>} */
+const lintedCodeFiles = ["**/*.{js,jsx,ts,tsx,cjs,cts,mjs,mts}"];
+
+/**
+ * @param {import("oxlint").OxlintConfig["rules"]} rules
+ * @returns {NonNullable<import("oxlint").OxlintConfig["rules"]>}
+ */
+function disableRules(rules) {
+  return Object.fromEntries(Object.keys(rules ?? {}).map((rule) => [rule, "off"]));
+}
+
+/**
+ * Turns test-runner rules on at the root so `oxlint --rules` reports them as enabled,
+ * then turns them back off for non-test files.
+ *
+ * @param {{
+ *   baseConfig: import("oxlint").OxlintConfig,
+ *   commonjsOverride: NonNullable<import("oxlint").OxlintConfig["overrides"]>[number],
+ *   plugins: NonNullable<import("oxlint").OxlintConfig["plugins"]>,
+ *   rootRules: NonNullable<import("oxlint").OxlintConfig["rules"]>,
+ *   runnerRules: NonNullable<import("oxlint").OxlintConfig["rules"]>,
+ *   runnerEnvName: "jest" | "vitest",
+ * }} options
+ * @returns {import("oxlint").OxlintConfig}
+ */
+function createScopedTestRunnerPreset({
+  baseConfig,
+  commonjsOverride,
+  plugins,
+  rootRules,
+  runnerRules,
+  runnerEnvName,
+}) {
+  const resetOverride = {
+    files: lintedCodeFiles,
+    rules: disableRules(rootRules),
+  };
+
+  const runnerOverride = {
+    files: testFiles,
+    env: {
+      ...baseConfig.env,
+      [runnerEnvName]: true,
+    },
+    rules: {
+      ...testRules,
+      ...runnerRules,
+    },
+  };
+
+  return {
+    ...baseConfig,
+    plugins,
+    rules: {
+      ...baseConfig.rules,
+      ...rootRules,
+    },
+    overrides: [commonjsOverride, resetOverride, runnerOverride],
+  };
+}
+
+export { createScopedTestRunnerPreset };

--- a/packages/oxlint-config/src/configs/vitest.js
+++ b/packages/oxlint-config/src/configs/vitest.js
@@ -1,28 +1,29 @@
 // @ts-check
-import testRules from "./shared/default-rules/test.js";
+import jestRules from "./shared/default-rules/jest.js";
 import vitestRules from "./shared/default-rules/vitest.js";
 import { baseBrowserConfig, commonjsOverride } from "./shared/base.js";
 import { vitestPlugins } from "./shared/plugins.js";
-import testFiles from "./shared/test-files.js";
+import { createScopedTestRunnerPreset } from "./shared/test-preset.js";
 
-/** @type {NonNullable<import("oxlint").OxlintConfig["overrides"]>[number]} */
-const vitestOverride = {
-  files: testFiles,
-  plugins: vitestPlugins,
-  env: {
-    ...baseBrowserConfig.env,
-    vitest: true,
-  },
-  rules: {
-    ...testRules,
-    ...vitestRules,
-  },
-};
+/** @type {NonNullable<import("oxlint").OxlintConfig["rules"]>} */
+const conflictingJestRules = Object.fromEntries(
+  Object.keys(vitestRules)
+    .map((rule) => rule.replace(/^vitest\//u, ""))
+    .filter((ruleName) => `jest/${ruleName}` in jestRules)
+    .map((ruleName) => [`jest/${ruleName}`, "off"]),
+);
 
 /** @type {import("oxlint").OxlintConfig} */
-const vitest = {
-  ...baseBrowserConfig,
-  overrides: [commonjsOverride, vitestOverride],
-};
+const vitest = createScopedTestRunnerPreset({
+  baseConfig: baseBrowserConfig,
+  commonjsOverride,
+  plugins: vitestPlugins,
+  rootRules: vitestRules,
+  runnerRules: {
+    ...vitestRules,
+    ...conflictingJestRules,
+  },
+  runnerEnvName: "vitest",
+});
 
 export default vitest;

--- a/packages/oxlint-config/test/extends.test.ts
+++ b/packages/oxlint-config/test/extends.test.ts
@@ -97,7 +97,8 @@ function getRulesTableRows(output: string): string[] {
     }
 
     if (/^\s+\|/u.test(line) && rows.length > 0) {
-      return [...rows.slice(0, -1), `${rows.at(-1)}${line.trimStart()}`];
+      const previousRow = rows[rows.length - 1];
+      return [...rows.slice(0, -1), `${previousRow}${line.trimStart()}`];
     }
 
     return [...rows, line];

--- a/packages/oxlint-config/test/extends.test.ts
+++ b/packages/oxlint-config/test/extends.test.ts
@@ -90,6 +90,42 @@ function getDiagnostics(result: OxlintLintResult): string[] {
   return result.diagnostics.map((diagnostic) => `${diagnostic.code}:${diagnostic.severity}`);
 }
 
+function getRulesTableRows(output: string): string[] {
+  return output.split("\n").reduce<string[]>((rows, line) => {
+    if (!line.includes("|")) {
+      return rows;
+    }
+
+    if (/^\s+\|/u.test(line) && rows.length > 0) {
+      rows[rows.length - 1] += line.trimStart();
+      return rows;
+    }
+
+    rows.push(line);
+    return rows;
+  }, []);
+}
+
+function isRuleEnabled(output: string, ruleName: string, source: string): boolean {
+  const ruleRow = getRulesTableRows(output).find((candidate) => {
+    const cells = candidate
+      .split("|")
+      .slice(1, -1)
+      .map((cell) => cell.trim());
+    return cells[0] === ruleName && cells[1] === source;
+  });
+
+  if (!ruleRow) {
+    throw new Error(`Missing rule row for ${source}/${ruleName}`);
+  }
+
+  const cells = ruleRow
+    .split("|")
+    .slice(1, -1)
+    .map((cell) => cell.trim());
+  return cells[3] === "✅";
+}
+
 async function lintWithConfig(config: TestOxlintConfig, filePath: string, contents: string): Promise<OxlintLintResult> {
   const runId = fileCounter++;
   const configFile = path.join(tempDir, `config-${runId}.json`);
@@ -127,6 +163,32 @@ async function lintWithPresets(
 }
 
 describe("preset extension resolution", () => {
+  async function listRulesWithPresets(extendsPresets: PresetName[]): Promise<string> {
+    const runId = fileCounter++;
+    const configFile = path.join(tempDir, `rules-config-${runId}.ts`);
+    const extendsList = extendsPresets.map((preset) => `qlik.${preset}`).join(", ");
+    const configContents = [
+      'import qlik from "../src/index.js";',
+      'import { defineConfig } from "oxlint";',
+      "",
+      "export default defineConfig({",
+      `  extends: [${extendsList}],`,
+      "});",
+    ].join("\n");
+
+    await fs.writeFile(configFile, `${configContents}\n`, "utf8");
+
+    return execFileSync(oxlintBin, ["--rules", "--config", configFile], {
+      cwd: packageRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        COLUMNS: "220",
+        NO_COLOR: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  }
   it("only gets the native Vitest default rules when the plugin is enabled at the root", async () => {
     const rootResult = await lintWithConfig(
       rootVitestPluginConfig,
@@ -196,5 +258,24 @@ describe("preset extension resolution", () => {
     const result = await lintWithPresets(["recommended", "react"], "eslint.config.cjs", 'console.log("x");\n');
 
     expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    {
+      preset: "vitest" as const,
+      ruleName: "require-awaited-expect-poll",
+      source: "vitest",
+    },
+    {
+      preset: "jest" as const,
+      ruleName: "prefer-snapshot-hint",
+      source: "jest",
+    },
+  ])("marks $preset preset rules as enabled in oxlint --rules output", async ({ preset, ruleName, source }) => {
+    const withoutPresetRules = await listRulesWithPresets(["recommended", "react"]);
+    const withPresetRules = await listRulesWithPresets(["recommended", "react", preset]);
+
+    expect(isRuleEnabled(withoutPresetRules, ruleName, source)).toBe(false);
+    expect(isRuleEnabled(withPresetRules, ruleName, source)).toBe(true);
   });
 });

--- a/packages/oxlint-config/test/extends.test.ts
+++ b/packages/oxlint-config/test/extends.test.ts
@@ -125,6 +125,21 @@ function isRuleEnabled(output: string, ruleName: string, source: string): boolea
   return cells[3] === "✅";
 }
 
+function getStableRulesCommandEnv(): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {
+    ...process.env,
+    COLUMNS: "220",
+    NO_COLOR: "1",
+    TERM: "xterm-256color",
+  };
+
+  // `oxlint --rules` changes its captured output in CI mode, which hides the rows this test asserts on.
+  delete environment.CI;
+  delete environment.GITHUB_ACTIONS;
+
+  return environment;
+}
+
 async function lintWithConfig(config: TestOxlintConfig, filePath: string, contents: string): Promise<OxlintLintResult> {
   const runId = fileCounter++;
   const configFile = path.join(tempDir, `config-${runId}.json`);
@@ -180,11 +195,7 @@ describe("preset extension resolution", () => {
     return execFileSync(oxlintBin, ["--rules", "--config", configFile], {
       cwd: packageRoot,
       encoding: "utf8",
-      env: {
-        ...process.env,
-        COLUMNS: "220",
-        NO_COLOR: "1",
-      },
+      env: getStableRulesCommandEnv(),
       stdio: ["ignore", "pipe", "pipe"],
     });
   }

--- a/packages/oxlint-config/test/extends.test.ts
+++ b/packages/oxlint-config/test/extends.test.ts
@@ -97,12 +97,10 @@ function getRulesTableRows(output: string): string[] {
     }
 
     if (/^\s+\|/u.test(line) && rows.length > 0) {
-      rows[rows.length - 1] += line.trimStart();
-      return rows;
+      return [...rows.slice(0, -1), `${rows.at(-1)}${line.trimStart()}`];
     }
 
-    rows.push(line);
-    return rows;
+    return [...rows, line];
   }, []);
 }
 

--- a/packages/oxlint-config/test/generated/jest-final-config.json
+++ b/packages/oxlint-config/test/generated/jest-final-config.json
@@ -30,6 +30,29 @@
       }
     },
     {
+      "env": null,
+      "files": [
+        "**/*.{js,jsx,ts,tsx,cjs,cts,mjs,mts}"
+      ],
+      "globals": null,
+      "plugins": null,
+      "rules": {
+        "jest/expect-expect": "allow",
+        "jest/no-commented-out-tests": "allow",
+        "jest/no-conditional-expect": "allow",
+        "jest/no-disabled-tests": "allow",
+        "jest/no-export": "allow",
+        "jest/no-focused-tests": "allow",
+        "jest/no-standalone-expect": "allow",
+        "jest/prefer-snapshot-hint": "allow",
+        "jest/require-to-throw-message": "allow",
+        "jest/valid-describe-callback": "allow",
+        "jest/valid-expect": "allow",
+        "jest/valid-expect-in-promise": "allow",
+        "jest/valid-title": "allow"
+      }
+    },
+    {
       "env": {
         "browser": true,
         "builtin": true,
@@ -41,13 +64,7 @@
         "**/*.{test,spec}.{js,jsx,ts,tsx}"
       ],
       "globals": null,
-      "plugins": [
-        "unicorn",
-        "typescript",
-        "oxc",
-        "import",
-        "jest"
-      ],
+      "plugins": null,
       "rules": {
         "jest/expect-expect": "deny",
         "jest/no-commented-out-tests": "deny",
@@ -77,7 +94,8 @@
     "unicorn",
     "typescript",
     "oxc",
-    "import"
+    "import",
+    "jest"
   ],
   "rules": {
     "array-callback-return": [
@@ -150,6 +168,19 @@
     "import/no-self-import": "deny",
     "import/no-unassigned-import": "deny",
     "import/no-webpack-loader-syntax": "deny",
+    "jest/expect-expect": "deny",
+    "jest/no-commented-out-tests": "deny",
+    "jest/no-conditional-expect": "deny",
+    "jest/no-disabled-tests": "deny",
+    "jest/no-export": "deny",
+    "jest/no-focused-tests": "deny",
+    "jest/no-standalone-expect": "deny",
+    "jest/prefer-snapshot-hint": "deny",
+    "jest/require-to-throw-message": "deny",
+    "jest/valid-describe-callback": "deny",
+    "jest/valid-expect": "deny",
+    "jest/valid-expect-in-promise": "deny",
+    "jest/valid-title": "deny",
     "new-cap": [
       "deny",
       [

--- a/packages/oxlint-config/test/generated/vitest-final-config.json
+++ b/packages/oxlint-config/test/generated/vitest-final-config.json
@@ -30,6 +30,30 @@
       }
     },
     {
+      "env": null,
+      "files": [
+        "**/*.{js,jsx,ts,tsx,cjs,cts,mjs,mts}"
+      ],
+      "globals": null,
+      "plugins": null,
+      "rules": {
+        "vitest/consistent-each-for": "allow",
+        "vitest/expect-expect": "allow",
+        "vitest/hoisted-apis-on-top": "allow",
+        "vitest/no-commented-out-tests": "allow",
+        "vitest/no-conditional-expect": "allow",
+        "vitest/no-conditional-tests": "allow",
+        "vitest/no-disabled-tests": "allow",
+        "vitest/no-focused-tests": "allow",
+        "vitest/require-awaited-expect-poll": "allow",
+        "vitest/require-local-test-context-for-concurrent-snapshots": "allow",
+        "vitest/require-mock-type-parameters": "allow",
+        "vitest/valid-expect": "allow",
+        "vitest/valid-title": "allow",
+        "vitest/warn-todo": "allow"
+      }
+    },
+    {
       "env": {
         "browser": true,
         "builtin": true,
@@ -41,14 +65,15 @@
         "**/*.{test,spec}.{js,jsx,ts,tsx}"
       ],
       "globals": null,
-      "plugins": [
-        "unicorn",
-        "typescript",
-        "oxc",
-        "import",
-        "vitest"
-      ],
+      "plugins": null,
       "rules": {
+        "jest/expect-expect": "allow",
+        "jest/no-commented-out-tests": "allow",
+        "jest/no-conditional-expect": "allow",
+        "jest/no-disabled-tests": "allow",
+        "jest/no-focused-tests": "allow",
+        "jest/valid-expect": "allow",
+        "jest/valid-title": "allow",
         "typescript/no-explicit-any": "warn",
         "typescript/no-non-null-assertion": "allow",
         "typescript/no-unsafe-argument": "allow",
@@ -78,7 +103,8 @@
     "unicorn",
     "typescript",
     "oxc",
-    "import"
+    "import",
+    "vitest"
   ],
   "rules": {
     "array-callback-return": [
@@ -151,6 +177,19 @@
     "import/no-self-import": "deny",
     "import/no-unassigned-import": "deny",
     "import/no-webpack-loader-syntax": "deny",
+    "jest/expect-expect": "deny",
+    "jest/no-commented-out-tests": "deny",
+    "jest/no-conditional-expect": "deny",
+    "jest/no-disabled-tests": "deny",
+    "jest/no-export": "deny",
+    "jest/no-focused-tests": "deny",
+    "jest/no-standalone-expect": "deny",
+    "jest/prefer-snapshot-hint": "deny",
+    "jest/require-to-throw-message": "deny",
+    "jest/valid-describe-callback": "deny",
+    "jest/valid-expect": "deny",
+    "jest/valid-expect-in-promise": "deny",
+    "jest/valid-title": "deny",
     "new-cap": [
       "deny",
       [
@@ -710,6 +749,20 @@
     "unicorn/require-post-message-target-origin": "deny",
     "use-isnan": "deny",
     "valid-typeof": "deny",
+    "vitest/consistent-each-for": "deny",
+    "vitest/expect-expect": "deny",
+    "vitest/hoisted-apis-on-top": "deny",
+    "vitest/no-commented-out-tests": "deny",
+    "vitest/no-conditional-expect": "deny",
+    "vitest/no-conditional-tests": "deny",
+    "vitest/no-disabled-tests": "deny",
+    "vitest/no-focused-tests": "deny",
+    "vitest/require-awaited-expect-poll": "deny",
+    "vitest/require-local-test-context-for-concurrent-snapshots": "deny",
+    "vitest/require-mock-type-parameters": "allow",
+    "vitest/valid-expect": "deny",
+    "vitest/valid-title": "deny",
+    "vitest/warn-todo": "deny",
     "yoda": "deny"
   },
   "settings": {


### PR DESCRIPTION
## Summary
- root-enable the shared Jest and Vitest preset rule sets so `oxlint --rules` marks them as enabled, then turn them back off for non-test files before re-enabling them in matching test files
- add an `oxlint --rules` regression test that exercises a real temporary `oxlint.config.ts`, and refresh the generated preset snapshots
- remove the invalid `overrides[].extends` README example and document the supported root-level composition for the `jest` and `vitest` presets

## Validation
- `cd packages/oxlint-config && pnpm test`
- `cd packages/oxlint-config && pnpm check-types`
- testing of projects locally using this update