### PR TITLE
fix: use HTTPS repository metadata for prettier config

### DIFF
--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Qlik's shared Prettier config",
   "license": "ISC",
-  "repository": "git@github.com:qlik-oss/dev-tools-js.git",
+  "repository": "git+https://github.com/qlik-oss/dev-tools-js.git",
   "main": "./prettier.config.js",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary
- update @qlik/prettier-config repository metadata from SSH to public git+https
- leave runtime code, dependencies, package contents, and version unchanged

## Validation
- `node -e "const p=require('./packages/prettier-config/package.json'); if(p.name!=='@qlik/prettier-config') throw new Error('wrong package'); if(p.repository!=='git+https://github.com/qlik-oss/dev-tools-js.git') throw new Error('repository URL not converted'); console.log(JSON.stringify({name:p.name, repository:p.repository}, null, 2))"`
- `npm pack --dry-run --ignore-scripts --json ./packages/prettier-config`
- `git diff --check`