### PR TITLE
chore: use HTTPS repository metadata for prettier config

### DIFF
--- a/.changeset/quiet-squids-care.md
+++ b/.changeset/quiet-squids-care.md
@@ -1,0 +1,5 @@
+---
+"@qlik/prettier-config": patch
+---
+
+Use an HTTPS repository URL for package metadata.

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Qlik's shared Prettier config",
   "license": "ISC",
-  "repository": "git@github.com:qlik-oss/dev-tools-js.git",
+  "repository": "git+https://github.com/qlik-oss/dev-tools-js.git",
   "main": "./prettier.config.js",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary
- update `@qlik/prettier-config` repository metadata from an SSH URL to the public `git+https` Git URL
- leave runtime code, dependencies, package contents, and version unchanged

## Validation
- node metadata assertion for `packages/prettier-config/package.json`
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm --dir packages/prettier-config format:check`
- `npm pack --dry-run --ignore-scripts --json ./packages/prettier-config`
- `git diff --check`
