### PR TITLE
fix: esm requires file endings on imports

### DIFF
--- a/.changeset/purple-lines-draw.md
+++ b/.changeset/purple-lines-draw.md
@@ -1,0 +1,5 @@
+---
+"@qlik/oxlint-config": patch
+---
+
+ann/esm addition

--- a/packages/oxlint-config/src/configs/esm.js
+++ b/packages/oxlint-config/src/configs/esm.js
@@ -7,6 +7,20 @@ const esm = {
   rules: {
     ...baseNodeConfig.rules,
     "import/no-unassigned-import": "off",
+    "import/extensions": [
+      "error",
+      "ignorePackages",
+      {
+        js: "always",
+        cjs: "never",
+        mjs: "always",
+        jsx: "never",
+        ts: "never",
+        cts: "never",
+        mts: "never",
+        tsx: "never",
+      },
+    ],
   },
   overrides: [commonjsOverride],
 };

--- a/packages/oxlint-config/test/generated/esm-final-config.json
+++ b/packages/oxlint-config/test/generated/esm-final-config.json
@@ -77,9 +77,9 @@
         {
           "cjs": "never",
           "cts": "never",
-          "js": "never",
+          "js": "always",
           "jsx": "never",
-          "mjs": "never",
+          "mjs": "always",
           "mts": "never",
           "ts": "never",
           "tsx": "never"


### PR DESCRIPTION
If Javascript uses the `esm` config it is expected to always import from files using the file extension.

For example:

```
import foo from "./foo.js";
import bar from "./bar.json";
```

For typescript this does not have to be the case.

https://oxc.rs/docs/guide/usage/linter/rules/import/extensions
